### PR TITLE
Fix quiz answer cards leaking correct answer

### DIFF
--- a/poker-trainer.html
+++ b/poker-trainer.html
@@ -1061,9 +1061,8 @@ function showQuizQ() {
 
   qCorrect = t.term;
   document.getElementById('answers').innerHTML = opts.map(o=>
-    `<button class="ans-btn" onclick="answerQuiz(this,'${o.term.replace(/'/g,"\\'")}')">
-      <strong>${o.term}</strong><br>
-      <span style="font-size:.82rem;color:#a09070">${o.def.slice(0,80)}…</span>
+    `<button class="ans-btn" data-term="${o.term.replace(/"/g,'&quot;')}" onclick="answerQuiz(this,'${o.term.replace(/'/g,"\\'")}')">
+      <span style="font-size:.82rem;color:#a09070">${o.def}</span>
     </button>`
   ).join('');
   document.getElementById('quiz-next').style.display='none';
@@ -1077,7 +1076,7 @@ function answerQuiz(btn, chosen) {
   if (isCorrect) { btn.classList.add('correct'); qScore++; qStreak++; }
   else {
     btn.classList.add('wrong'); qStreak=0;
-    btns.forEach(b=>{ if(b.textContent.trim().startsWith(correct)) b.classList.add('correct'); });
+    btns.forEach(b=>{ if(b.dataset.term===correct) b.classList.add('correct'); });
   }
   qTotal++;
   document.getElementById('q-score').textContent=qScore;


### PR DESCRIPTION
## Summary
- Removed the term title from quiz answer buttons so it no longer reveals the correct answer
- Show the full definition text instead of truncating to 80 characters
- Use `data-term` attribute for correct answer highlighting instead of matching on `textContent`

## Test plan
- [ ] Start a quiz and verify answer buttons only show the definition, not the term
- [ ] Verify full definition text is displayed (no truncation)
- [ ] Answer incorrectly and verify the correct answer button is still highlighted green

https://claude.ai/code/session_01MMhCKR5sdfdJqDjorR6b51