### PR TITLE
Add README.md and document README maintenance process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ Texas Hold'em Poker Trainer — a browser-based educational app for learning pok
 poker-trainer/
 ├── poker-trainer.html      # Entire application (HTML + CSS + JS, ~1600 lines)
 ├── index.html              # Redirect shim → poker-trainer.html
+├── README.md               # Project README (keep in sync — see README Maintenance)
+├── CLAUDE.md               # AI development instructions
 ├── .github/
 │   └── workflows/
 │       └── deploy.yml      # GitHub Actions → GitHub Pages on push to main
@@ -191,6 +193,21 @@ Use existing CSS variables (`var(--gold)`, `var(--felt)`, etc.) — don't hardco
 | Key | Content |
 |---|---|
 | `rfi-quiz-stats` | JSON: `{ totalQuizzes, totalQuestions, totalCorrect, byPosition, recentScores }` |
+
+---
+
+## README Maintenance
+
+**Update `README.md` whenever a change affects the project's structure or functionality.** This includes:
+
+- Adding, removing, or renaming files in the repository
+- Adding or changing application modes/tabs
+- Modifying the tech stack (new dependencies, changed hosting, etc.)
+- Changing the deployment process
+- Adding new features or removing existing ones
+- Changing the design system or theme
+
+Keep the README concise and user-facing — it describes *what the project does and how to use it*, not internal implementation details (those belong in CLAUDE.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,78 @@
+# Texas Hold'em Poker Trainer
+
+**Poker Trainer** is a browser-based educational app for learning poker terminology, hand rankings, GTO preflop strategy, and decision-making. Built as a single-page static site with zero dependencies.
+
+**Play now:** https://mpechuk.github.io/poker-trainer/
+
+## Key Features
+
+- **Study Mode** — 3D flashcard system with elegant flip animations. Each card shows a poker term on one side and its definition with a custom SVG illustration on the other.
+- **Quiz Mode** — Multiple-choice questions (4 options) with real-time score and streak tracking to test your poker vocabulary.
+- **Reference** — Searchable glossary of ~78 poker terms organized across 9 categories, with detailed modal views.
+- **Charts** — Interactive 13x13 preflop RFI (Raise First In) hand range grids for each table position (UTG, HJ, CO, BTN, SB).
+- **RFI Quiz** — Practice raise/fold decisions against GTO-optimal preflop ranges with persistent progress tracking via localStorage.
+
+## Technology
+
+| Concern | Implementation |
+|---|---|
+| UI | Vanilla HTML5 + CSS3 |
+| Logic | Vanilla JavaScript |
+| Fonts | Google Fonts (Playfair Display, Crimson Pro) |
+| State | Global JS variables + `localStorage` |
+| Build | None — no bundler, no transpiler |
+| Hosting | GitHub Pages (static) |
+| CI/CD | GitHub Actions |
+
+The entire application lives in a single file (`poker-trainer.html`) with no external dependencies, no build step, and no framework.
+
+## Repository Structure
+
+```
+poker-trainer/
+├── poker-trainer.html      # Entire application (HTML + CSS + JS)
+├── index.html              # Redirect shim -> poker-trainer.html
+├── README.md               # This file
+├── CLAUDE.md               # AI development instructions
+├── .github/
+│   └── workflows/
+│       └── deploy.yml      # GitHub Actions -> GitHub Pages deployment
+├── .agents/skills/         # Claude Code skill definitions
+├── .claude/skills/         # Symlinks to .agents/skills/
+└── skills-lock.json        # Locked skill versions
+```
+
+## Development
+
+No setup required. Edit `poker-trainer.html` directly and open it in a browser:
+
+```bash
+# Clone the repo
+git clone https://github.com/mpechuk/poker-trainer.git
+cd poker-trainer
+
+# Open in browser
+open poker-trainer.html
+```
+
+All CSS is in the `<style>` block and all JavaScript is in the `<script>` block at the bottom of `<body>`. Changes are live immediately on file save — no compilation or build step needed.
+
+## Deployment
+
+Push to `main` triggers GitHub Actions which deploys to GitHub Pages automatically. No build step — the workflow uploads the repository directory as-is.
+
+## Design
+
+The UI uses a casino-inspired dark green felt theme with gold accents:
+
+- **Background:** Dark green felt texture (`#0c2416`) with subtle radial gradient
+- **Accent:** Gold palette (`#c9a84c` / `#edd97a` / `#7a5e1a`)
+- **Typography:** Playfair Display (headings) + Crimson Pro (body)
+- **Cards:** Cream background (`#f9f5ea`) with 3D CSS perspective flip animations
+
+## Contributing
+
+1. All changes go in `poker-trainer.html` — do not split into separate files
+2. Use existing CSS variables (`var(--gold)`, `var(--felt)`, etc.) instead of hardcoded colors
+3. No external dependencies — no npm packages or CDN libraries (except existing Google Fonts)
+4. The file must work by opening directly in a browser with no build step


### PR DESCRIPTION
## Summary
Added a comprehensive README.md file to document the Poker Trainer project for end users and contributors, and updated CLAUDE.md to establish a README maintenance policy.

## Changes Made

- **Added README.md** — New user-facing documentation covering:
  - Project overview and live demo link
  - Key features (Study Mode, Quiz Mode, Reference, Charts, RFI Quiz)
  - Technology stack and architecture (vanilla HTML/CSS/JS, no dependencies)
  - Repository structure
  - Development setup instructions (no build required)
  - Deployment process (GitHub Actions → GitHub Pages)
  - Design system (casino-inspired dark green felt theme with gold accents)
  - Contributing guidelines

- **Updated CLAUDE.md** — Added "README Maintenance" section that:
  - Specifies when README.md should be updated (file changes, new modes, tech stack changes, deployment changes, feature additions/removals, design changes)
  - Clarifies that README is user-facing (describes *what* and *how to use*) while CLAUDE.md covers internal implementation details
  - Establishes a policy to keep README concise and in sync with the project

## Implementation Details

The README follows the existing project philosophy: clear, accessible documentation for a zero-dependency, single-file application. It emphasizes the key selling points (no build step, no dependencies, works in any browser) and provides quick-start instructions for both users and developers.

https://claude.ai/code/session_01WLoSP8yAKFR2HaTjxQuxo4