### PR TITLE
Add GitHub Pages deployment workflow and index redirect

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "."
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/index.html
+++ b/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta http-equiv="refresh" content="0; url=poker-trainer.html">
+    <title>Poker Trainer</title>
+</head>
+<body>
+    <p>Redirecting to <a href="poker-trainer.html">Poker Trainer</a>...</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
This PR sets up automated deployment to GitHub Pages and adds a root index page to redirect users to the poker trainer application.

## Key Changes
- **GitHub Actions Workflow**: Added `.github/workflows/deploy.yml` to automatically build and deploy the site to GitHub Pages on every push to the main branch
  - Configured with appropriate permissions for GitHub Pages deployment
  - Uses standard GitHub Pages deployment actions (setup, upload artifact, deploy)
  - Includes concurrency controls to prevent simultaneous deployments

- **Root Index Page**: Added `index.html` as a redirect page that automatically forwards visitors to `poker-trainer.html`
  - Uses meta refresh for automatic redirection
  - Includes a fallback link for users with JavaScript disabled or slow page loads

## Implementation Details
The deployment workflow is triggered on pushes to the main branch and can also be manually triggered via `workflow_dispatch`. The index page uses a simple HTTP refresh redirect (0-second delay) to seamlessly guide users to the main application without requiring additional navigation.

https://claude.ai/code/session_01BzEGWyNJDTj3cu77H3PCcj