### PR TITLE
Add Welcome landing page with hand rankings overview

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ poker-trainer/
 │   ├── styles/
 │   │   ├── base.css                    # :root vars, body, fonts, global reset
 │   │   ├── header.css                  # Header, section nav, sub-nav tabs
+│   │   ├── welcome.css                 # Welcome page hand rankings, section cards
 │   │   ├── study.css                   # Flashcard scene, 3D flip, card nav
 │   │   ├── quiz.css                    # Term quiz + RFI quiz styles
 │   │   ├── reference.css              # Search input, ref grid, modal
@@ -51,12 +52,14 @@ poker-trainer/
 │   │   ├── useFilters.js               # activeCats state + toggle logic
 │   │   └── useDeck.js                  # deck, idx, flipped, nav, shuffle
 │   ├── components/
-│   │   ├── Header.jsx                  # App header + section nav (Terminology | Preflop | Stats)
+│   │   ├── Header.jsx                  # App header + section nav (Home | Terminology | Preflop | Stats)
 │   │   ├── SubNav.jsx                  # Sub-navigation tabs within a section
 │   │   ├── FilterChips.jsx             # Category filter chip bar
 │   │   ├── ProgressBar.jsx             # Study progress bar
 │   │   └── Modal.jsx                   # Term detail modal overlay
 │   └── sections/
+│       ├── welcome/
+│       │   └── Welcome.jsx             # Landing page with hand rankings overview
 │       ├── terminology/
 │       │   ├── Study.jsx               # Flashcard study mode
 │       │   ├── Quiz.jsx                # Multiple-choice terminology quiz
@@ -79,14 +82,15 @@ Hash-based routing (`#/path`) for GitHub Pages compatibility.
 
 | Route | Component | Description |
 |---|---|---|
-| `#/terminology/study` | Study.jsx | Flashcard study mode (default) |
+| `#/welcome` | Welcome.jsx | Landing page with hand rankings overview (default) |
+| `#/terminology/study` | Study.jsx | Flashcard study mode |
 | `#/terminology/quiz` | Quiz.jsx | Multiple-choice terminology quiz |
 | `#/terminology/reference` | Reference.jsx | Searchable glossary |
 | `#/preflop/charts` | Charts.jsx | RFI hand range grids |
 | `#/preflop/quiz` | Quiz.jsx | Raise/fold RFI quiz |
 | `#/stats` | Dashboard.jsx | Full stats dashboard |
 
-Redirects: `/` → `/terminology/study`, `/terminology` → `/terminology/study`, `/preflop` → `/preflop/charts`
+Redirects: `/` → `/welcome`, `/terminology` → `/terminology/study`, `/preflop` → `/preflop/charts`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 ## Sections
 
+### Welcome
+- **Home** — Landing page with poker hand rankings (Royal Flush through High Card) and an overview of all trainer sections.
+
 ### Terminology
 - **Study** — 3D flashcard system with elegant flip animations. Each card shows a poker term on one side and its definition with a custom SVG illustration on the other.
 - **Quiz** — Multiple-choice questions (4 options) with real-time score, streak tracking, and persistent stats.
@@ -45,7 +48,7 @@ poker-trainer/
 │   ├── utils/                  # illustrations.jsx, shuffle.js, storage.js
 │   ├── hooks/                  # useFilters.js, useDeck.js
 │   ├── components/             # Header, SubNav, FilterChips, ProgressBar, Modal
-│   └── sections/               # terminology/, preflop/, stats/
+│   └── sections/               # welcome/, terminology/, preflop/, stats/
 ├── .github/workflows/deploy.yml
 └── CLAUDE.md
 ```
@@ -71,6 +74,7 @@ All routes use hash-based URLs for GitHub Pages compatibility:
 
 | Route | View |
 |---|---|
+| `#/welcome` | Welcome / hand rankings overview |
 | `#/terminology/study` | Flashcard study mode |
 | `#/terminology/quiz` | Multiple-choice terminology quiz |
 | `#/terminology/reference` | Searchable glossary |

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -6,6 +6,7 @@ import { Reference } from './sections/terminology/Reference.jsx';
 import { Charts } from './sections/preflop/Charts.jsx';
 import { PreflopQuiz } from './sections/preflop/Quiz.jsx';
 import { Dashboard } from './sections/stats/Dashboard.jsx';
+import { Welcome } from './sections/welcome/Welcome.jsx';
 import { REDIRECTS } from './routing.js';
 
 function useHashRoute() {
@@ -22,6 +23,7 @@ function useHashRoute() {
 }
 
 const ROUTES = {
+  '/welcome': Welcome,
   '/terminology/study': Study,
   '/terminology/quiz': TermQuiz,
   '/terminology/reference': Reference,
@@ -42,7 +44,7 @@ export function App() {
   }, [redirect]);
 
   const effectivePath = redirect || path;
-  const Page = ROUTES[effectivePath] || Study;
+  const Page = ROUTES[effectivePath] || Welcome;
 
   return (
     <>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -10,7 +10,7 @@ export function Header() {
     return () => window.removeEventListener('hashchange', onHash);
   }, []);
 
-  const section = currentPath.split('/')[1] || 'terminology';
+  const section = currentPath.split('/')[1] || 'welcome';
 
   return (
     <header>
@@ -23,6 +23,7 @@ export function Header() {
       <h1><em>Texas Hold'em</em> Poker Trainer</h1>
       <p class="subtitle">Master the language of the felt</p>
       <nav class="section-nav">
+        <a href="#/welcome" class={section === 'welcome' ? 'active' : ''}>Home</a>
         <a href="#/terminology/study" class={section === 'terminology' ? 'active' : ''}>Terminology</a>
         <a href="#/preflop/charts" class={section === 'preflop' ? 'active' : ''}>Preflop</a>
         <a href="#/stats" class={section === 'stats' ? 'active' : ''}>Stats</a>

--- a/src/routing.js
+++ b/src/routing.js
@@ -1,5 +1,6 @@
 // Pure routing logic extracted for testability
 export const ROUTES_LIST = [
+  '/welcome',
   '/terminology/study',
   '/terminology/quiz',
   '/terminology/reference',
@@ -9,7 +10,7 @@ export const ROUTES_LIST = [
 ];
 
 export const REDIRECTS = {
-  '/': '/terminology/study',
+  '/': '/welcome',
   '/terminology': '/terminology/study',
   '/preflop': '/preflop/charts',
 };

--- a/src/routing.test.js
+++ b/src/routing.test.js
@@ -2,8 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { REDIRECTS, ROUTES_LIST, resolveRoute } from './routing.js';
 
 describe('routing', () => {
-  it('resolves / to /terminology/study (default landing page)', () => {
-    expect(resolveRoute('/')).toBe('/terminology/study');
+  it('resolves / to /welcome (default landing page)', () => {
+    expect(resolveRoute('/')).toBe('/welcome');
+  });
+
+  it('welcome route exists in routes list', () => {
+    expect(ROUTES_LIST).toContain('/welcome');
   });
 
   it('resolves /terminology shorthand to study page', () => {

--- a/src/sections/welcome/Welcome.jsx
+++ b/src/sections/welcome/Welcome.jsx
@@ -1,0 +1,65 @@
+import { ILLUS } from '../../utils/illustrations.jsx';
+import '../../styles/welcome.css';
+
+const HAND_RANKINGS = [
+  { key: 'royal-flush', name: 'Royal Flush', desc: 'A, K, Q, J, 10 — all the same suit' },
+  { key: 'straight-flush', name: 'Straight Flush', desc: 'Five consecutive cards of the same suit' },
+  { key: 'quads', name: 'Four of a Kind', desc: 'Four cards of the same rank' },
+  { key: 'full-house', name: 'Full House', desc: 'Three of a kind plus a pair' },
+  { key: 'flush', name: 'Flush', desc: 'Five cards of the same suit, any order' },
+  { key: 'straight', name: 'Straight', desc: 'Five consecutive cards of mixed suits' },
+  { key: 'trips', name: 'Three of a Kind', desc: 'Three cards of the same rank' },
+  { key: 'two-pair', name: 'Two Pair', desc: 'Two different pairs' },
+  { key: 'pair', name: 'One Pair', desc: 'Two cards of the same rank' },
+  { key: 'high-card', name: 'High Card', desc: 'No combination — highest card plays' },
+];
+
+const SECTIONS = [
+  {
+    href: '#/terminology/study',
+    title: 'Terminology',
+    desc: 'Learn the language of poker with interactive flashcards, quizzes, and a searchable glossary of 78+ terms.',
+  },
+  {
+    href: '#/preflop/charts',
+    title: 'Preflop Strategy',
+    desc: 'Study GTO-optimal preflop raise ranges for every position with interactive charts and a raise-or-fold quiz.',
+  },
+  {
+    href: '#/stats',
+    title: 'Stats',
+    desc: 'Track your learning progress across all study modes and quiz scores in one dashboard.',
+  },
+];
+
+export function Welcome({ path }) {
+  return (
+    <div class="welcome">
+      <h2>Poker Hand Rankings</h2>
+      <p class="welcome-intro">From strongest to weakest — know these by heart.</p>
+
+      <div class="rankings-grid">
+        {HAND_RANKINGS.map((h, i) => (
+          <div class="ranking-card" key={h.key}>
+            <span class="ranking-rank">#{i + 1}</span>
+            <div class="ranking-name">{h.name}</div>
+            <div class="ranking-illus" dangerouslySetInnerHTML={{ __html: ILLUS[h.key]() }} />
+            <div class="ranking-desc">{h.desc}</div>
+          </div>
+        ))}
+      </div>
+
+      <h2 class="sections-heading">Explore the Trainer</h2>
+
+      <div class="sections-grid">
+        {SECTIONS.map(s => (
+          <a class="section-card" href={s.href} key={s.href}>
+            <div class="section-card-title">{s.title}</div>
+            <div class="section-card-desc">{s.desc}</div>
+            <span class="section-card-link">Start learning &rarr;</span>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/styles/welcome.css
+++ b/src/styles/welcome.css
@@ -1,0 +1,27 @@
+.welcome{max-width:900px;margin:0 auto;padding:1.5rem 1rem 3rem}
+.welcome h2{font-family:'Playfair Display',Georgia,serif;color:var(--gold-bright);
+  text-align:center;font-size:1.6rem;margin:1.5rem 0 .4rem}
+.welcome-intro{text-align:center;color:var(--muted);margin-bottom:1.2rem;font-size:1rem}
+
+/* Hand rankings grid */
+.rankings-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;margin-bottom:2rem}
+.ranking-card{background:rgba(0,0,0,.2);border:1px solid rgba(201,168,76,.15);border-radius:14px;
+  padding:1rem;text-align:center;transition:border-color .25s}
+.ranking-card:hover{border-color:var(--gold)}
+.ranking-rank{display:inline-block;font-family:'Playfair Display',Georgia,serif;
+  font-size:.85rem;color:var(--gold-dark);margin-bottom:.3rem}
+.ranking-name{font-family:'Playfair Display',Georgia,serif;color:var(--gold-bright);
+  font-size:1.15rem;font-weight:600;margin-bottom:.5rem}
+.ranking-illus{display:flex;justify-content:center;margin-bottom:.5rem}
+.ranking-desc{color:var(--muted);font-size:.85rem;line-height:1.3}
+
+/* Sections overview */
+.sections-heading{margin-top:2.5rem}
+.sections-grid{display:grid;gap:1rem;margin-top:.8rem}
+.section-card{display:block;background:rgba(0,0,0,.2);border:1px solid rgba(201,168,76,.15);
+  border-radius:14px;padding:1.2rem 1.4rem;text-decoration:none;transition:all .25s}
+.section-card:hover{border-color:var(--gold);background:rgba(201,168,76,.08)}
+.section-card-title{font-family:'Playfair Display',Georgia,serif;color:var(--gold-bright);
+  font-size:1.15rem;font-weight:600;margin-bottom:.35rem}
+.section-card-desc{color:var(--text);font-size:.95rem;line-height:1.4;margin-bottom:.5rem}
+.section-card-link{color:var(--gold);font-size:.85rem}


### PR DESCRIPTION
## Summary
Introduces a new Welcome section as the default landing page for the poker trainer, featuring a comprehensive hand rankings guide and navigation overview to all trainer sections.

## Key Changes
- **New Welcome component** (`src/sections/welcome/Welcome.jsx`) — Landing page displaying all 10 poker hand rankings (Royal Flush through High Card) with custom SVG illustrations, descriptions, and ranking numbers. Includes a section overview with cards linking to Terminology, Preflop Strategy, and Stats modules.
- **New welcome styles** (`src/styles/welcome.css`) — Responsive grid layouts for hand ranking cards and section overview cards with hover effects and gold accent styling consistent with the app theme.
- **Updated routing** — Changed default route from `#/terminology/study` to `#/welcome`. Updated `REDIRECTS` and `ROUTES_LIST` in `src/routing.js` to reflect the new landing page.
- **Updated Header navigation** — Added "Home" link to section nav in `src/components/Header.jsx` pointing to `#/welcome` with active state detection.
- **Updated App component** — Imported Welcome component and added it to `ROUTES` object. Changed fallback page from Study to Welcome.
- **Updated documentation** — Modified README.md and CLAUDE.md to document the new Welcome section and updated routing structure.
- **Updated routing tests** — Changed test expectations to verify `#/` resolves to `#/welcome` and that the welcome route exists in the routes list.

## Implementation Details
- Hand rankings are defined as a static array with keys matching SVG illustration identifiers in the illustrations utility
- Section cards use hash-based links for GitHub Pages compatibility
- Responsive grid uses `auto-fit` with `minmax()` for flexible card layouts
- Styling follows existing design system with CSS custom properties for colors and consistent border/hover treatments

https://claude.ai/code/session_01T94y3Jr65f5xXZ3DjUAwe3