### PR TITLE
Fix blank page, add regression test, add PR preview workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,18 +1,24 @@
 name: Deploy to GitHub Pages
 
-# One-time repo setup required to enable both production + PR previews:
-#   Settings → Pages → Source → "Deploy from a branch" → Branch: gh-pages / folder: / (root)
-
 on:
   push:
     branches: ["main"]
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
   deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,11 +39,14 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          folder: dist
-          branch: gh-pages
-          clean: true
-          clean-exclude: |
-            pr-*/
+          path: "./dist"
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,15 +3,14 @@ name: PR Preview
 on:
   pull_request:
     branches: ["main"]
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
 jobs:
-  deploy-preview:
-    if: github.event.action != 'closed'
+  preview:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -29,32 +28,33 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Build with PR base path
+      - name: Build
         run: npm run build
-        env:
-          VITE_BASE_PATH: /poker-trainer/pr-${{ github.event.number }}/
 
-      - name: Deploy preview to gh-pages
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
         with:
-          folder: dist
-          branch: gh-pages
-          target-folder: pr-${{ github.event.number }}
-          clean: true
+          name: preview-pr-${{ github.event.number }}
+          path: dist/
+          retention-days: 7
 
-      - name: Post preview URL on PR
+      - name: Post preview comment
         uses: actions/github-script@v7
         with:
           script: |
             const pr = context.issue.number;
-            const url = `https://mpechuk.github.io/poker-trainer/pr-${pr}/`;
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const body = [
-              '## Preview deployment ready',
+              '## Preview build ready',
               '',
-              `**[Open preview \u2192](${url})**`,
-              `\`${url}\``,
+              `Build succeeded for this PR. Download the artifact from the [Actions run](${runUrl}) to test locally:`,
               '',
-              '_Updates on every push. Removed when the PR is closed._',
+              '```',
+              '# After downloading and unzipping preview-pr-' + pr + '.zip:',
+              'npx serve dist',
+              '```',
+              '',
+              '_Artifact expires after 7 days. Updates on every push._',
             ].join('\n');
 
             const { data: comments } = await github.rest.issues.listComments({
@@ -63,7 +63,7 @@ jobs:
             });
 
             const existing = comments.find(
-              c => c.user.type === 'Bot' && c.body.includes('Preview deployment ready')
+              c => c.user.type === 'Bot' && c.body.includes('Preview build ready')
             );
 
             if (existing) {
@@ -79,26 +79,3 @@ jobs:
                 body,
               });
             }
-
-  cleanup-preview:
-    if: github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          fetch-depth: 0
-
-      - name: Remove preview directory and push
-        run: |
-          PR_DIR="pr-${{ github.event.number }}"
-          if [ -d "$PR_DIR" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git rm -rf "$PR_DIR"
-            git commit -m "chore: remove preview for PR #${{ github.event.number }}"
-            git push
-          else
-            echo "No preview directory to clean up for PR #${{ github.event.number }}"
-          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,18 +228,19 @@ it('empty hash on initial load resolves to a renderable route — no blank page 
 
 ## Staging Deployments (PR Previews)
 
-Each PR automatically deploys a preview build to the `gh-pages` branch under `pr-<number>/`.
+Each PR automatically builds a preview and uploads it as a GitHub Actions artifact.
 
-**Preview URL**: `https://mpechuk.github.io/poker-trainer/pr-<number>/`
-
-**One-time repo setup required** (do this once in GitHub repo settings):
-> Settings → Pages → Source → "Deploy from a branch" → Branch: `gh-pages` / folder: `/ (root)`
+**How to preview**: When a PR is opened or updated, a bot comments with a link to the Actions run. Download the `preview-pr-<number>` artifact, unzip it, and run `npx serve dist` to test locally.
 
 Workflows:
-- `.github/workflows/preview.yml` — builds and deploys on PR open/update, comments URL on PR, cleans up on PR close
-- `.github/workflows/deploy.yml` — production deploy to root on push to `main`
+- `.github/workflows/preview.yml` — builds on PR open/update, uploads artifact, comments link on PR
+- `.github/workflows/deploy.yml` — production deploy to GitHub Pages on push to `main`
 
-Dynamic base path is controlled by `VITE_BASE_PATH` env var (default: `/poker-trainer/`).
+Dynamic base path is controlled by `VITE_BASE_PATH` env var (default: `/poker-trader/`).
+
+**To enable live staging URLs** (optional, requires one-time repo settings change):
+> Settings → Pages → Source → "Deploy from a branch" → `gh-pages` / `/ (root)`
+> Then update `deploy.yml` and `preview.yml` to use `JamesIves/github-pages-deploy-action@v4` deploying to subdirectories of the `gh-pages` branch.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Restores production deploy** — reverts `deploy.yml` back to artifact-based GitHub Pages deployment (the previous merge broke the site by switching to gh-pages branch mode, which conflicts with the repo's Pages source setting)
- **Blank page fix confirmed** — `app.jsx` renders `effectivePath` immediately instead of returning `null` during redirect; no blank page on initial load
- **Regression test** — adds `'empty hash on initial load resolves to a renderable route'` to `src/routing.test.js`
- **CI fix** — `test.yml` now runs `npm test` (vitest unit tests) in addition to `node test.js` (favicon)
- **PR preview workflow** — `preview.yml` builds on every PR push, uploads artifact, and posts a download link comment
- **Dynamic base path** — `vite.config.js` reads `VITE_BASE_PATH` env var (default `/poker-trainer/`) for future staging URL support
- **CLAUDE.md** — adds Testing Requirements and Staging Deployments sections

## Test plan

- [ ] Merge triggers `deploy.yml` → site restores at https://mpechuk.github.io/poker-trainer/
- [ ] Navigating to the root URL (no hash) loads the Terminology/Study page — no blank page
- [ ] `npm test` passes locally (7 tests)
- [ ] Future PRs get a bot comment with a preview artifact download link

https://claude.ai/code/session_01VJdmjpfn5JmXrD6rZV2NLh