### PR TITLE
Add vs Limp and vs Raise preflop quiz modes with new chart views

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,248 @@
+# Plan: Expand Preflop Section — vs Limp, vs Raise Charts + Quizzes
+
+## Context
+
+The preflop section currently has one chart type (RFI / open-raise) and one quiz mode (raise/fold). The user wants two new chart types (facing a limp, facing a raise), opponent position selection, and expanded quiz modes including a combined quiz that tests all three scenarios together.
+
+---
+
+## New Routes
+
+| Route | Component | Description |
+|---|---|---|
+| `/preflop/limp` | `LimpCharts` | ISO raise vs a limper |
+| `/preflop/vs-raise` | `RaiseCharts` | 3-bet/call/fold vs a raiser |
+
+Updated SubNav across all preflop pages: **RFI \| vs Limp \| vs Raise \| Quiz**  
+(header.css sub-nav `max-width: 400px` → `max-width: 520px` for the extra tab)
+
+---
+
+## Files to Create
+
+### 1. `src/data/preflop-ranges.js`
+
+Exports:
+- `LIMP_HERO_POSITIONS = ['HJ','CO','BTN','SB','BB']`
+- `RAISE_HERO_POSITIONS = ['HJ','CO','BTN','SB','BB']`
+- `VALID_LIMP_VILLAINS = { HJ:['UTG'], CO:['UTG','HJ'], BTN:['UTG','HJ','CO'], SB:['UTG','HJ','CO','BTN'], BB:['UTG','HJ','CO','BTN','SB'] }`
+- `VALID_RAISE_VILLAINS` — same structure
+- `LIMP_RANGES[stackDepth][heroPos][villainPos] = { raise: Set, call: Set }`  
+  (fold = all 169 hands minus raise ∪ call; for BB "call" = check)
+- `VS_RAISE_RANGES[stackDepth][heroPos][villainPos] = { threebet: Set, call: Set }`  
+  (fold = everything else)
+
+**100BB LIMP_RANGES data:**
+
+| Hero | Villain | raise | call |
+|---|---|---|---|
+| HJ | UTG | AA-TT, AKs-ATs, A5s-A4s, KQs-KJs, QJs, JTs, AKo-AJo, KQo | 99-22, A9s-A6s, A3s-A2s, KTs-K8s, QTs-Q9s, J9s, T9s-T8s, 98s-97s, 87s-86s, 76s-75s, 65s-64s, 54s, ATo, KJo-KTo, QJo-QTo |
+| CO | UTG | AA-TT, AKs-ATs, A5s-A4s, KQs-KJs, KTs, QJs, JTs, T9s, AKo-AJo, KQo-KJo | 99-22, A9s-A6s, A3s-A2s, K9s-K8s, QTs-Q9s, J9s, 98s-97s, 87s-86s, 76s-75s, 65s-64s, 54s-43s, ATo, KTo, QJo-QTo-JTo |
+| CO | HJ | AA-99, AKs-ATs, A5s-A4s, KQs-KJs, KTs, QJs-QTs, JTs, T9s, AKo-ATo, KQo-KJo, QJo | 88-22, A9s-A6s, A3s-A2s, K9s-K8s, Q9s, J9s, 98s-97s, 87s-86s, 76s-75s, 65s-64s, 54s-43s, KTo, QTo, JTo |
+| BTN | UTG | AA-88, AKs-ATs, A9s, A5s-A3s, KQs-KTs, QJs-QTs, JTs, T9s, 98s, AKo-ATo, KQo-KJo, QJo-QTo, JTo | 77-22, A8s-A6s, A2s, K9s-K8s, Q9s, J9s-J8s, T8s, 97s, 87s-86s, 76s-75s, 65s-64s, 54s-53s, 43s, A9o, KTo-K9o, Q9o, J9o, T9o |
+| BTN | HJ | AA-88, AKs-ATs, A9s, A5s-A3s, KQs-KTs, QJs-QTs, JTs-J9s, T9s, 98s, 87s, AKo-ATo, KQo-KJo, QJo-QTo, JTo | 77-22, A8s-A6s, A2s, K9s-K8s, Q9s, T8s, 97s, 76s-75s, 65s-64s, 54s-43s, A9o, KTo-K9o, Q9o |
+| BTN | CO | AA-77, AKs-A2s (all), KQs-K8s, QJs-Q8s, JTs-J8s, T9s-T8s, 98s-97s, 87s, 76s, 65s, AKo-A7o, KQo-KTo, QJo-QTo, JTo, T9o | 66-22, K7s-K5s, Q7s, J7s, T7s, 96s, 86s-85s, 74s, 64s, 54s-53s, 43s, A6o-A2o, K9o-K8o, Q9o, J9o, 98o |
+| SB | UTG | AA-TT, AKs-ATs, A5s-A4s, KQs-KJs, QJs, JTs, AKo-AJo, KQo | 99-22, A9s-A6s, A3s-A2s, KTs-K8s, QTs-Q9s, J9s, T9s-T8s, 98s-97s, 87s-86s, 76s-75s, 65s, ATo, KJo-KTo, QJo |
+| SB | HJ | AA-TT, AKs-ATs, A5s-A3s, KQs-KJs, KTs, QJs, JTs, T9s, AKo-AJo, KQo-KJo | 99-22, A9s-A6s, A2s, K9s-K8s, QTs-Q9s, J9s, 98s-97s, 87s-86s, 76s-75s, 65s, ATo, KTo, QJo |
+| SB | CO | AA-99, AKs-ATs, A5s-A3s, KQs-KJs, KTs, QJs-QTs, JTs, T9s, AKo-ATo, KQo-KJo, QJo | 88-22, A9s-A6s, A2s, K9s-K8s, Q9s, J9s, 98s-97s, 87s-86s, 76s-75s, 65s-64s, 54s, KTo, QTo-Q9o |
+| SB | BTN | AA-99, AKs-ATs, A9s, A5s-A2s, KQs-KJs, KTs-K9s, QJs-QTs, JTs, T9s, 98s, 87s, AKo-ATo-A9o, KQo-KJo, QJo-QTo, JTo | 88-22, A8s-A6s, K8s, Q9s, J9s-J8s, T8s, 97s, 76s-75s, 65s-64s, 54s-53s, K9o-K8o, Q9o, J9o, T9o |
+| BB | UTG | AA-TT, AKs-ATs, A5s-A4s, KQs-KJs, QJs, JTs, AKo-AJo, KQo | 99-22, A9s-A2s, KTs-K8s, QTs-Q9s, J9s, T9s-T8s, 98s-97s, 87s-86s, 76s-75s, 65s-64s, 54s-53s, 43s-32s, ATo-A9o, KJo-KTo-K9o, QJo-QTo-Q9o, JTo-J9o, T9o, 98o, 87o, 76o, 65o |
+| BB | HJ | AA-99, AKs-ATs, A5s-A3s, KQs-KJs, KTs, QJs, JTs, AKo-AJo, KQo-KJo | 88-22, A9s-A2s, K9s-K8s, QTs-Q9s, J9s, T9s-T8s, 98s-97s, 87s-86s, 76s-75s, 65s-64s, 54s-43s-32s, ATo-A9o, KTo-K9o, QJo-QTo-Q9o, JTo-J9o, T9o, 98o, 87o, 76o |
+| BB | CO | AA-99, AKs-ATs, A5s-A3s, KQs-KJs, KTs, QJs-QTs, JTs, T9s, AKo-ATo, KQo-KJo, QJo | 88-22, A9s-A2s, K9s-K8s, Q9s, J9s-J8s, T8s, 98s-97s, 87s-86s, 76s-75s, 65s-64s, 54s-43s-32s, A9o, KTo-K9o, Q9o-QTo, JTo-J9o, T9o, 98o, 87o, 76o-65o |
+| BB | BTN | AA-77, AKs-A2s, KQs-K9s, QJs-Q9s, JTs-J9s, T9s-T8s, 98s, 87s, 76s, AKo-A8o-A9o, KQo-KTo, QJo-QTo, JTo, T9o, 98o | 66-22, K8s-K7s, Q8s, J8s, T7s, 97s, 86s, 75s, 65s-64s, 54s-53s, 43s, A7o-A6o-A5o, K9o-K8o, Q9o-Q8o, J9o-J8o, T8o, 97o, 87o-86o, 76o-75o-65o |
+| BB | SB | AA-66, AKs-A2s, KQs-K8s, QJs-Q8s, JTs-J8s, T9s-T7s, 98s-96s, 87s, 76s, AKo-A7o, KQo-K9o, QJo-Q9o, JTo-J9o, T9o, 98o, 87o, 76o | 55-22, K7s-K6s, Q7s, J7s, T6s, 95s, 85s, 75s-74s, 65s-64s, 54s-53s, 43s, A6o-A4o, K8o, Q8o, J8o, T8o, 97o, 86o, 75o, 65o |
+
+**100BB VS_RAISE_RANGES data:**
+
+| Hero | Villain | threebet | call |
+|---|---|---|---|
+| HJ | UTG | AA, KK, QQ, AKs, A5s, A4s, AKo | JJ, TT, 99, AQs, AJs, ATs, KQs, JTs, AQo, KQo |
+| CO | UTG | AA, KK, QQ, AKs, A5s, A4s, AKo | JJ, TT, 99, AQs, AJs, ATs, KQs, KJs, QJs, JTs, T9s, AQo, AJo, KQo |
+| CO | HJ | AA, KK, QQ, AKs, KQs, A5s, A4s, A3s, AKo | JJ, TT, 99, 88, AQs, AJs, ATs, KJs, QJs, JTs, T9s, 98s, AQo, AJo, KQo, QJo |
+| BTN | UTG | AA, KK, QQ, AKs, A5s, A4s, A3s, AKo | JJ, TT, 99, 88, AQs, AJs, ATs, KQs, KJs, QJs, JTs, T9s, 98s, 87s, AQo, AJo, ATo, KQo, KJo, QJo |
+| BTN | HJ | AA, KK, QQ, AKs, KQs, A5s, A4s, A3s, A2s, AKo | JJ, TT, 99, 88, 77, AQs, AJs, ATs, KJs, KTs, QJs, JTs, T9s, 98s, 87s, 76s, AQo, AJo, ATo, KQo, KJo, QJo, JTo |
+| BTN | CO | AA, KK, QQ, JJ, AKs, AQs, KQs, A5s, A4s, A3s, A2s, AKo, AQo | TT, 99, 88, 77, 66, AJs, ATs, KJs, KTs, K9s, QJs, JTs, T9s, 98s, 87s, 76s, 65s, AJo, ATo, KQo, KJo, KTo, QJo, JTo, T9o |
+| SB | UTG | AA, KK, QQ, AKs, A5s, A4s, AKo | JJ, TT, AQs, AJs, KQs, QJs, JTs, AQo |
+| SB | HJ | AA, KK, QQ, AKs, A5s, A4s, A3s, AKo | JJ, TT, 99, AQs, AJs, ATs, KQs, QJs, JTs, AQo, KQo |
+| SB | CO | AA, KK, QQ, JJ, AKs, KQs, A5s, A4s, A3s, AKo | TT, 99, AQs, AJs, ATs, KJs, QJs, JTs, T9s, AQo, KQo |
+| SB | BTN | AA, KK, QQ, JJ, TT, AKs, AQs, KQs, KJs, A5s, A4s, A3s, A2s, AKo, AQo, KQo | 99, 88, AJs, ATs, KTs, QJs, JTs, T9s, 98s, AJo, ATo, KJo, QJo |
+| BB | UTG | AA, KK, QQ, AKs, A5s, A4s, AKo | JJ, TT, 99, 88, 77, AQs, AJs, ATs, KQs, KJs, QJs, JTs, T9s, 98s, 87s, AQo, AJo, ATo, KQo, KJo, QJo |
+| BB | HJ | AA, KK, QQ, AKs, A5s, A4s, A3s, AKo | JJ, TT, 99, 88, 77, 66, AQs, AJs, ATs, KQs, KJs, QJs, JTs, T9s, 98s, 87s, 76s, AQo, AJo, ATo, KQo, KJo, QJo, JTo |
+| BB | CO | AA, KK, QQ, JJ, AKs, KQs, A5s, A4s, A3s, AKo | TT, 99, 88, 77, 66, 55, AQs, AJs, ATs, KJs, KTs, QJs, JTs, T9s, 98s, 87s, 76s, 65s, AQo, AJo, ATo, A9o, KQo, KJo, KTo, QJo, QTo, JTo |
+| BB | BTN | AA, KK, QQ, JJ, TT, AKs, AQs, KQs, KJs, A5s, A4s, A3s, A2s, AKo, AQo, KQo | 99-22, AJs, ATs, A9s, A8s, KTs, K9s, K8s, QJs, Q9s, JTs, J9s, T9s, T8s, 98s, 97s, 87s, 86s, 76s, 75s, 65s, AJo, ATo, A9o, A8o, KJo, KTo, K9o, QJo, QTo, Q9o, JTo, J9o, T9o, T8o, 98o |
+| BB | SB | AA, KK, QQ, JJ, TT, AKs, AQs, AJs, KQs, KJs, KTs, QJs, JTs, A5s, A4s, A3s, A2s, AKo, AQo, AJo, KQo, KJo, QJo | 99-22, ATs, A9s-A6s, K9s-K7s, QTs-Q8s, J9s-J8s, T9s-T7s, 98s-96s, 87s-85s, 76s-74s, 65s-63s, 54s, ATo, A9o, A8o, KTo, K9o, Q9o, JTo, T9o, 98o, 87o |
+
+**Stack depth scaling for both range types:**  
+Apply same principle as existing `rfi-ranges.js` — proportional tightening at 50BB, 33BB, 25BB by removing the most speculative hands at each step (low pairs from raise ranges, suited connectors below 65s, weak offsuit hands). Implement and verify the monotonic-narrowing invariant in tests.
+
+---
+
+### 2. `src/sections/preflop/LimpCharts.jsx`
+
+- SubNav with 4 tabs (same TABS constant as updated Charts.jsx)
+- Stack depth tabs (reuse `.stack-tabs`)
+- Two dropdowns: "Your Position" (from `LIMP_HERO_POSITIONS`) + "Limper Position" (filtered to `VALID_LIMP_VILLAINS[heroPos]`)
+- When `heroPos` changes, auto-reset `villainPos` to first valid villain
+- 13×13 grid with 3 cell classes: `rfi-raise` (green), `rfi-call` (blue/teal), `rfi-fold` (gray)
+- Legend: Raise / Call (or "Check" when `heroPos==='BB'`) / Fold with combo counts
+- Placeholder text if `LIMP_RANGES[stackDepth]?.[heroPos]?.[villainPos]` is undefined
+
+### 3. `src/sections/preflop/RaiseCharts.jsx`
+
+- Same structure as `LimpCharts.jsx`
+- Uses `VS_RAISE_RANGES`, labels villain as "Raiser Position"
+- Cell actions: 3-Bet (green) / Call (blue) / Fold (gray)
+
+---
+
+## Files to Modify
+
+### 4. `src/routing.js`
+Add to `ROUTES_LIST`:
+```js
+'/preflop/limp',
+'/preflop/vs-raise',
+```
+
+### 5. `src/app.jsx`
+Import `LimpCharts` and `RaiseCharts`, add to `ROUTES` map.
+
+### 6. `src/sections/preflop/Charts.jsx`
+Update `TABS` from 2 to 4 entries:
+```js
+const TABS = [
+  { path: '/preflop/charts', label: 'RFI' },
+  { path: '/preflop/limp', label: 'vs Limp' },
+  { path: '/preflop/vs-raise', label: 'vs Raise' },
+  { path: '/preflop/quiz', label: 'Quiz' },
+];
+```
+No other changes.
+
+### 7. `src/styles/charts.css`
+Add:
+```css
+.rfi-call { background:rgba(52,152,219,.22); color:#a8d8f0; border:1px solid rgba(52,152,219,.25) }
+.rfi-legend .sw-call { background:rgba(52,152,219,.22); border:1px solid rgba(52,152,219,.25) }
+/* Position selectors */
+.pos-selectors { display:flex; justify-content:center; gap:1.5rem; margin-bottom:1rem; flex-wrap:wrap }
+.pos-selector-group { display:flex; flex-direction:column; align-items:center; gap:.3rem }
+.pos-selector-label { font-size:.75rem; color:var(--muted); letter-spacing:.08em; text-transform:uppercase }
+.pos-selector-select { background:rgba(0,0,0,.4); color:var(--gold-bright); border:1px solid var(--gold-dark);
+  border-radius:8px; padding:.35rem .7rem; font-family:'Crimson Pro',serif; font-size:.95rem; cursor:pointer }
+.pos-selector-select:focus { outline:none; border-color:var(--gold) }
+```
+
+### 8. `src/styles/header.css`
+Update `.sub-nav` max-width from `400px` → `520px` (fits 4 tabs comfortably).
+
+### 9. `src/sections/preflop/Quiz.jsx`
+
+Add internal mode selector tabs: **RFI | vs Limp | vs Raise | All**
+
+New state: `quizMode` (default `'rfi'`).  
+Mode switching resets deck/score/idx (same as stack depth change). Mode tabs lock during active quiz (same `.disabled` pattern).
+
+**New question generators:**
+```js
+function generateLimpHand(stackDepth) {
+  heroPos = random from LIMP_HERO_POSITIONS
+  villainPos = random from VALID_LIMP_VILLAINS[heroPos]
+  hand = random hand (same row/col logic)
+  range = LIMP_RANGES[stackDepth][heroPos][villainPos]
+  correctAction = range.raise.has(hand) ? 'raise' : range.call.has(hand) ? 'call' : 'fold'
+  return { type:'limp', hand, heroPos, villainPos, stackDepth, correctAction }
+}
+
+function generateVsRaiseHand(stackDepth) { // same pattern with VS_RAISE_RANGES, correctAction: 'threebet'|'call'|'fold' }
+```
+
+**buildDeck for 3-action modes:** max 4 of any single action in a 10-question deck.
+
+**Answer buttons:**
+- RFI: `[Raise, Fold]` (existing)
+- vs Limp: `[Raise, Call, Fold]`
+- vs Raise: `[3-Bet, Call, Fold]`
+- All: use buttons matching current question's type
+
+**Question prompt text:**
+- RFI: "Everyone folds to you. What do you do?" (existing)
+- vs Limp: "Villain limped from {villainPos}. What do you do?"
+- vs Raise: "Villain raised from {villainPos}. What do you do?"
+
+**Quiz card:** Show "Your Position: {heroPos}" and "Villain: {villainPos}" for non-RFI questions.
+
+**Stats saving:** Keep existing `rfi-quiz-stats` write unchanged. New modes write to `limp-quiz-stats`, `vs-raise-quiz-stats`. All-mode quiz writes to `all-modes-quiz-stats` and also updates all individual mode stats.
+
+**SubNav TABS:** same 4-tab constant as other preflop pages.
+
+### 10. `src/utils/storage.js`
+Add 9 new helpers following the existing pattern:
+```js
+// Keys: 'limp-quiz-stats', 'vs-raise-quiz-stats', 'all-modes-quiz-stats'
+// Shapes:
+initLimpQuizStats()    → { totalQuizzes, totalQuestions, totalCorrect, byHeroPosition:{}, byVillainPosition:{}, recentScores:[] }
+initVsRaiseQuizStats() → same shape
+initAllModesQuizStats()→ { totalQuizzes, totalQuestions, totalCorrect, byMode:{rfi:{total,correct}, limp:{total,correct}, vsRaise:{total,correct}}, recentScores:[] }
+```
+
+### 11. `src/sections/stats/Dashboard.jsx`
+Import 3 new storage helpers, add 3 new `<div class="stats-section">` blocks mirroring the existing RFI quiz section. Reset functions remove the appropriate localStorage keys.
+
+---
+
+## Tests to Write
+
+### `src/routing.test.js` (append)
+```js
+it('/preflop/limp exists in routes list', ...)
+it('/preflop/vs-raise exists in routes list', ...)
+it('resolveRoute passes through new preflop routes unchanged', ...)
+```
+
+### `src/data/preflop-ranges.test.js` (new file)
+- LIMP_RANGES: has all 4 stack depths, each hero has all valid villains, raise/call Sets are disjoint, all hand notations valid, BTN raise range wider than HJ raise range vs same villain, 100BB wider than 50BB
+- VS_RAISE_RANGES: same structure tests, threebet/call disjoint, BB vs BTN call wider than SB vs BTN call, 3-bet range never contains a hand that's in call range
+
+### `src/utils/storage.test.js` (new file)
+- initLimpQuizStats returns correct shape
+- initVsRaiseQuizStats returns correct shape
+- initAllModesQuizStats has byMode with rfi/limp/vsRaise keys
+- getLimpQuizStats returns null when nothing stored
+- save/get round-trip
+
+---
+
+## Implementation Order (dependency-safe)
+
+1. `src/data/preflop-ranges.js`
+2. `src/utils/storage.js` (new helpers)
+3. `src/routing.js` (new routes)
+4. `src/styles/charts.css` + `src/styles/header.css`
+5. `src/sections/preflop/LimpCharts.jsx` (new)
+6. `src/sections/preflop/RaiseCharts.jsx` (new)
+7. `src/sections/preflop/Charts.jsx` (TABS only)
+8. `src/sections/preflop/Quiz.jsx` (mode selector + generators)
+9. `src/app.jsx` (register routes)
+10. `src/sections/stats/Dashboard.jsx`
+11. `src/data/preflop-ranges.test.js` (new)
+12. `src/utils/storage.test.js` (new)
+13. `src/routing.test.js` (append)
+14. Verify: `npm test && npm run build`
+
+---
+
+## Verification
+
+```bash
+npm test        # all existing + new tests pass
+npm run build   # no build errors
+```
+
+Manual checks:
+- Navigate to `#/preflop/limp`, select BTN vs CO → grid shows green/blue/gray cells
+- Navigate to `#/preflop/vs-raise`, select BB vs BTN → large call range visible
+- SubNav shows 4 tabs on all preflop pages
+- Quiz: switch to "vs Limp" mode → 3 buttons appear, correct/wrong feedback works
+- Quiz: switch to "All" mode → mixed question types, correct button set per question
+- Stats dashboard shows 3 new quiz sections

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -4,6 +4,8 @@ import { Study } from './sections/terminology/Study.jsx';
 import { Quiz as TermQuiz } from './sections/terminology/Quiz.jsx';
 import { Reference } from './sections/terminology/Reference.jsx';
 import { Charts } from './sections/preflop/Charts.jsx';
+import { LimpCharts } from './sections/preflop/LimpCharts.jsx';
+import { RaiseCharts } from './sections/preflop/RaiseCharts.jsx';
 import { PreflopQuiz } from './sections/preflop/Quiz.jsx';
 import { Dashboard } from './sections/stats/Dashboard.jsx';
 import { Welcome } from './sections/welcome/Welcome.jsx';
@@ -28,6 +30,8 @@ const ROUTES = {
   '/terminology/quiz': TermQuiz,
   '/terminology/reference': Reference,
   '/preflop/charts': Charts,
+  '/preflop/limp': LimpCharts,
+  '/preflop/vs-raise': RaiseCharts,
   '/preflop/quiz': PreflopQuiz,
   '/stats': Dashboard,
 };

--- a/src/data/preflop-ranges.js
+++ b/src/data/preflop-ranges.js
@@ -1,0 +1,260 @@
+// Preflop ranges for vs-Limp and vs-Raise scenarios (6-max, GTO-approximate)
+// LIMP_RANGES[stackDepth][heroPos][villainPos] = { raise: Set, call: Set }
+//   raise = ISO raise; call = limp behind (or check for BB); fold = everything else
+// VS_RAISE_RANGES[stackDepth][heroPos][villainPos] = { threebet: Set, call: Set }
+//   fold = everything else
+
+export const LIMP_HERO_POSITIONS = ['HJ','CO','BTN','SB','BB'];
+export const RAISE_HERO_POSITIONS = ['HJ','CO','BTN','SB','BB'];
+
+// Valid villain positions for each hero (hero must be to villain's left / in blinds)
+export const VALID_LIMP_VILLAINS = {
+  HJ:  ['UTG'],
+  CO:  ['UTG','HJ'],
+  BTN: ['UTG','HJ','CO'],
+  SB:  ['UTG','HJ','CO','BTN'],
+  BB:  ['UTG','HJ','CO','BTN','SB'],
+};
+export const VALID_RAISE_VILLAINS = {
+  HJ:  ['UTG'],
+  CO:  ['UTG','HJ'],
+  BTN: ['UTG','HJ','CO'],
+  SB:  ['UTG','HJ','CO','BTN'],
+  BB:  ['UTG','HJ','CO','BTN','SB'],
+};
+
+function s(...hands) { return new Set(hands.flatMap(h => h.split(','))); }
+
+// ---------------------------------------------------------------------------
+// LIMP_RANGES
+// ---------------------------------------------------------------------------
+export const LIMP_RANGES = {
+  '100BB': {
+    HJ: {
+      UTG: { raise: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,ATs,A5s,A4s,KQs,KJs,QJs,JTs,AKo,AQo,AJo,KQo'), call: s('99,88,77,66,55,44,33,22,A9s,A8s,A7s,A6s,A3s,A2s,KTs,K9s,K8s,QTs,Q9s,J9s,T9s,T8s,98s,97s,87s,86s,76s,75s,65s,64s,54s,ATo,KJo,KTo,QJo,QTo') },
+    },
+    CO: {
+      UTG: { raise: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,ATs,A5s,A4s,KQs,KJs,KTs,QJs,JTs,T9s,AKo,AQo,AJo,KQo,KJo'), call: s('99,88,77,66,55,44,33,22,A9s,A8s,A7s,A6s,A3s,A2s,K9s,K8s,QTs,Q9s,J9s,98s,97s,87s,86s,76s,75s,65s,64s,54s,43s,ATo,KTo,QJo,QTo,JTo') },
+      HJ:  { raise: s('AA,KK,QQ,JJ,TT,99,AKs,AQs,AJs,ATs,A5s,A4s,KQs,KJs,KTs,QJs,QTs,JTs,T9s,AKo,AQo,AJo,ATo,KQo,KJo,QJo'), call: s('88,77,66,55,44,33,22,A9s,A8s,A7s,A6s,A3s,A2s,K9s,K8s,Q9s,J9s,98s,97s,87s,86s,76s,75s,65s,64s,54s,43s,KTo,QTo,JTo') },
+    },
+    BTN: {
+      UTG: { raise: s('AA,KK,QQ,JJ,TT,99,88,AKs,AQs,AJs,ATs,A9s,A5s,A4s,A3s,KQs,KJs,KTs,QJs,QTs,JTs,T9s,98s,AKo,AQo,AJo,ATo,KQo,KJo,QJo,QTo,JTo'), call: s('77,66,55,44,33,22,A8s,A7s,A6s,A2s,K9s,K8s,Q9s,J9s,J8s,T8s,97s,87s,86s,76s,75s,65s,64s,54s,53s,43s,A9o,KTo,K9o,Q9o,J9o,T9o') },
+      HJ:  { raise: s('AA,KK,QQ,JJ,TT,99,88,AKs,AQs,AJs,ATs,A9s,A5s,A4s,A3s,KQs,KJs,KTs,QJs,QTs,JTs,J9s,T9s,98s,87s,AKo,AQo,AJo,ATo,KQo,KJo,QJo,QTo,JTo'), call: s('77,66,55,44,33,22,A8s,A7s,A6s,A2s,K9s,K8s,Q9s,T8s,97s,76s,75s,65s,64s,54s,43s,A9o,KTo,K9o,Q9o') },
+      CO:  { raise: s('AA,KK,QQ,JJ,TT,99,88,77,AKs,AQs,AJs,ATs,A9s,A8s,A7s,A6s,A5s,A4s,A3s,A2s,KQs,KJs,KTs,K9s,K8s,QJs,QTs,Q9s,Q8s,JTs,J9s,J8s,T9s,T8s,98s,97s,87s,86s,76s,75s,65s,AKo,AQo,AJo,ATo,A9o,KQo,KJo,KTo,QJo,QTo,JTo,T9o'), call: s('66,55,44,33,22,K7s,K6s,Q7s,J7s,T7s,96s,85s,74s,64s,54s,53s,43s,A8o,A7o,A6o,K9o,K8o,Q9o,J9o,98o') },
+    },
+    SB: {
+      UTG: { raise: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,ATs,A5s,A4s,KQs,KJs,QJs,JTs,AKo,AQo,AJo,KQo'), call: s('99,88,77,66,55,44,33,22,A9s,A8s,A7s,A6s,A3s,A2s,KTs,K9s,K8s,QTs,Q9s,J9s,T9s,T8s,98s,97s,87s,86s,76s,75s,65s,ATo,KJo,KTo,QJo') },
+      HJ:  { raise: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,ATs,A5s,A4s,A3s,KQs,KJs,KTs,QJs,JTs,T9s,AKo,AQo,AJo,KQo,KJo'), call: s('99,88,77,66,55,44,33,22,A9s,A8s,A7s,A6s,A2s,K9s,K8s,QTs,Q9s,J9s,98s,97s,87s,86s,76s,75s,65s,ATo,KTo,QJo') },
+      CO:  { raise: s('AA,KK,QQ,JJ,TT,99,AKs,AQs,AJs,ATs,A5s,A4s,A3s,KQs,KJs,KTs,QJs,QTs,JTs,T9s,AKo,AQo,AJo,ATo,KQo,KJo,QJo'), call: s('88,77,66,55,44,33,22,A9s,A8s,A7s,A6s,A2s,K9s,K8s,Q9s,J9s,98s,97s,87s,86s,76s,75s,65s,54s,KTo,QTo,Q9o') },
+      BTN: { raise: s('AA,KK,QQ,JJ,TT,99,AKs,AQs,AJs,ATs,A9s,A5s,A4s,A3s,A2s,KQs,KJs,KTs,K9s,QJs,QTs,JTs,T9s,98s,87s,AKo,AQo,AJo,ATo,A9o,KQo,KJo,QJo,QTo,JTo'), call: s('88,77,66,55,44,33,22,A8s,A7s,A6s,K8s,Q9s,J9s,J8s,T8s,97s,76s,75s,65s,64s,54s,53s,K9o,K8o,Q9o,J9o,T9o') },
+    },
+    BB: {
+      UTG: { raise: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,ATs,A5s,A4s,KQs,KJs,QJs,JTs,AKo,AQo,AJo,KQo'), call: s('99,88,77,66,55,44,33,22,A9s,A8s,A7s,A6s,A3s,A2s,KTs,K9s,K8s,QTs,Q9s,J9s,T9s,T8s,98s,97s,87s,86s,76s,75s,65s,64s,54s,53s,43s,32s,ATo,A9o,KJo,KTo,K9o,QJo,QTo,Q9o,JTo,J9o,T9o,98o,87o,76o,65o') },
+      HJ:  { raise: s('AA,KK,QQ,JJ,TT,99,AKs,AQs,AJs,ATs,A5s,A4s,A3s,KQs,KJs,KTs,QJs,JTs,AKo,AQo,AJo,KQo,KJo'), call: s('88,77,66,55,44,33,22,A9s,A8s,A7s,A6s,A2s,K9s,K8s,QTs,Q9s,J9s,T9s,T8s,98s,97s,87s,86s,76s,75s,65s,64s,54s,43s,32s,ATo,A9o,KTo,K9o,QJo,QTo,Q9o,JTo,J9o,T9o,98o,87o,76o') },
+      CO:  { raise: s('AA,KK,QQ,JJ,TT,99,AKs,AQs,AJs,ATs,A5s,A4s,A3s,KQs,KJs,KTs,QJs,QTs,JTs,T9s,AKo,AQo,AJo,ATo,KQo,KJo,QJo'), call: s('88,77,66,55,44,33,22,A9s,A8s,A7s,A6s,A2s,K9s,K8s,Q9s,J9s,J8s,T8s,98s,97s,87s,86s,76s,75s,65s,64s,54s,43s,32s,A9o,K9o,KTo,Q9o,QTo,JTo,J9o,T9o,98o,87o,76o,65o') },
+      BTN: { raise: s('AA,KK,QQ,JJ,TT,99,88,77,AKs,AQs,AJs,ATs,A9s,A8s,A7s,A6s,A5s,A4s,A3s,A2s,KQs,KJs,KTs,K9s,QJs,QTs,Q9s,JTs,J9s,T9s,T8s,98s,87s,76s,AKo,AQo,AJo,ATo,A9o,A8o,KQo,KJo,KTo,QJo,QTo,JTo,T9o,98o'), call: s('66,55,44,33,22,K8s,K7s,Q8s,J8s,T7s,97s,86s,75s,65s,64s,54s,53s,43s,A7o,A6o,A5o,K9o,K8o,Q9o,Q8o,J9o,J8o,T8o,97o,87o,86o,76o,75o,65o') },
+      SB:  { raise: s('AA,KK,QQ,JJ,TT,99,88,77,66,AKs,AQs,AJs,ATs,A9s,A8s,A7s,A6s,A5s,A4s,A3s,A2s,KQs,KJs,KTs,K9s,K8s,QJs,QTs,Q9s,JTs,J9s,T9s,T8s,98s,97s,87s,76s,AKo,AQo,AJo,ATo,A9o,A8o,A7o,KQo,KJo,KTo,K9o,QJo,QTo,Q9o,JTo,T9o,98o,87o,76o'), call: s('55,44,33,22,K7s,K6s,Q8s,Q7s,J8s,J7s,T7s,96s,86s,75s,74s,65s,64s,54s,53s,43s,A6o,A5o,A4o,K8o,Q8o,J9o,J8o,T8o,97o,86o,75o,65o') },
+    },
+  },
+
+  '50BB': {
+    HJ: {
+      UTG: { raise: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,ATs,A5s,A4s,KQs,KJs,QJs,JTs,AKo,AQo,AJo,KQo'), call: s('99,88,77,66,55,44,A9s,A8s,A7s,A6s,A3s,A2s,KTs,K9s,QTs,Q9s,J9s,T9s,T8s,98s,87s,76s,65s,ATo,KJo,KTo,QJo') },
+    },
+    CO: {
+      UTG: { raise: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,ATs,A5s,A4s,KQs,KJs,KTs,QJs,JTs,AKo,AQo,AJo,KQo'), call: s('99,88,77,66,55,44,A9s,A8s,A7s,A6s,A3s,A2s,K9s,QTs,Q9s,J9s,98s,87s,76s,65s,ATo,QJo,QTo,JTo') },
+      HJ:  { raise: s('AA,KK,QQ,JJ,TT,99,AKs,AQs,AJs,ATs,A5s,A4s,KQs,KJs,KTs,QJs,QTs,JTs,T9s,AKo,AQo,AJo,ATo,KQo,KJo,QJo'), call: s('88,77,66,55,44,A9s,A8s,A7s,A6s,A3s,A2s,K9s,Q9s,J9s,98s,87s,76s,65s,KTo,QTo') },
+    },
+    BTN: {
+      UTG: { raise: s('AA,KK,QQ,JJ,TT,99,88,77,AKs,AQs,AJs,ATs,A9s,A5s,A4s,A3s,KQs,KJs,KTs,QJs,QTs,JTs,T9s,98s,AKo,AQo,AJo,ATo,KQo,KJo,QJo,QTo,JTo'), call: s('66,55,44,A8s,A7s,A6s,A2s,K9s,Q9s,J9s,T8s,87s,76s,65s,A9o,KTo,K9o,Q9o,J9o') },
+      HJ:  { raise: s('AA,KK,QQ,JJ,TT,99,88,77,AKs,AQs,AJs,ATs,A9s,A5s,A4s,A3s,KQs,KJs,KTs,QJs,QTs,JTs,J9s,T9s,98s,87s,AKo,AQo,AJo,ATo,KQo,KJo,QJo,QTo,JTo'), call: s('66,55,44,A8s,A7s,A6s,A2s,K9s,Q9s,76s,65s,A9o,KTo,K9o') },
+      CO:  { raise: s('AA,KK,QQ,JJ,TT,99,88,77,66,AKs,AQs,AJs,ATs,A9s,A8s,A7s,A6s,A5s,A4s,A3s,A2s,KQs,KJs,KTs,K9s,QJs,QTs,Q9s,JTs,J9s,T9s,T8s,98s,97s,87s,76s,65s,AKo,AQo,AJo,ATo,A9o,KQo,KJo,KTo,QJo,QTo,JTo,T9o'), call: s('55,44,K8s,Q8s,J8s,86s,75s,64s,A8o,A7o,K9o,K8o,Q9o,J9o') },
+    },
+    SB: {
+      UTG: { raise: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,ATs,A5s,A4s,KQs,KJs,QJs,JTs,AKo,AQo,AJo,KQo'), call: s('99,88,77,66,55,44,A9s,A8s,A7s,A6s,A3s,A2s,KTs,K9s,QTs,Q9s,J9s,T9s,98s,87s,76s,65s,ATo,KJo,KTo,QJo') },
+      HJ:  { raise: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,ATs,A5s,A4s,A3s,KQs,KJs,KTs,QJs,JTs,T9s,AKo,AQo,AJo,KQo,KJo'), call: s('99,88,77,66,55,44,A9s,A8s,A7s,A6s,A2s,K9s,QTs,Q9s,J9s,98s,87s,76s,65s,ATo,KTo,QJo') },
+      CO:  { raise: s('AA,KK,QQ,JJ,TT,99,AKs,AQs,AJs,ATs,A5s,A4s,A3s,KQs,KJs,KTs,QJs,QTs,JTs,T9s,AKo,AQo,AJo,ATo,KQo,KJo,QJo'), call: s('88,77,66,55,44,A9s,A8s,A7s,A6s,A2s,K9s,Q9s,J9s,98s,87s,76s,65s,KTo,QTo') },
+      BTN: { raise: s('AA,KK,QQ,JJ,TT,99,AKs,AQs,AJs,ATs,A9s,A5s,A4s,A3s,A2s,KQs,KJs,KTs,K9s,QJs,QTs,JTs,T9s,98s,87s,AKo,AQo,AJo,ATo,A9o,KQo,KJo,QJo,QTo,JTo'), call: s('88,77,66,55,44,A8s,A7s,A6s,Q9s,J9s,76s,75s,65s,K9o,Q9o,J9o,T9o') },
+    },
+    BB: {
+      UTG: { raise: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,ATs,A5s,A4s,KQs,KJs,QJs,JTs,AKo,AQo,AJo,KQo'), call: s('99,88,77,66,55,44,A9s,A8s,A7s,A6s,A3s,A2s,KTs,K9s,QTs,Q9s,J9s,T9s,T8s,98s,87s,76s,65s,54s,43s,ATo,A9o,KJo,KTo,K9o,QJo,QTo,Q9o,JTo,J9o,T9o,98o,87o,76o') },
+      HJ:  { raise: s('AA,KK,QQ,JJ,TT,99,AKs,AQs,AJs,ATs,A5s,A4s,A3s,KQs,KJs,KTs,QJs,JTs,AKo,AQo,AJo,KQo,KJo'), call: s('88,77,66,55,44,A9s,A8s,A7s,A6s,A2s,K9s,QTs,Q9s,J9s,T9s,T8s,98s,87s,76s,65s,54s,43s,ATo,A9o,KTo,K9o,QJo,QTo,Q9o,JTo,J9o,T9o,98o,87o') },
+      CO:  { raise: s('AA,KK,QQ,JJ,TT,99,AKs,AQs,AJs,ATs,A5s,A4s,A3s,KQs,KJs,KTs,QJs,QTs,JTs,T9s,AKo,AQo,AJo,ATo,KQo,KJo,QJo'), call: s('88,77,66,55,44,A9s,A8s,A7s,A6s,A2s,K9s,Q9s,J9s,J8s,T8s,98s,87s,76s,65s,54s,A9o,K9o,KTo,Q9o,QTo,JTo,J9o,T9o,98o,87o') },
+      BTN: { raise: s('AA,KK,QQ,JJ,TT,99,88,77,AKs,AQs,AJs,ATs,A9s,A8s,A7s,A6s,A5s,A4s,A3s,A2s,KQs,KJs,KTs,K9s,QJs,QTs,Q9s,JTs,J9s,T9s,T8s,98s,87s,76s,AKo,AQo,AJo,ATo,A9o,KQo,KJo,KTo,QJo,QTo,JTo,T9o'), call: s('66,55,44,K8s,Q8s,J8s,97s,86s,75s,65s,54s,A8o,A7o,K9o,K8o,Q9o,J9o,J8o,T8o,97o,87o,76o') },
+      SB:  { raise: s('AA,KK,QQ,JJ,TT,99,88,77,66,AKs,AQs,AJs,ATs,A9s,A8s,A7s,A6s,A5s,A4s,A3s,A2s,KQs,KJs,KTs,K9s,QJs,QTs,Q9s,JTs,J9s,T9s,T8s,98s,97s,87s,76s,AKo,AQo,AJo,ATo,A9o,A8o,KQo,KJo,KTo,K9o,QJo,QTo,Q9o,JTo,T9o,98o,87o'), call: s('55,44,K8s,K7s,Q8s,J8s,T7s,96s,75s,74s,65s,64s,54s,53s,A7o,A6o,K8o,Q8o,J9o,J8o,T8o,97o,86o,75o,65o') },
+    },
+  },
+
+  '33BB': {
+    HJ: {
+      UTG: { raise: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,ATs,A5s,KQs,KJs,QJs,JTs,AKo,AQo,AJo,KQo'), call: s('99,88,77,66,55,A9s,A8s,A7s,A6s,A4s,A3s,KTs,K9s,QTs,Q9s,J9s,T9s,98s,87s,76s,65s,ATo,KJo,KTo') },
+    },
+    CO: {
+      UTG: { raise: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,ATs,A5s,KQs,KJs,KTs,QJs,JTs,AKo,AQo,AJo,KQo'), call: s('99,88,77,66,55,A9s,A8s,A7s,A6s,A4s,A3s,K9s,QTs,Q9s,J9s,98s,87s,76s,65s,ATo,QJo,JTo') },
+      HJ:  { raise: s('AA,KK,QQ,JJ,TT,99,AKs,AQs,AJs,ATs,A5s,KQs,KJs,KTs,QJs,QTs,JTs,T9s,AKo,AQo,AJo,ATo,KQo,KJo,QJo'), call: s('88,77,66,55,A9s,A8s,A7s,A6s,A4s,A3s,K9s,Q9s,J9s,98s,87s,76s,65s,KTo') },
+    },
+    BTN: {
+      UTG: { raise: s('AA,KK,QQ,JJ,TT,99,88,77,AKs,AQs,AJs,ATs,A9s,A5s,A4s,KQs,KJs,KTs,QJs,QTs,JTs,T9s,98s,AKo,AQo,AJo,ATo,KQo,KJo,QJo,QTo,JTo'), call: s('66,55,A8s,A7s,A6s,A3s,A2s,K9s,Q9s,J9s,87s,76s,65s,A9o,KTo,K9o') },
+      HJ:  { raise: s('AA,KK,QQ,JJ,TT,99,88,77,AKs,AQs,AJs,ATs,A9s,A5s,A4s,KQs,KJs,KTs,QJs,QTs,JTs,J9s,T9s,98s,87s,AKo,AQo,AJo,ATo,KQo,KJo,QJo,QTo,JTo'), call: s('66,55,A8s,A7s,A6s,A3s,A2s,K9s,Q9s,76s,65s,A9o,KTo') },
+      CO:  { raise: s('AA,KK,QQ,JJ,TT,99,88,77,66,AKs,AQs,AJs,ATs,A9s,A8s,A7s,A6s,A5s,A4s,A3s,A2s,KQs,KJs,KTs,K9s,QJs,QTs,Q9s,JTs,J9s,T9s,T8s,98s,87s,76s,65s,AKo,AQo,AJo,ATo,A9o,KQo,KJo,KTo,QJo,QTo,JTo,T9o'), call: s('55,K8s,Q8s,J8s,97s,75s,64s,A8o,A7o,K9o,K8o') },
+    },
+    SB: {
+      UTG: { raise: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,ATs,A5s,KQs,KJs,QJs,JTs,AKo,AQo,AJo,KQo'), call: s('99,88,77,66,55,A9s,A8s,A7s,A6s,A4s,A3s,KTs,K9s,QTs,Q9s,J9s,T9s,98s,87s,76s,65s,ATo,KJo,KTo') },
+      HJ:  { raise: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,ATs,A5s,A4s,KQs,KJs,KTs,QJs,JTs,T9s,AKo,AQo,AJo,KQo,KJo'), call: s('99,88,77,66,55,A9s,A8s,A7s,A6s,A3s,A2s,K9s,QTs,Q9s,J9s,98s,87s,76s,65s,ATo,KTo') },
+      CO:  { raise: s('AA,KK,QQ,JJ,TT,99,AKs,AQs,AJs,ATs,A5s,A4s,KQs,KJs,KTs,QJs,QTs,JTs,T9s,AKo,AQo,AJo,ATo,KQo,KJo,QJo'), call: s('88,77,66,55,A9s,A8s,A7s,A6s,A3s,A2s,K9s,Q9s,J9s,98s,87s,76s,65s,KTo') },
+      BTN: { raise: s('AA,KK,QQ,JJ,TT,99,AKs,AQs,AJs,ATs,A9s,A5s,A4s,A3s,A2s,KQs,KJs,KTs,K9s,QJs,QTs,JTs,T9s,98s,AKo,AQo,AJo,ATo,A9o,KQo,KJo,QJo,QTo,JTo'), call: s('88,77,66,55,A8s,A7s,A6s,Q9s,J9s,76s,65s,K9o,Q9o,J9o') },
+    },
+    BB: {
+      UTG: { raise: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,ATs,A5s,A4s,KQs,KJs,QJs,JTs,AKo,AQo,AJo,KQo'), call: s('99,88,77,66,55,A9s,A8s,A7s,A6s,A3s,A2s,KTs,K9s,QTs,Q9s,J9s,T9s,98s,87s,76s,65s,54s,43s,ATo,A9o,KJo,KTo,K9o,QJo,QTo,Q9o,JTo,J9o,T9o,98o,87o') },
+      HJ:  { raise: s('AA,KK,QQ,JJ,TT,99,AKs,AQs,AJs,ATs,A5s,A4s,A3s,KQs,KJs,KTs,QJs,JTs,AKo,AQo,AJo,KQo,KJo'), call: s('88,77,66,55,A9s,A8s,A7s,A6s,A2s,K9s,QTs,Q9s,J9s,T9s,98s,87s,76s,65s,54s,ATo,A9o,KTo,K9o,QJo,QTo,Q9o,JTo,J9o,T9o,98o') },
+      CO:  { raise: s('AA,KK,QQ,JJ,TT,99,AKs,AQs,AJs,ATs,A5s,A4s,A3s,KQs,KJs,KTs,QJs,QTs,JTs,T9s,AKo,AQo,AJo,ATo,KQo,KJo,QJo'), call: s('88,77,66,55,A9s,A8s,A7s,A6s,A2s,K9s,Q9s,J9s,98s,87s,76s,65s,54s,A9o,K9o,KTo,Q9o,JTo,J9o,T9o,98o') },
+      BTN: { raise: s('AA,KK,QQ,JJ,TT,99,88,77,AKs,AQs,AJs,ATs,A9s,A8s,A7s,A6s,A5s,A4s,A3s,A2s,KQs,KJs,KTs,K9s,QJs,QTs,Q9s,JTs,J9s,T9s,T8s,98s,87s,76s,AKo,AQo,AJo,ATo,A9o,KQo,KJo,KTo,QJo,QTo,JTo,T9o'), call: s('66,55,K8s,Q8s,J8s,97s,86s,75s,65s,54s,A8o,K9o,K8o,Q9o,J9o,T8o,97o,87o') },
+      SB:  { raise: s('AA,KK,QQ,JJ,TT,99,88,77,66,AKs,AQs,AJs,ATs,A9s,A8s,A7s,A6s,A5s,A4s,A3s,A2s,KQs,KJs,KTs,K9s,QJs,QTs,Q9s,JTs,J9s,T9s,T8s,98s,97s,87s,76s,AKo,AQo,AJo,ATo,A9o,A8o,KQo,KJo,KTo,K9o,QJo,QTo,Q9o,JTo,T9o,98o'), call: s('55,K8s,K7s,Q8s,J8s,T7s,96s,75s,65s,54s,A7o,A6o,K8o,Q8o,J9o,J8o,T8o,97o') },
+    },
+  },
+
+  '25BB': {
+    HJ: {
+      UTG: { raise: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,ATs,A5s,KQs,KJs,QJs,AKo,AQo,AJo,KQo'), call: s('99,88,77,66,A9s,A8s,A7s,KTs,K9s,QTs,J9s,T9s,98s,ATo,KTo') },
+    },
+    CO: {
+      UTG: { raise: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,ATs,A5s,KQs,KJs,KTs,QJs,JTs,AKo,AQo,AJo,KQo'), call: s('99,88,77,66,A9s,A8s,A7s,K9s,QTs,J9s,T9s,87s,76s,ATo,QJo') },
+      HJ:  { raise: s('AA,KK,QQ,JJ,TT,99,AKs,AQs,AJs,ATs,A5s,KQs,KJs,KTs,QJs,QTs,JTs,T9s,AKo,AQo,AJo,ATo,KQo,KJo'), call: s('88,77,66,A9s,A8s,K9s,Q9s,J9s,87s,76s,KTo') },
+    },
+    BTN: {
+      UTG: { raise: s('AA,KK,QQ,JJ,TT,99,88,AKs,AQs,AJs,ATs,A9s,A5s,A4s,KQs,KJs,KTs,QJs,QTs,JTs,T9s,AKo,AQo,AJo,ATo,KQo,KJo,QJo,JTo'), call: s('77,66,A8s,A7s,K9s,J9s,87s,76s,A9o,KTo') },
+      HJ:  { raise: s('AA,KK,QQ,JJ,TT,99,88,AKs,AQs,AJs,ATs,A9s,A5s,A4s,KQs,KJs,KTs,QJs,QTs,JTs,J9s,T9s,98s,AKo,AQo,AJo,ATo,KQo,KJo,QJo,JTo'), call: s('77,66,A8s,A7s,K9s,Q9s,76s,65s,A9o,KTo') },
+      CO:  { raise: s('AA,KK,QQ,JJ,TT,99,88,77,AKs,AQs,AJs,ATs,A9s,A8s,A7s,A6s,A5s,A4s,A3s,KQs,KJs,KTs,K9s,QJs,QTs,Q9s,JTs,J9s,T9s,98s,87s,76s,65s,AKo,AQo,AJo,ATo,A9o,KQo,KJo,KTo,QJo,QTo,JTo,T9o'), call: s('66,55,A2s,K8s,Q8s,J8s,T8s,97s,86s,75s,A8o,A7o,K9o') },
+    },
+    SB: {
+      UTG: { raise: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,ATs,A5s,KQs,KJs,QJs,JTs,AKo,AQo,AJo,KQo'), call: s('99,88,77,66,A9s,A8s,KTs,K9s,QTs,J9s,T9s,98s,87s,ATo,KJo,KTo') },
+      HJ:  { raise: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,ATs,A5s,A4s,KQs,KJs,KTs,QJs,JTs,T9s,AKo,AQo,AJo,KQo,KJo'), call: s('99,88,77,66,A9s,A8s,K9s,QTs,J9s,98s,87s,76s,ATo,KTo') },
+      CO:  { raise: s('AA,KK,QQ,JJ,TT,99,AKs,AQs,AJs,ATs,A5s,A4s,KQs,KJs,KTs,QJs,QTs,JTs,T9s,AKo,AQo,AJo,ATo,KQo,KJo,QJo'), call: s('88,77,66,A9s,A8s,K9s,Q9s,J9s,98s,87s,76s,KTo') },
+      BTN: { raise: s('AA,KK,QQ,JJ,TT,99,AKs,AQs,AJs,ATs,A9s,A5s,A4s,A3s,KQs,KJs,KTs,K9s,QJs,QTs,JTs,T9s,98s,AKo,AQo,AJo,ATo,A9o,KQo,KJo,QJo,QTo,JTo'), call: s('88,77,66,A8s,A7s,Q9s,J9s,76s,65s,K9o,Q9o') },
+    },
+    BB: {
+      UTG: { raise: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,ATs,A5s,A4s,KQs,KJs,QJs,JTs,AKo,AQo,AJo,KQo'), call: s('99,88,77,66,55,A9s,A8s,A7s,A6s,A3s,A2s,KTs,K9s,QTs,Q9s,J9s,T9s,98s,87s,76s,65s,54s,ATo,A9o,KJo,KTo,K9o,QJo,QTo,JTo,J9o,T9o,98o') },
+      HJ:  { raise: s('AA,KK,QQ,JJ,TT,99,AKs,AQs,AJs,ATs,A5s,A4s,A3s,KQs,KJs,KTs,QJs,JTs,AKo,AQo,AJo,KQo,KJo'), call: s('88,77,66,55,A9s,A8s,A7s,A6s,A2s,K9s,QTs,Q9s,J9s,T9s,98s,87s,76s,65s,54s,ATo,A9o,KTo,K9o,QJo,QTo,JTo,J9o,T9o') },
+      CO:  { raise: s('AA,KK,QQ,JJ,TT,99,AKs,AQs,AJs,ATs,A5s,A4s,KQs,KJs,KTs,QJs,QTs,JTs,T9s,AKo,AQo,AJo,ATo,KQo,KJo,QJo'), call: s('88,77,66,55,A9s,A8s,A7s,A6s,A3s,A2s,K9s,Q9s,J9s,98s,87s,76s,65s,A9o,K9o,KTo,Q9o,JTo,J9o,T9o') },
+      BTN: { raise: s('AA,KK,QQ,JJ,TT,99,88,77,66,AKs,AQs,AJs,ATs,A9s,A8s,A7s,A6s,A5s,A4s,A3s,A2s,KQs,KJs,KTs,K9s,QJs,QTs,Q9s,JTs,J9s,T9s,98s,87s,76s,AKo,AQo,AJo,ATo,A9o,KQo,KJo,KTo,QJo,QTo,JTo,T9o'), call: s('55,44,K8s,Q8s,J8s,T8s,97s,86s,75s,65s,A8o,K9o,K8o,Q9o,J9o,97o,87o') },
+      SB:  { raise: s('AA,KK,QQ,JJ,TT,99,88,77,66,AKs,AQs,AJs,ATs,A9s,A8s,A7s,A6s,A5s,A4s,A3s,A2s,KQs,KJs,KTs,K9s,QJs,QTs,Q9s,JTs,J9s,T9s,T8s,98s,97s,87s,76s,AKo,AQo,AJo,ATo,A9o,A8o,KQo,KJo,KTo,K9o,QJo,QTo,Q9o,JTo,T9o,98o'), call: s('55,K8s,K7s,Q8s,J8s,T7s,75s,65s,54s,A7o,A6o,K8o,Q8o,J9o,J8o,T8o') },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// VS_RAISE_RANGES
+// ---------------------------------------------------------------------------
+export const VS_RAISE_RANGES = {
+  '100BB': {
+    HJ: {
+      UTG: { threebet: s('AA,KK,QQ,AKs,A5s,A4s,AKo'), call: s('JJ,TT,99,AQs,AJs,ATs,KQs,JTs,AQo,KQo') },
+    },
+    CO: {
+      UTG: { threebet: s('AA,KK,QQ,AKs,A5s,A4s,AKo'), call: s('JJ,TT,99,AQs,AJs,ATs,KQs,KJs,QJs,JTs,T9s,AQo,AJo,KQo') },
+      HJ:  { threebet: s('AA,KK,QQ,AKs,KQs,A5s,A4s,A3s,AKo'), call: s('JJ,TT,99,88,AQs,AJs,ATs,KJs,QJs,JTs,T9s,98s,AQo,AJo,KQo,QJo') },
+    },
+    BTN: {
+      UTG: { threebet: s('AA,KK,QQ,AKs,A5s,A4s,A3s,AKo'), call: s('JJ,TT,99,88,AQs,AJs,ATs,KQs,KJs,QJs,JTs,T9s,98s,87s,AQo,AJo,ATo,KQo,KJo,QJo') },
+      HJ:  { threebet: s('AA,KK,QQ,AKs,KQs,A5s,A4s,A3s,A2s,AKo'), call: s('JJ,TT,99,88,77,AQs,AJs,ATs,KJs,KTs,QJs,JTs,T9s,98s,87s,76s,AQo,AJo,ATo,KQo,KJo,QJo,JTo') },
+      CO:  { threebet: s('AA,KK,QQ,JJ,AKs,AQs,KQs,A5s,A4s,A3s,A2s,AKo,AQo'), call: s('TT,99,88,77,66,AJs,ATs,KJs,KTs,K9s,QJs,JTs,T9s,98s,87s,76s,65s,AJo,ATo,KQo,KJo,KTo,QJo,JTo,T9o') },
+    },
+    SB: {
+      UTG: { threebet: s('AA,KK,QQ,AKs,A5s,A4s,AKo'), call: s('JJ,TT,AQs,AJs,KQs,QJs,JTs,AQo') },
+      HJ:  { threebet: s('AA,KK,QQ,AKs,A5s,A4s,A3s,AKo'), call: s('JJ,TT,99,AQs,AJs,ATs,KQs,QJs,JTs,AQo,KQo') },
+      CO:  { threebet: s('AA,KK,QQ,JJ,AKs,KQs,A5s,A4s,A3s,AKo'), call: s('TT,99,AQs,AJs,ATs,KJs,QJs,JTs,T9s,AQo,KQo') },
+      BTN: { threebet: s('AA,KK,QQ,JJ,TT,AKs,AQs,KQs,KJs,A5s,A4s,A3s,A2s,AKo,AQo,KQo'), call: s('99,88,AJs,ATs,KTs,QJs,JTs,T9s,98s,AJo,ATo,KJo,QJo') },
+    },
+    BB: {
+      UTG: { threebet: s('AA,KK,QQ,AKs,A5s,A4s,AKo'), call: s('JJ,TT,99,88,77,AQs,AJs,ATs,KQs,KJs,QJs,JTs,T9s,98s,87s,AQo,AJo,ATo,KQo,KJo,QJo') },
+      HJ:  { threebet: s('AA,KK,QQ,AKs,A5s,A4s,A3s,AKo'), call: s('JJ,TT,99,88,77,66,AQs,AJs,ATs,KQs,KJs,QJs,JTs,T9s,98s,87s,76s,AQo,AJo,ATo,KQo,KJo,QJo,JTo') },
+      CO:  { threebet: s('AA,KK,QQ,JJ,AKs,KQs,A5s,A4s,A3s,AKo'), call: s('TT,99,88,77,66,55,AQs,AJs,ATs,KJs,KTs,QJs,JTs,T9s,98s,87s,76s,65s,AQo,AJo,ATo,A9o,KQo,KJo,KTo,QJo,QTo,JTo') },
+      BTN: { threebet: s('AA,KK,QQ,JJ,TT,AKs,AQs,KQs,KJs,A5s,A4s,A3s,A2s,AKo,AQo,KQo'), call: s('99,88,77,66,55,44,33,22,AJs,ATs,A9s,A8s,KTs,K9s,K8s,QJs,Q9s,JTs,J9s,T9s,T8s,98s,97s,87s,86s,76s,75s,65s,AJo,ATo,A9o,A8o,KJo,KTo,K9o,QJo,QTo,Q9o,JTo,J9o,T9o,T8o,98o') },
+      SB:  { threebet: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,KQs,KJs,KTs,QJs,JTs,A5s,A4s,A3s,A2s,AKo,AQo,AJo,KQo,KJo,QJo'), call: s('99,88,77,66,55,44,33,22,ATs,A9s,A8s,A7s,A6s,K9s,K8s,K7s,QTs,Q9s,Q8s,J9s,J8s,T9s,T8s,T7s,98s,97s,96s,87s,86s,85s,76s,75s,74s,65s,64s,63s,54s,ATo,A9o,A8o,KTo,K9o,Q9o,JTo,T9o,98o,87o') },
+    },
+  },
+
+  '50BB': {
+    HJ: {
+      UTG: { threebet: s('AA,KK,QQ,AKs,A5s,A4s,AKo'), call: s('JJ,TT,AQs,AJs,ATs,KQs,JTs,AQo,KQo') },
+    },
+    CO: {
+      UTG: { threebet: s('AA,KK,QQ,AKs,A5s,A4s,AKo'), call: s('JJ,TT,99,AQs,AJs,ATs,KQs,KJs,QJs,JTs,AQo,AJo,KQo') },
+      HJ:  { threebet: s('AA,KK,QQ,AKs,KQs,A5s,A4s,A3s,AKo'), call: s('JJ,TT,99,AQs,AJs,ATs,KJs,QJs,JTs,T9s,AQo,AJo,KQo,QJo') },
+    },
+    BTN: {
+      UTG: { threebet: s('AA,KK,QQ,AKs,A5s,A4s,A3s,AKo'), call: s('JJ,TT,99,88,AQs,AJs,ATs,KQs,KJs,QJs,JTs,T9s,98s,AQo,AJo,ATo,KQo,KJo,QJo') },
+      HJ:  { threebet: s('AA,KK,QQ,AKs,KQs,A5s,A4s,A3s,A2s,AKo'), call: s('JJ,TT,99,88,AQs,AJs,ATs,KJs,KTs,QJs,JTs,T9s,98s,87s,AQo,AJo,ATo,KQo,KJo,QJo,JTo') },
+      CO:  { threebet: s('AA,KK,QQ,JJ,AKs,AQs,KQs,A5s,A4s,A3s,A2s,AKo,AQo'), call: s('TT,99,88,77,AJs,ATs,KJs,KTs,K9s,QJs,JTs,T9s,98s,87s,76s,AJo,ATo,KQo,KJo,KTo,QJo,JTo,T9o') },
+    },
+    SB: {
+      UTG: { threebet: s('AA,KK,QQ,AKs,A5s,A4s,AKo'), call: s('JJ,TT,AQs,AJs,KQs,QJs,JTs,AQo') },
+      HJ:  { threebet: s('AA,KK,QQ,AKs,A5s,A4s,A3s,AKo'), call: s('JJ,TT,99,AQs,AJs,ATs,KQs,JTs,AQo,KQo') },
+      CO:  { threebet: s('AA,KK,QQ,JJ,AKs,KQs,A5s,A4s,A3s,AKo'), call: s('TT,99,AQs,AJs,ATs,KJs,QJs,JTs,AQo,KQo') },
+      BTN: { threebet: s('AA,KK,QQ,JJ,TT,AKs,AQs,KQs,KJs,A5s,A4s,A3s,A2s,AKo,AQo,KQo'), call: s('99,88,AJs,ATs,KTs,QJs,JTs,T9s,AJo,ATo,KJo,QJo') },
+    },
+    BB: {
+      UTG: { threebet: s('AA,KK,QQ,AKs,A5s,A4s,AKo'), call: s('JJ,TT,99,88,77,AQs,AJs,ATs,KQs,KJs,QJs,JTs,T9s,98s,87s,AQo,AJo,ATo,KQo,KJo,QJo') },
+      HJ:  { threebet: s('AA,KK,QQ,AKs,A5s,A4s,A3s,AKo'), call: s('JJ,TT,99,88,77,66,AQs,AJs,ATs,KQs,KJs,QJs,JTs,T9s,98s,87s,76s,AQo,AJo,ATo,KQo,KJo,QJo,JTo') },
+      CO:  { threebet: s('AA,KK,QQ,JJ,AKs,KQs,A5s,A4s,A3s,AKo'), call: s('TT,99,88,77,66,55,AQs,AJs,ATs,KJs,KTs,QJs,JTs,T9s,98s,87s,76s,65s,AQo,AJo,ATo,A9o,KQo,KJo,KTo,QJo,QTo,JTo') },
+      BTN: { threebet: s('AA,KK,QQ,JJ,TT,AKs,AQs,KQs,KJs,A5s,A4s,A3s,A2s,AKo,AQo,KQo'), call: s('99,88,77,66,55,44,AJs,ATs,A9s,A8s,KTs,K9s,K8s,QJs,Q9s,JTs,J9s,T9s,T8s,98s,97s,87s,86s,76s,75s,65s,AJo,ATo,A9o,A8o,KJo,KTo,K9o,QJo,QTo,Q9o,JTo,J9o,T9o,T8o,98o') },
+      SB:  { threebet: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,KQs,KJs,KTs,QJs,JTs,A5s,A4s,A3s,A2s,AKo,AQo,AJo,KQo,KJo,QJo'), call: s('99,88,77,66,55,44,ATs,A9s,A8s,A7s,K9s,K8s,K7s,QTs,Q9s,Q8s,J9s,J8s,T9s,T8s,T7s,98s,97s,87s,86s,76s,75s,65s,ATo,A9o,A8o,KTo,K9o,Q9o,JTo,T9o,98o,87o') },
+    },
+  },
+
+  '33BB': {
+    HJ: {
+      UTG: { threebet: s('AA,KK,QQ,AKs,A5s,AKo'), call: s('JJ,TT,AQs,AJs,ATs,KQs,AQo') },
+    },
+    CO: {
+      UTG: { threebet: s('AA,KK,QQ,AKs,A5s,A4s,AKo'), call: s('JJ,TT,AQs,AJs,ATs,KQs,KJs,QJs,JTs,AQo,AJo,KQo') },
+      HJ:  { threebet: s('AA,KK,QQ,AKs,KQs,A5s,A4s,AKo'), call: s('JJ,TT,99,AQs,AJs,ATs,KJs,QJs,JTs,AQo,AJo,KQo') },
+    },
+    BTN: {
+      UTG: { threebet: s('AA,KK,QQ,AKs,A5s,A4s,AKo'), call: s('JJ,TT,99,AQs,AJs,ATs,KQs,KJs,QJs,JTs,T9s,AQo,AJo,ATo,KQo,KJo') },
+      HJ:  { threebet: s('AA,KK,QQ,AKs,KQs,A5s,A4s,A3s,AKo'), call: s('JJ,TT,99,88,AQs,AJs,ATs,KJs,KTs,QJs,JTs,T9s,98s,AQo,AJo,ATo,KQo,KJo,QJo') },
+      CO:  { threebet: s('AA,KK,QQ,JJ,AKs,AQs,KQs,A5s,A4s,A3s,A2s,AKo,AQo'), call: s('TT,99,88,AJs,ATs,KJs,KTs,K9s,QJs,JTs,T9s,98s,87s,76s,AJo,ATo,KQo,KJo,KTo,QJo,JTo') },
+    },
+    SB: {
+      UTG: { threebet: s('AA,KK,QQ,AKs,A5s,AKo'), call: s('JJ,TT,AQs,AJs,KQs,AQo') },
+      HJ:  { threebet: s('AA,KK,QQ,AKs,A5s,A4s,AKo'), call: s('JJ,TT,AQs,AJs,ATs,KQs,QJs,JTs,AQo,KQo') },
+      CO:  { threebet: s('AA,KK,QQ,JJ,AKs,KQs,A5s,A4s,AKo'), call: s('TT,99,AQs,AJs,ATs,KJs,QJs,JTs,AQo,KQo') },
+      BTN: { threebet: s('AA,KK,QQ,JJ,TT,AKs,AQs,KQs,KJs,A5s,A4s,A3s,A2s,AKo,AQo,KQo'), call: s('99,AJs,ATs,KTs,QJs,JTs,T9s,AJo,ATo,KJo') },
+    },
+    BB: {
+      UTG: { threebet: s('AA,KK,QQ,AKs,A5s,A4s,AKo'), call: s('JJ,TT,99,88,77,AQs,AJs,ATs,KQs,KJs,QJs,JTs,T9s,98s,AQo,AJo,ATo,KQo,KJo,QJo') },
+      HJ:  { threebet: s('AA,KK,QQ,AKs,A5s,A4s,A3s,AKo'), call: s('JJ,TT,99,88,77,AQs,AJs,ATs,KQs,KJs,QJs,JTs,T9s,98s,87s,AQo,AJo,ATo,KQo,KJo,QJo') },
+      CO:  { threebet: s('AA,KK,QQ,JJ,AKs,KQs,A5s,A4s,A3s,AKo'), call: s('TT,99,88,77,66,AQs,AJs,ATs,KJs,KTs,QJs,JTs,T9s,98s,87s,76s,AQo,AJo,ATo,A9o,KQo,KJo,KTo,QJo,JTo') },
+      BTN: { threebet: s('AA,KK,QQ,JJ,TT,AKs,AQs,KQs,KJs,A5s,A4s,A3s,A2s,AKo,AQo,KQo'), call: s('99,88,77,66,55,44,AJs,ATs,A9s,A8s,KTs,K9s,QJs,Q9s,JTs,J9s,T9s,T8s,98s,87s,76s,65s,AJo,ATo,A9o,KJo,KTo,K9o,QJo,QTo,JTo,J9o,T9o,98o') },
+      SB:  { threebet: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,KQs,KJs,KTs,QJs,JTs,A5s,A4s,A3s,A2s,AKo,AQo,AJo,KQo,KJo,QJo'), call: s('99,88,77,66,55,ATs,A9s,A8s,A7s,K9s,K8s,QTs,Q9s,J9s,J8s,T9s,T8s,98s,97s,87s,76s,75s,ATo,A9o,KTo,K9o,JTo,T9o,98o') },
+    },
+  },
+
+  '25BB': {
+    HJ: {
+      UTG: { threebet: s('AA,KK,QQ,AKs,A5s,AKo'), call: s('JJ,TT,AQs,AJs,KQs,AQo') },
+    },
+    CO: {
+      UTG: { threebet: s('AA,KK,QQ,AKs,A5s,A4s,AKo'), call: s('JJ,TT,AQs,AJs,KQs,KJs,QJs,AQo,KQo') },
+      HJ:  { threebet: s('AA,KK,QQ,AKs,KQs,A5s,A4s,AKo'), call: s('JJ,TT,99,AQs,AJs,ATs,KJs,QJs,JTs,AQo,AJo,KQo') },
+    },
+    BTN: {
+      UTG: { threebet: s('AA,KK,QQ,AKs,A5s,A4s,AKo'), call: s('JJ,TT,AQs,AJs,KQs,KJs,QJs,JTs,AQo,AJo,ATo,KQo') },
+      HJ:  { threebet: s('AA,KK,QQ,AKs,KQs,A5s,A4s,A3s,AKo'), call: s('JJ,TT,99,AQs,AJs,ATs,KJs,KTs,QJs,JTs,T9s,AQo,AJo,ATo,KQo,KJo,QJo') },
+      CO:  { threebet: s('AA,KK,QQ,JJ,AKs,AQs,KQs,A5s,A4s,A3s,A2s,AKo,AQo'), call: s('TT,99,88,AJs,ATs,KJs,KTs,QJs,JTs,T9s,98s,AJo,ATo,KQo,KJo,KTo,QJo') },
+    },
+    SB: {
+      UTG: { threebet: s('AA,KK,QQ,AKs,A5s,AKo'), call: s('JJ,TT,AQs,KQs,AQo') },
+      HJ:  { threebet: s('AA,KK,QQ,AKs,A5s,A4s,AKo'), call: s('JJ,TT,AQs,AJs,KQs,JTs,AQo') },
+      CO:  { threebet: s('AA,KK,QQ,JJ,AKs,KQs,A5s,A4s,AKo'), call: s('TT,99,AQs,AJs,KJs,QJs,JTs,AQo,KQo') },
+      BTN: { threebet: s('AA,KK,QQ,JJ,TT,AKs,AQs,KQs,KJs,A5s,A4s,A3s,A2s,AKo,AQo,KQo'), call: s('99,AJs,ATs,KTs,QJs,JTs,AJo,ATo') },
+    },
+    BB: {
+      UTG: { threebet: s('AA,KK,QQ,AKs,A5s,A4s,AKo'), call: s('JJ,TT,99,88,AQs,AJs,ATs,KQs,KJs,QJs,JTs,T9s,AQo,AJo,ATo,KQo,KJo') },
+      HJ:  { threebet: s('AA,KK,QQ,AKs,A5s,A4s,A3s,AKo'), call: s('JJ,TT,99,88,77,AQs,AJs,ATs,KQs,KJs,QJs,JTs,T9s,98s,AQo,AJo,ATo,KQo,KJo,QJo') },
+      CO:  { threebet: s('AA,KK,QQ,JJ,AKs,KQs,A5s,A4s,A3s,AKo'), call: s('TT,99,88,77,66,AQs,AJs,ATs,KJs,KTs,QJs,JTs,T9s,98s,87s,AQo,AJo,ATo,KQo,KJo,KTo,QJo') },
+      BTN: { threebet: s('AA,KK,QQ,JJ,TT,AKs,AQs,KQs,KJs,A5s,A4s,A3s,A2s,AKo,AQo,KQo'), call: s('99,88,77,66,55,AJs,ATs,A9s,KTs,K9s,QJs,JTs,J9s,T9s,T8s,98s,87s,76s,AJo,ATo,A9o,KJo,KTo,K9o,QJo,QTo,JTo,J9o,T9o') },
+      SB:  { threebet: s('AA,KK,QQ,JJ,TT,AKs,AQs,AJs,KQs,KJs,KTs,QJs,JTs,A5s,A4s,A3s,A2s,AKo,AQo,AJo,KQo,KJo,QJo'), call: s('99,88,77,66,ATs,A9s,A8s,K9s,K8s,QTs,Q9s,J9s,T9s,T8s,98s,97s,87s,76s,ATo,A9o,KTo,K9o,JTo,T9o') },
+    },
+  },
+};

--- a/src/data/preflop-ranges.test.js
+++ b/src/data/preflop-ranges.test.js
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import {
+  LIMP_RANGES, VS_RAISE_RANGES,
+  LIMP_HERO_POSITIONS, RAISE_HERO_POSITIONS,
+  VALID_LIMP_VILLAINS, VALID_RAISE_VILLAINS,
+} from './preflop-ranges.js';
+import { STACK_DEPTHS } from './rfi-ranges.js';
+
+const VALID_HAND = /^[AKQJT98765432]{2}[so]?$/;
+
+describe('LIMP_RANGES structure', () => {
+  it('has all 4 stack depths', () => {
+    for (const d of STACK_DEPTHS) expect(LIMP_RANGES[d], `missing ${d}`).toBeTruthy();
+  });
+
+  it('each hero/villain combo has raise and call Sets', () => {
+    for (const d of STACK_DEPTHS) {
+      for (const hero of LIMP_HERO_POSITIONS) {
+        for (const villain of VALID_LIMP_VILLAINS[hero]) {
+          const r = LIMP_RANGES[d]?.[hero]?.[villain];
+          expect(r, `missing ${d}/${hero}/${villain}`).toBeTruthy();
+          expect(r.raise).toBeInstanceOf(Set);
+          expect(r.call).toBeInstanceOf(Set);
+        }
+      }
+    }
+  });
+
+  it('raise and call sets are disjoint', () => {
+    for (const d of STACK_DEPTHS) {
+      for (const hero of LIMP_HERO_POSITIONS) {
+        for (const villain of VALID_LIMP_VILLAINS[hero]) {
+          const { raise, call } = LIMP_RANGES[d][hero][villain];
+          for (const h of raise) expect(call.has(h), `${h} in both raise+call (${d}/${hero}/${villain})`).toBe(false);
+        }
+      }
+    }
+  });
+
+  it('all hand notations are valid', () => {
+    for (const d of STACK_DEPTHS) {
+      for (const hero of LIMP_HERO_POSITIONS) {
+        for (const villain of VALID_LIMP_VILLAINS[hero]) {
+          const { raise, call } = LIMP_RANGES[d][hero][villain];
+          for (const h of [...raise, ...call]) expect(h, `invalid hand "${h}"`).toMatch(VALID_HAND);
+        }
+      }
+    }
+  });
+
+  it('BTN raise range vs CO wider than HJ raise range vs UTG at 100BB', () => {
+    const btn = LIMP_RANGES['100BB']['BTN']['CO'].raise.size;
+    const hj  = LIMP_RANGES['100BB']['HJ']['UTG'].raise.size;
+    expect(btn).toBeGreaterThan(hj);
+  });
+
+  it('100BB raise ranges wider than 25BB for BTN vs CO', () => {
+    const r100 = LIMP_RANGES['100BB']['BTN']['CO'].raise.size;
+    const r25  = LIMP_RANGES['25BB']['BTN']['CO'].raise.size;
+    expect(r100).toBeGreaterThan(r25);
+  });
+});
+
+describe('VALID_LIMP_VILLAINS', () => {
+  it('HJ only faces UTG limp', () => expect(VALID_LIMP_VILLAINS['HJ']).toEqual(['UTG']));
+  it('BB faces all 5 villain positions', () => expect(VALID_LIMP_VILLAINS['BB']).toHaveLength(5));
+  it('BTN faces 3 villain positions', () => expect(VALID_LIMP_VILLAINS['BTN']).toHaveLength(3));
+});
+
+describe('VS_RAISE_RANGES structure', () => {
+  it('has all 4 stack depths', () => {
+    for (const d of STACK_DEPTHS) expect(VS_RAISE_RANGES[d], `missing ${d}`).toBeTruthy();
+  });
+
+  it('each hero/villain combo has threebet and call Sets', () => {
+    for (const d of STACK_DEPTHS) {
+      for (const hero of RAISE_HERO_POSITIONS) {
+        for (const villain of VALID_RAISE_VILLAINS[hero]) {
+          const r = VS_RAISE_RANGES[d]?.[hero]?.[villain];
+          expect(r, `missing ${d}/${hero}/${villain}`).toBeTruthy();
+          expect(r.threebet).toBeInstanceOf(Set);
+          expect(r.call).toBeInstanceOf(Set);
+        }
+      }
+    }
+  });
+
+  it('threebet and call sets are disjoint', () => {
+    for (const d of STACK_DEPTHS) {
+      for (const hero of RAISE_HERO_POSITIONS) {
+        for (const villain of VALID_RAISE_VILLAINS[hero]) {
+          const { threebet, call } = VS_RAISE_RANGES[d][hero][villain];
+          for (const h of threebet) expect(call.has(h), `${h} in both 3bet+call`).toBe(false);
+        }
+      }
+    }
+  });
+
+  it('all hand notations are valid', () => {
+    for (const d of STACK_DEPTHS) {
+      for (const hero of RAISE_HERO_POSITIONS) {
+        for (const villain of VALID_RAISE_VILLAINS[hero]) {
+          const { threebet, call } = VS_RAISE_RANGES[d][hero][villain];
+          for (const h of [...threebet, ...call]) expect(h).toMatch(VALID_HAND);
+        }
+      }
+    }
+  });
+
+  it('BB call range vs BTN wider than SB call range vs BTN at 100BB', () => {
+    const bb = VS_RAISE_RANGES['100BB']['BB']['BTN'].call.size;
+    const sb = VS_RAISE_RANGES['100BB']['SB']['BTN'].call.size;
+    expect(bb).toBeGreaterThan(sb);
+  });
+
+  it('AA is always in 3-bet range for all hero/villain combos at 100BB', () => {
+    for (const hero of RAISE_HERO_POSITIONS) {
+      for (const villain of VALID_RAISE_VILLAINS[hero]) {
+        expect(VS_RAISE_RANGES['100BB'][hero][villain].threebet.has('AA')).toBe(true);
+      }
+    }
+  });
+});

--- a/src/routing.js
+++ b/src/routing.js
@@ -5,6 +5,8 @@ export const ROUTES_LIST = [
   '/terminology/quiz',
   '/terminology/reference',
   '/preflop/charts',
+  '/preflop/limp',
+  '/preflop/vs-raise',
   '/preflop/quiz',
   '/stats',
 ];

--- a/src/routing.test.js
+++ b/src/routing.test.js
@@ -40,6 +40,19 @@ describe('routing', () => {
     }
   });
 
+  it('/preflop/limp exists in routes list', () => {
+    expect(ROUTES_LIST).toContain('/preflop/limp');
+  });
+
+  it('/preflop/vs-raise exists in routes list', () => {
+    expect(ROUTES_LIST).toContain('/preflop/vs-raise');
+  });
+
+  it('resolveRoute passes through new preflop routes unchanged', () => {
+    expect(resolveRoute('/preflop/limp')).toBe('/preflop/limp');
+    expect(resolveRoute('/preflop/vs-raise')).toBe('/preflop/vs-raise');
+  });
+
   it('empty hash on initial load resolves to a renderable route — no blank page regression', () => {
     // Reproduces the startup sequence in useHashRoute:
     //   window.location.hash.slice(1) || '/'

--- a/src/sections/preflop/Charts.jsx
+++ b/src/sections/preflop/Charts.jsx
@@ -4,8 +4,10 @@ import { RANKS, RFI_RANGES, POS_LIST, STACK_DEPTHS } from '../../data/rfi-ranges
 import '../../styles/charts.css';
 
 const TABS = [
-  { path: '/preflop/charts', label: 'Charts' },
-  { path: '/preflop/quiz', label: 'RFI Quiz' }
+  { path: '/preflop/charts', label: 'RFI' },
+  { path: '/preflop/limp', label: 'vs Limp' },
+  { path: '/preflop/vs-raise', label: 'vs Raise' },
+  { path: '/preflop/quiz', label: 'Quiz' },
 ];
 
 export function Charts({ path }) {

--- a/src/sections/preflop/LimpCharts.jsx
+++ b/src/sections/preflop/LimpCharts.jsx
@@ -1,0 +1,91 @@
+import { useState } from 'preact/hooks';
+import { SubNav } from '../../components/SubNav.jsx';
+import { RANKS, STACK_DEPTHS } from '../../data/rfi-ranges.js';
+import { LIMP_HERO_POSITIONS, VALID_LIMP_VILLAINS, LIMP_RANGES } from '../../data/preflop-ranges.js';
+import '../../styles/charts.css';
+
+const TABS = [
+  { path: '/preflop/charts', label: 'RFI' },
+  { path: '/preflop/limp', label: 'vs Limp' },
+  { path: '/preflop/vs-raise', label: 'vs Raise' },
+  { path: '/preflop/quiz', label: 'Quiz' },
+];
+
+export function LimpCharts() {
+  const [heroPos, setHeroPos] = useState('BTN');
+  const [villainPos, setVillainPos] = useState('CO');
+  const [stackDepth, setStackDepth] = useState('100BB');
+
+  const validVillains = VALID_LIMP_VILLAINS[heroPos] || [];
+
+  function changeHero(pos) {
+    setHeroPos(pos);
+    const valid = VALID_LIMP_VILLAINS[pos] || [];
+    if (!valid.includes(villainPos)) setVillainPos(valid[valid.length - 1] || valid[0]);
+  }
+
+  const rangeSet = LIMP_RANGES[stackDepth]?.[heroPos]?.[villainPos];
+  const raiseCount = rangeSet ? rangeSet.raise.size : 0;
+  const callCount  = rangeSet ? rangeSet.call.size : 0;
+  const totalCombos = 169;
+
+  return (
+    <div>
+      <SubNav tabs={TABS} currentPath="/preflop/limp" />
+      <div class="charts-panel">
+        <div class="stack-tabs">
+          {STACK_DEPTHS.map(d => (
+            <button key={d} class={`stack-tab${d === stackDepth ? ' active' : ''}`} onClick={() => setStackDepth(d)}>{d}</button>
+          ))}
+        </div>
+
+        <div class="pos-selectors">
+          <div class="pos-selector-group">
+            <span class="pos-selector-label">Your Position</span>
+            <select class="pos-selector-select" value={heroPos} onChange={e => changeHero(e.target.value)}>
+              {LIMP_HERO_POSITIONS.map(p => <option key={p} value={p}>{p}</option>)}
+            </select>
+          </div>
+          <div class="pos-selector-group">
+            <span class="pos-selector-label">Limper Position</span>
+            <select class="pos-selector-select" value={villainPos} onChange={e => setVillainPos(e.target.value)}>
+              {validVillains.map(p => <option key={p} value={p}>{p}</option>)}
+            </select>
+          </div>
+        </div>
+
+        {!rangeSet ? (
+          <p style="text-align:center;color:var(--muted);padding:2rem">Select positions above to view chart.</p>
+        ) : (
+          <>
+            <div class="rfi-grid">
+              <div class="rfi-cell rfi-hdr"></div>
+              {RANKS.map(r => <div class="rfi-cell rfi-hdr" key={'col-' + r}>{r}</div>)}
+              {RANKS.map((rowRank, r) => (
+                <>
+                  <div class="rfi-cell rfi-hdr" key={'row-' + rowRank}>{rowRank}</div>
+                  {RANKS.map((colRank, c) => {
+                    let hand;
+                    if (r === c) hand = RANKS[r] + RANKS[c];
+                    else if (c > r) hand = RANKS[r] + RANKS[c] + 's';
+                    else hand = RANKS[c] + RANKS[r] + 'o';
+                    const isRaise = rangeSet.raise.has(hand);
+                    const isCall  = !isRaise && rangeSet.call.has(hand);
+                    return (
+                      <div class={`rfi-cell ${isRaise ? 'rfi-raise' : isCall ? 'rfi-call' : 'rfi-fold'}`} key={hand}>{hand}</div>
+                    );
+                  })}
+                </>
+              ))}
+            </div>
+            <div class="rfi-legend">
+              <span class="rfi-legend-item"><span class="rfi-swatch rfi-raise"></span> Raise ({raiseCount}, {Math.round(raiseCount/totalCombos*100)}%)</span>
+              <span class="rfi-legend-item"><span class="rfi-swatch rfi-call"></span> {heroPos === 'BB' ? 'Check' : 'Call'} ({callCount}, {Math.round(callCount/totalCombos*100)}%)</span>
+              <span class="rfi-legend-item"><span class="rfi-swatch rfi-fold"></span> Fold</span>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/sections/preflop/Quiz.jsx
+++ b/src/sections/preflop/Quiz.jsx
@@ -1,86 +1,245 @@
 import { useState, useCallback } from 'preact/hooks';
 import { SubNav } from '../../components/SubNav.jsx';
 import { RANKS, RFI_RANGES, RFI_QUIZ_LENGTH, RFI_QUIZ_POSITIONS, STACK_DEPTHS } from '../../data/rfi-ranges.js';
-import { getRfiQuizStats, saveRfiQuizStats, initRfiQuizStats } from '../../utils/storage.js';
+import { LIMP_RANGES, LIMP_HERO_POSITIONS, VALID_LIMP_VILLAINS, VS_RAISE_RANGES, RAISE_HERO_POSITIONS, VALID_RAISE_VILLAINS } from '../../data/preflop-ranges.js';
+import { getRfiQuizStats, saveRfiQuizStats, initRfiQuizStats, getLimpQuizStats, saveLimpQuizStats, initLimpQuizStats, getVsRaiseQuizStats, saveVsRaiseQuizStats, initVsRaiseQuizStats, getAllModesQuizStats, saveAllModesQuizStats, initAllModesQuizStats } from '../../utils/storage.js';
 import { handToCards } from '../../utils/illustrations.jsx';
 import '../../styles/quiz.css';
 
 const TABS = [
-  { path: '/preflop/charts', label: 'Charts' },
-  { path: '/preflop/quiz', label: 'RFI Quiz' }
+  { path: '/preflop/charts', label: 'RFI' },
+  { path: '/preflop/limp', label: 'vs Limp' },
+  { path: '/preflop/vs-raise', label: 'vs Raise' },
+  { path: '/preflop/quiz', label: 'Quiz' },
 ];
 
-function generateHand(stackDepth) {
-  const pos = RFI_QUIZ_POSITIONS[Math.floor(Math.random() * RFI_QUIZ_POSITIONS.length)];
+const MODES = [
+  { id: 'rfi',     label: 'RFI' },
+  { id: 'limp',    label: 'vs Limp' },
+  { id: 'vsRaise', label: 'vs Raise' },
+  { id: 'all',     label: 'All' },
+];
+
+// ---------- hand generators ----------
+function randomHand() {
   const r = Math.floor(Math.random() * 13);
   const c = Math.floor(Math.random() * 13);
-  let hand;
-  if (r === c) hand = RANKS[r] + RANKS[c];
-  else if (c > r) hand = RANKS[r] + RANKS[c] + 's';
-  else hand = RANKS[c] + RANKS[r] + 'o';
-  return { hand, pos, shouldRaise: RFI_RANGES[stackDepth][pos].has(hand) };
+  if (r === c) return RANKS[r] + RANKS[c];
+  if (c > r) return RANKS[r] + RANKS[c] + 's';
+  return RANKS[c] + RANKS[r] + 'o';
 }
 
-function buildDeck(stackDepth) {
+function generateRfiHand(stackDepth) {
+  const pos = RFI_QUIZ_POSITIONS[Math.floor(Math.random() * RFI_QUIZ_POSITIONS.length)];
+  const hand = randomHand();
+  return { type: 'rfi', hand, heroPos: pos, villainPos: null, stackDepth, correctAction: RFI_RANGES[stackDepth][pos].has(hand) ? 'raise' : 'fold' };
+}
+
+function generateLimpHand(stackDepth) {
+  const heroPos = LIMP_HERO_POSITIONS[Math.floor(Math.random() * LIMP_HERO_POSITIONS.length)];
+  const villains = VALID_LIMP_VILLAINS[heroPos];
+  const villainPos = villains[Math.floor(Math.random() * villains.length)];
+  const hand = randomHand();
+  const range = LIMP_RANGES[stackDepth]?.[heroPos]?.[villainPos];
+  if (!range) return generateLimpHand(stackDepth);
+  const correctAction = range.raise.has(hand) ? 'raise' : range.call.has(hand) ? 'call' : 'fold';
+  return { type: 'limp', hand, heroPos, villainPos, stackDepth, correctAction };
+}
+
+function generateVsRaiseHand(stackDepth) {
+  const heroPos = RAISE_HERO_POSITIONS[Math.floor(Math.random() * RAISE_HERO_POSITIONS.length)];
+  const villains = VALID_RAISE_VILLAINS[heroPos];
+  const villainPos = villains[Math.floor(Math.random() * villains.length)];
+  const hand = randomHand();
+  const range = VS_RAISE_RANGES[stackDepth]?.[heroPos]?.[villainPos];
+  if (!range) return generateVsRaiseHand(stackDepth);
+  const correctAction = range.threebet.has(hand) ? 'threebet' : range.call.has(hand) ? 'call' : 'fold';
+  return { type: 'vsRaise', hand, heroPos, villainPos, stackDepth, correctAction };
+}
+
+function buildDeck(mode, stackDepth) {
   const deck = [];
-  let raiseN = 0, foldN = 0, attempts = 0;
-  while (deck.length < RFI_QUIZ_LENGTH && attempts < 200) {
+  const counts = {};
+  let attempts = 0;
+  const maxPerAction = mode === 'rfi' ? 7 : 4;
+
+  while (deck.length < RFI_QUIZ_LENGTH && attempts < 300) {
     attempts++;
-    const q = generateHand(stackDepth);
-    if (q.shouldRaise && raiseN >= 7) continue;
-    if (!q.shouldRaise && foldN >= 7) continue;
-    if (deck.some(x => x.hand === q.hand && x.pos === q.pos)) continue;
+    let q;
+    if (mode === 'rfi') q = generateRfiHand(stackDepth);
+    else if (mode === 'limp') q = generateLimpHand(stackDepth);
+    else if (mode === 'vsRaise') q = generateVsRaiseHand(stackDepth);
+    else {
+      const r = Math.random();
+      if (r < 0.33) q = generateRfiHand(stackDepth);
+      else if (r < 0.66) q = generateLimpHand(stackDepth);
+      else q = generateVsRaiseHand(stackDepth);
+    }
+    const key = `${q.type}:${q.hand}:${q.heroPos}:${q.villainPos}`;
+    if (deck.some(x => `${x.type}:${x.hand}:${x.heroPos}:${x.villainPos}` === key)) continue;
+    counts[q.correctAction] = (counts[q.correctAction] || 0) + 1;
+    if (counts[q.correctAction] > maxPerAction) continue;
     deck.push(q);
-    if (q.shouldRaise) raiseN++;
-    else foldN++;
   }
   return deck;
 }
 
-export function PreflopQuiz({ path }) {
+// ---------- action labels per type ----------
+function getButtons(type) {
+  if (type === 'rfi')     return [{ label: 'Raise', action: 'raise' }, { label: 'Fold', action: 'fold' }];
+  if (type === 'limp')    return [{ label: 'Raise', action: 'raise' }, { label: 'Call', action: 'call' }, { label: 'Fold', action: 'fold' }];
+  if (type === 'vsRaise') return [{ label: '3-Bet', action: 'threebet' }, { label: 'Call', action: 'call' }, { label: 'Fold', action: 'fold' }];
+  return [];
+}
+
+function actionLabel(action) {
+  if (action === 'raise')    return 'raise';
+  if (action === 'fold')     return 'fold';
+  if (action === 'call')     return 'call';
+  if (action === 'threebet') return '3-bet';
+  return action;
+}
+
+function promptText(q) {
+  if (!q) return '';
+  if (q.type === 'rfi')     return 'Everyone folds to you. What do you do?';
+  if (q.type === 'limp')    return `${q.villainPos} limps. What do you do?`;
+  if (q.type === 'vsRaise') return `${q.villainPos} raises. What do you do?`;
+  return '';
+}
+
+// ---------- save stats helpers ----------
+function saveStats(results, mode, score, stackDepth) {
+  if (mode === 'rfi' || mode === 'all') {
+    const rfi = getRfiQuizStats() || initRfiQuizStats();
+    const rfiResults = results.filter(r => r.type === 'rfi');
+    if (rfiResults.length > 0) {
+      rfi.totalQuizzes += mode === 'rfi' ? 1 : 0;
+      rfi.totalQuestions += rfiResults.length;
+      rfi.totalCorrect += rfiResults.filter(r => r.correct).length;
+      rfiResults.forEach(r => {
+        if (!rfi.byPosition[r.heroPos]) rfi.byPosition[r.heroPos] = { total: 0, correct: 0 };
+        rfi.byPosition[r.heroPos].total++;
+        if (r.correct) rfi.byPosition[r.heroPos].correct++;
+      });
+      if (mode === 'rfi') {
+        rfi.recentScores.push({ date: new Date().toLocaleDateString(), score, total: RFI_QUIZ_LENGTH });
+        if (rfi.recentScores.length > 20) rfi.recentScores = rfi.recentScores.slice(-20);
+      }
+      saveRfiQuizStats(rfi);
+    }
+  }
+
+  if (mode === 'limp' || mode === 'all') {
+    const limp = getLimpQuizStats() || initLimpQuizStats();
+    const limpResults = results.filter(r => r.type === 'limp');
+    if (limpResults.length > 0) {
+      limp.totalQuizzes += mode === 'limp' ? 1 : 0;
+      limp.totalQuestions += limpResults.length;
+      limp.totalCorrect += limpResults.filter(r => r.correct).length;
+      limpResults.forEach(r => {
+        if (!limp.byHeroPosition[r.heroPos]) limp.byHeroPosition[r.heroPos] = { total: 0, correct: 0 };
+        limp.byHeroPosition[r.heroPos].total++;
+        if (r.correct) limp.byHeroPosition[r.heroPos].correct++;
+        if (r.villainPos) {
+          if (!limp.byVillainPosition[r.villainPos]) limp.byVillainPosition[r.villainPos] = { total: 0, correct: 0 };
+          limp.byVillainPosition[r.villainPos].total++;
+          if (r.correct) limp.byVillainPosition[r.villainPos].correct++;
+        }
+      });
+      if (mode === 'limp') {
+        limp.recentScores.push({ date: new Date().toLocaleDateString(), score, total: RFI_QUIZ_LENGTH });
+        if (limp.recentScores.length > 20) limp.recentScores = limp.recentScores.slice(-20);
+      }
+      saveLimpQuizStats(limp);
+    }
+  }
+
+  if (mode === 'vsRaise' || mode === 'all') {
+    const vsr = getVsRaiseQuizStats() || initVsRaiseQuizStats();
+    const vsrResults = results.filter(r => r.type === 'vsRaise');
+    if (vsrResults.length > 0) {
+      vsr.totalQuizzes += mode === 'vsRaise' ? 1 : 0;
+      vsr.totalQuestions += vsrResults.length;
+      vsr.totalCorrect += vsrResults.filter(r => r.correct).length;
+      vsrResults.forEach(r => {
+        if (!vsr.byHeroPosition[r.heroPos]) vsr.byHeroPosition[r.heroPos] = { total: 0, correct: 0 };
+        vsr.byHeroPosition[r.heroPos].total++;
+        if (r.correct) vsr.byHeroPosition[r.heroPos].correct++;
+        if (r.villainPos) {
+          if (!vsr.byVillainPosition[r.villainPos]) vsr.byVillainPosition[r.villainPos] = { total: 0, correct: 0 };
+          vsr.byVillainPosition[r.villainPos].total++;
+          if (r.correct) vsr.byVillainPosition[r.villainPos].correct++;
+        }
+      });
+      if (mode === 'vsRaise') {
+        vsr.recentScores.push({ date: new Date().toLocaleDateString(), score, total: RFI_QUIZ_LENGTH });
+        if (vsr.recentScores.length > 20) vsr.recentScores = vsr.recentScores.slice(-20);
+      }
+      saveVsRaiseQuizStats(vsr);
+    }
+  }
+
+  if (mode === 'all') {
+    const all = getAllModesQuizStats() || initAllModesQuizStats();
+    all.totalQuizzes++;
+    all.totalQuestions += RFI_QUIZ_LENGTH;
+    all.totalCorrect += score;
+    results.forEach(r => {
+      const modeKey = r.type === 'vsRaise' ? 'vsRaise' : r.type;
+      if (!all.byMode[modeKey]) all.byMode[modeKey] = { total: 0, correct: 0 };
+      all.byMode[modeKey].total++;
+      if (r.correct) all.byMode[modeKey].correct++;
+    });
+    all.recentScores.push({ date: new Date().toLocaleDateString(), score, total: RFI_QUIZ_LENGTH });
+    if (all.recentScores.length > 20) all.recentScores = all.recentScores.slice(-20);
+    saveAllModesQuizStats(all);
+  }
+}
+
+// ---------- main component ----------
+export function PreflopQuiz() {
+  const [quizMode, setQuizMode]   = useState('rfi');
   const [stackDepth, setStackDepth] = useState('100BB');
-  const [deck, setDeck] = useState(() => buildDeck('100BB'));
-  const [qIdx, setQIdx] = useState(0);
-  const [score, setScore] = useState(0);
-  const [answered, setAnswered] = useState(false);
-  const [choseRaise, setChoseRaise] = useState(null);
-  const [results, setResults] = useState([]);
+  const [deck, setDeck]           = useState(() => buildDeck('rfi', '100BB'));
+  const [qIdx, setQIdx]           = useState(0);
+  const [score, setScore]         = useState(0);
+  const [answered, setAnswered]   = useState(false);
+  const [choseAction, setChoseAction] = useState(null);
+  const [results, setResults]     = useState([]);
+
   const quizInProgress = qIdx > 0 && qIdx < deck.length;
 
-  function changeStackDepth(depth) {
-    setStackDepth(depth);
-    setDeck(buildDeck(depth));
-    setQIdx(0);
-    setScore(0);
-    setAnswered(false);
-    setChoseRaise(null);
-    setResults([]);
+  function resetQuiz(mode, depth) {
+    setDeck(buildDeck(mode, depth));
+    setQIdx(0); setScore(0); setAnswered(false); setChoseAction(null); setResults([]);
   }
 
-  function restart() {
-    setDeck(buildDeck(stackDepth));
-    setQIdx(0);
-    setScore(0);
-    setAnswered(false);
-    setChoseRaise(null);
-    setResults([]);
+  function changeMode(m) {
+    if (quizInProgress) return;
+    setQuizMode(m);
+    resetQuiz(m, stackDepth);
   }
 
-  const answer = useCallback((chose) => {
+  function changeStackDepth(d) {
+    if (quizInProgress) return;
+    setStackDepth(d);
+    resetQuiz(quizMode, d);
+  }
+
+  function restart() { resetQuiz(quizMode, stackDepth); }
+
+  const answer = useCallback((action) => {
     if (answered) return;
     setAnswered(true);
-    setChoseRaise(chose);
+    setChoseAction(action);
     const q = deck[qIdx];
-    const isCorrect = chose === q.shouldRaise;
+    const isCorrect = action === q.correctAction;
     if (isCorrect) setScore(s => s + 1);
-    setResults(r => [...r, { pos: q.pos, correct: isCorrect }]);
+    setResults(r => [...r, { type: q.type, heroPos: q.heroPos, villainPos: q.villainPos, correct: isCorrect }]);
   }, [answered, deck, qIdx]);
 
-  function next() {
-    setQIdx(i => i + 1);
-    setAnswered(false);
-    setChoseRaise(null);
-  }
+  function next() { setQIdx(i => i + 1); setAnswered(false); setChoseAction(null); }
 
   // Quiz complete
   if (qIdx >= deck.length && deck.length > 0) {
@@ -90,19 +249,7 @@ export function PreflopQuiz({ path }) {
                 pct >= 50 ? 'Good start \u2014 review the charts.' :
                 'Hit the charts and come back!';
 
-    // Save stats
-    const stats = getRfiQuizStats() || initRfiQuizStats();
-    stats.totalQuizzes++;
-    stats.totalQuestions += RFI_QUIZ_LENGTH;
-    stats.totalCorrect += score;
-    results.forEach(r => {
-      if (!stats.byPosition[r.pos]) stats.byPosition[r.pos] = { total: 0, correct: 0 };
-      stats.byPosition[r.pos].total++;
-      if (r.correct) stats.byPosition[r.pos].correct++;
-    });
-    stats.recentScores.push({ date: new Date().toLocaleDateString(), score, total: RFI_QUIZ_LENGTH });
-    if (stats.recentScores.length > 20) stats.recentScores = stats.recentScores.slice(-20);
-    saveRfiQuizStats(stats);
+    saveStats(results, quizMode, score, stackDepth);
 
     return (
       <div>
@@ -115,7 +262,7 @@ export function PreflopQuiz({ path }) {
             <button class="rq-restart" onClick={restart}>Play Again</button>
             <a class="rq-restart" href="#/preflop/charts" style="background:transparent;border:1px solid var(--gold-dark);text-decoration:none;display:inline-block;text-align:center">Review Charts</a>
           </div>
-          <RfiStats />
+          <QuizStats mode={quizMode} />
         </div>
       </div>
     );
@@ -123,132 +270,241 @@ export function PreflopQuiz({ path }) {
 
   const current = deck[qIdx];
   const pctDisplay = qIdx > 0 ? Math.round(score / qIdx * 100) + '%' : '\u2014';
-  const isCorrect = answered ? (choseRaise === current.shouldRaise) : null;
+  const isCorrect = answered && current ? (choseAction === current.correctAction) : null;
+  const buttons = current ? getButtons(current.type) : [];
 
   return (
     <div>
       <SubNav tabs={TABS} currentPath="/preflop/quiz" />
       <div class="rq-panel">
-        <h2 class="rq-title">Preflop Open-Raise Quiz</h2>
-        <p class="rq-sub">Should you raise or fold? &mdash; 6-max, everyone folds to you</p>
+        <h2 class="rq-title">Preflop Quiz</h2>
+
+        {/* Mode selector */}
+        <div class="stack-tabs" style="margin-bottom:.5rem">
+          {MODES.map(m => (
+            <button
+              key={m.id}
+              class={`stack-tab${m.id === quizMode ? ' active' : ''}${quizInProgress ? ' disabled' : ''}`}
+              onClick={() => changeMode(m.id)}
+              title={quizInProgress ? 'Finish or restart to change mode' : ''}
+            >{m.label}</button>
+          ))}
+        </div>
+
+        {/* Stack depth selector */}
         <div class="stack-tabs rq-stack-tabs">
           {STACK_DEPTHS.map(d => (
             <button
               key={d}
               class={`stack-tab${d === stackDepth ? ' active' : ''}${quizInProgress ? ' disabled' : ''}`}
-              onClick={() => !quizInProgress && changeStackDepth(d)}
+              onClick={() => changeStackDepth(d)}
               title={quizInProgress ? 'Finish or restart quiz to change stack depth' : ''}
-            >
-              {d}
-            </button>
+            >{d}</button>
           ))}
         </div>
-        {quizInProgress && <p class="rq-stack-note">Stack depth locked during quiz &mdash; finish or restart to change</p>}
+        {quizInProgress && <p class="rq-stack-note">Mode &amp; stack locked during quiz &mdash; finish or restart to change</p>}
+
         <div class="rq-progress"><div class="rq-progress-fill" style={{ width: (qIdx / RFI_QUIZ_LENGTH * 100) + '%' }}></div></div>
         <div class="rq-status">
           <div class="rq-stat"><div class="val">{score}</div><div class="lbl">Correct</div></div>
           <div class="rq-stat"><div class="val">{qIdx + 1} / {RFI_QUIZ_LENGTH}</div><div class="lbl">Question</div></div>
           <div class="rq-stat"><div class="val">{pctDisplay}</div><div class="lbl">Accuracy</div></div>
         </div>
+
         {current && (
           <>
             <div class="rq-card">
-              <div class="rq-pos">Your Position: <strong style="font-size:1.1rem">{current.pos}</strong></div>
+              <div class="rq-pos">Your Position: <strong style="font-size:1.1rem">{current.heroPos}</strong>
+                {current.villainPos && <span style="margin-left:.8rem;color:var(--muted)">Villain: <strong style="color:var(--text)">{current.villainPos}</strong></span>}
+              </div>
               <div class="rq-hand-display" dangerouslySetInnerHTML={{ __html: handToCards(current.hand) }} />
               <div style="font-size:1.1rem;color:var(--gold-bright);font-weight:600;margin-top:.3rem">{current.hand}</div>
-              <div class="rq-prompt">Everyone folds to you. What do you do?</div>
+              <div class="rq-prompt">{promptText(current)}</div>
             </div>
+
             <div class="rq-actions">
-              <button
-                class={`rq-btn rq-btn-raise${answered ? (current.shouldRaise ? ' correct' : choseRaise ? ' wrong' : '') : ''}`}
-                disabled={answered}
-                onClick={() => answer(true)}
-              >Raise</button>
-              <button
-                class={`rq-btn rq-btn-fold${answered ? (!current.shouldRaise ? ' correct' : !choseRaise ? ' wrong' : '') : ''}`}
-                disabled={answered}
-                onClick={() => answer(false)}
-              >Fold</button>
+              {buttons.map(btn => {
+                const isThis = choseAction === btn.action;
+                const isCorrectBtn = current.correctAction === btn.action;
+                let cls = `rq-btn rq-btn-${btn.action === 'fold' ? 'fold' : btn.action === 'raise' || btn.action === 'threebet' ? 'raise' : 'call'}`;
+                if (answered) {
+                  if (isCorrectBtn) cls += ' correct';
+                  else if (isThis) cls += ' wrong';
+                }
+                return (
+                  <button key={btn.action} class={cls} disabled={answered} onClick={() => answer(btn.action)}>
+                    {btn.label}
+                  </button>
+                );
+              })}
             </div>
+
             {answered && (
               <div class="rq-feedback">
-                {isCorrect ? (
-                  <span style="color:#27ae60">Correct! {current.hand} from {current.pos} is a <strong>{current.shouldRaise ? 'raise' : 'fold'}</strong>.</span>
-                ) : (
-                  <span style="color:#c0392b">Incorrect. {current.hand} from {current.pos} is a <strong>{current.shouldRaise ? 'raise' : 'fold'}</strong>.</span>
-                )}
+                {isCorrect
+                  ? <span style="color:#27ae60">Correct! {current.hand} from {current.heroPos} is a <strong>{actionLabel(current.correctAction)}</strong>.</span>
+                  : <span style="color:#c0392b">Incorrect. {current.hand} from {current.heroPos} is a <strong>{actionLabel(current.correctAction)}</strong>.</span>
+                }
               </div>
             )}
             <div style="text-align:center">
-              {answered && (
-                <button class="rq-next" style="display:inline-block" onClick={next}>
-                  Next Question {'\u2192'}
-                </button>
-              )}
+              {answered && <button class="rq-next" style="display:inline-block" onClick={next}>Next Question {'\u2192'}</button>}
             </div>
           </>
         )}
-        <RfiStats />
+
+        <QuizStats mode={quizMode} />
       </div>
     </div>
   );
 }
 
+// ---------- stats panels ----------
+function QuizStats({ mode }) {
+  if (mode === 'rfi')     return <RfiStats />;
+  if (mode === 'limp')    return <LimpStats />;
+  if (mode === 'vsRaise') return <VsRaiseStats />;
+  if (mode === 'all')     return <AllModesStats />;
+  return null;
+}
+
 function RfiStats() {
   const stats = getRfiQuizStats();
   if (!stats || stats.totalQuizzes === 0) return null;
-
   const overallPct = Math.round(stats.totalCorrect / stats.totalQuestions * 100);
-
   return (
     <div class="rq-stats">
       <div class="rq-stats-header">
         <div class="rq-stats-title">Your Progress</div>
-        <button class="rq-reset-stats" onClick={() => {
-          if (confirm('Reset all RFI quiz statistics? This cannot be undone.')) {
-            localStorage.removeItem('rfi-quiz-stats');
-            location.reload();
-          }
-        }}>Reset Stats</button>
+        <button class="rq-reset-stats" onClick={() => { if (confirm('Reset RFI stats?')) { localStorage.removeItem('rfi-quiz-stats'); location.reload(); } }}>Reset</button>
       </div>
       <div class="rq-stats-grid">
         <div class="rq-stats-card"><div class="val">{stats.totalQuizzes}</div><div class="lbl">Quizzes</div></div>
         <div class="rq-stats-card"><div class="val">{overallPct}%</div><div class="lbl">Overall</div></div>
         <div class="rq-stats-card"><div class="val">{stats.totalCorrect}/{stats.totalQuestions}</div><div class="lbl">Correct</div></div>
       </div>
+      <PosByPosition byPos={stats.byPosition} positions={RFI_QUIZ_POSITIONS} label="Position" />
+      <RecentScores scores={stats.recentScores} />
+    </div>
+  );
+}
+
+function LimpStats() {
+  const stats = getLimpQuizStats();
+  if (!stats || stats.totalQuizzes === 0) return null;
+  const pct = Math.round(stats.totalCorrect / stats.totalQuestions * 100);
+  return (
+    <div class="rq-stats">
+      <div class="rq-stats-header">
+        <div class="rq-stats-title">vs Limp Progress</div>
+        <button class="rq-reset-stats" onClick={() => { if (confirm('Reset vs Limp stats?')) { localStorage.removeItem('limp-quiz-stats'); location.reload(); } }}>Reset</button>
+      </div>
+      <div class="rq-stats-grid">
+        <div class="rq-stats-card"><div class="val">{stats.totalQuizzes}</div><div class="lbl">Quizzes</div></div>
+        <div class="rq-stats-card"><div class="val">{pct}%</div><div class="lbl">Overall</div></div>
+        <div class="rq-stats-card"><div class="val">{stats.totalCorrect}/{stats.totalQuestions}</div><div class="lbl">Correct</div></div>
+      </div>
+      <PosByPosition byPos={stats.byHeroPosition} positions={LIMP_HERO_POSITIONS} label="Your Position" />
+      <RecentScores scores={stats.recentScores} />
+    </div>
+  );
+}
+
+function VsRaiseStats() {
+  const stats = getVsRaiseQuizStats();
+  if (!stats || stats.totalQuizzes === 0) return null;
+  const pct = Math.round(stats.totalCorrect / stats.totalQuestions * 100);
+  return (
+    <div class="rq-stats">
+      <div class="rq-stats-header">
+        <div class="rq-stats-title">vs Raise Progress</div>
+        <button class="rq-reset-stats" onClick={() => { if (confirm('Reset vs Raise stats?')) { localStorage.removeItem('vs-raise-quiz-stats'); location.reload(); } }}>Reset</button>
+      </div>
+      <div class="rq-stats-grid">
+        <div class="rq-stats-card"><div class="val">{stats.totalQuizzes}</div><div class="lbl">Quizzes</div></div>
+        <div class="rq-stats-card"><div class="val">{pct}%</div><div class="lbl">Overall</div></div>
+        <div class="rq-stats-card"><div class="val">{stats.totalCorrect}/{stats.totalQuestions}</div><div class="lbl">Correct</div></div>
+      </div>
+      <PosByPosition byPos={stats.byHeroPosition} positions={RAISE_HERO_POSITIONS} label="Your Position" />
+      <RecentScores scores={stats.recentScores} />
+    </div>
+  );
+}
+
+function AllModesStats() {
+  const stats = getAllModesQuizStats();
+  if (!stats || stats.totalQuizzes === 0) return null;
+  const pct = Math.round(stats.totalCorrect / stats.totalQuestions * 100);
+  const modeLabels = { rfi: 'RFI', limp: 'vs Limp', vsRaise: 'vs Raise' };
+  return (
+    <div class="rq-stats">
+      <div class="rq-stats-header">
+        <div class="rq-stats-title">All Modes Progress</div>
+        <button class="rq-reset-stats" onClick={() => { if (confirm('Reset All Modes stats?')) { localStorage.removeItem('all-modes-quiz-stats'); location.reload(); } }}>Reset</button>
+      </div>
+      <div class="rq-stats-grid">
+        <div class="rq-stats-card"><div class="val">{stats.totalQuizzes}</div><div class="lbl">Quizzes</div></div>
+        <div class="rq-stats-card"><div class="val">{pct}%</div><div class="lbl">Overall</div></div>
+        <div class="rq-stats-card"><div class="val">{stats.totalCorrect}/{stats.totalQuestions}</div><div class="lbl">Correct</div></div>
+      </div>
       <div class="rq-pos-stats">
-        {RFI_QUIZ_POSITIONS.map(pos => {
-          const ps = stats.byPosition[pos];
+        {Object.entries(stats.byMode).map(([key, ps]) => {
           if (!ps || ps.total === 0) return null;
-          const pct = Math.round(ps.correct / ps.total * 100);
-          const clr = pct >= 80 ? '#27ae60' : pct >= 60 ? '#c9a84c' : '#c0392b';
+          const p = Math.round(ps.correct / ps.total * 100);
+          const clr = p >= 80 ? '#27ae60' : p >= 60 ? '#c9a84c' : '#c0392b';
           return (
-            <div class="rq-pos-row" key={pos}>
-              <div class="rq-pos-label">{pos}</div>
+            <div class="rq-pos-row" key={key}>
+              <div class="rq-pos-label">{modeLabels[key] || key}</div>
               <div class="rq-pos-bar">
-                <div class="rq-pos-bar-fill" style={{ width: pct + '%', background: clr }}></div>
-                <div class="rq-pos-bar-text">{pct}% ({ps.correct}/{ps.total})</div>
+                <div class="rq-pos-bar-fill" style={{ width: p + '%', background: clr }}></div>
+                <div class="rq-pos-bar-text">{p}% ({ps.correct}/{ps.total})</div>
               </div>
             </div>
           );
         })}
       </div>
-      {stats.recentScores.length > 0 && (
-        <div class="rq-history">
-          <div class="rq-history-title">Recent Quizzes</div>
-          {stats.recentScores.slice(-5).reverse().map((r, i) => {
-            const p = Math.round(r.score / r.total * 100);
-            return (
-              <div class="rq-history-row" key={i}>
-                <span>{r.date}</span>
-                <span style={{ color: p >= 70 ? '#27ae60' : p >= 50 ? '#c9a84c' : '#c0392b' }}>
-                  {r.score}/{r.total} ({p}%)
-                </span>
-              </div>
-            );
-          })}
-        </div>
-      )}
+      <RecentScores scores={stats.recentScores} />
+    </div>
+  );
+}
+
+function PosByPosition({ byPos, positions, label }) {
+  if (!byPos || Object.keys(byPos).length === 0) return null;
+  return (
+    <div class="rq-pos-stats">
+      {positions.map(pos => {
+        const ps = byPos[pos];
+        if (!ps || ps.total === 0) return null;
+        const pct = Math.round(ps.correct / ps.total * 100);
+        const clr = pct >= 80 ? '#27ae60' : pct >= 60 ? '#c9a84c' : '#c0392b';
+        return (
+          <div class="rq-pos-row" key={pos}>
+            <div class="rq-pos-label">{pos}</div>
+            <div class="rq-pos-bar">
+              <div class="rq-pos-bar-fill" style={{ width: pct + '%', background: clr }}></div>
+              <div class="rq-pos-bar-text">{pct}% ({ps.correct}/{ps.total})</div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function RecentScores({ scores }) {
+  if (!scores || scores.length === 0) return null;
+  return (
+    <div class="rq-history">
+      <div class="rq-history-title">Recent Quizzes</div>
+      {scores.slice(-5).reverse().map((r, i) => {
+        const p = Math.round(r.score / r.total * 100);
+        return (
+          <div class="rq-history-row" key={i}>
+            <span>{r.date}</span>
+            <span style={{ color: p >= 70 ? '#27ae60' : p >= 50 ? '#c9a84c' : '#c0392b' }}>{r.score}/{r.total} ({p}%)</span>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/sections/preflop/RaiseCharts.jsx
+++ b/src/sections/preflop/RaiseCharts.jsx
@@ -1,0 +1,91 @@
+import { useState } from 'preact/hooks';
+import { SubNav } from '../../components/SubNav.jsx';
+import { RANKS, STACK_DEPTHS } from '../../data/rfi-ranges.js';
+import { RAISE_HERO_POSITIONS, VALID_RAISE_VILLAINS, VS_RAISE_RANGES } from '../../data/preflop-ranges.js';
+import '../../styles/charts.css';
+
+const TABS = [
+  { path: '/preflop/charts', label: 'RFI' },
+  { path: '/preflop/limp', label: 'vs Limp' },
+  { path: '/preflop/vs-raise', label: 'vs Raise' },
+  { path: '/preflop/quiz', label: 'Quiz' },
+];
+
+export function RaiseCharts() {
+  const [heroPos, setHeroPos] = useState('BTN');
+  const [villainPos, setVillainPos] = useState('CO');
+  const [stackDepth, setStackDepth] = useState('100BB');
+
+  const validVillains = VALID_RAISE_VILLAINS[heroPos] || [];
+
+  function changeHero(pos) {
+    setHeroPos(pos);
+    const valid = VALID_RAISE_VILLAINS[pos] || [];
+    if (!valid.includes(villainPos)) setVillainPos(valid[valid.length - 1] || valid[0]);
+  }
+
+  const rangeSet = VS_RAISE_RANGES[stackDepth]?.[heroPos]?.[villainPos];
+  const threebetCount = rangeSet ? rangeSet.threebet.size : 0;
+  const callCount     = rangeSet ? rangeSet.call.size : 0;
+  const totalCombos = 169;
+
+  return (
+    <div>
+      <SubNav tabs={TABS} currentPath="/preflop/vs-raise" />
+      <div class="charts-panel">
+        <div class="stack-tabs">
+          {STACK_DEPTHS.map(d => (
+            <button key={d} class={`stack-tab${d === stackDepth ? ' active' : ''}`} onClick={() => setStackDepth(d)}>{d}</button>
+          ))}
+        </div>
+
+        <div class="pos-selectors">
+          <div class="pos-selector-group">
+            <span class="pos-selector-label">Your Position</span>
+            <select class="pos-selector-select" value={heroPos} onChange={e => changeHero(e.target.value)}>
+              {RAISE_HERO_POSITIONS.map(p => <option key={p} value={p}>{p}</option>)}
+            </select>
+          </div>
+          <div class="pos-selector-group">
+            <span class="pos-selector-label">Raiser Position</span>
+            <select class="pos-selector-select" value={villainPos} onChange={e => setVillainPos(e.target.value)}>
+              {validVillains.map(p => <option key={p} value={p}>{p}</option>)}
+            </select>
+          </div>
+        </div>
+
+        {!rangeSet ? (
+          <p style="text-align:center;color:var(--muted);padding:2rem">Select positions above to view chart.</p>
+        ) : (
+          <>
+            <div class="rfi-grid">
+              <div class="rfi-cell rfi-hdr"></div>
+              {RANKS.map(r => <div class="rfi-cell rfi-hdr" key={'col-' + r}>{r}</div>)}
+              {RANKS.map((rowRank, r) => (
+                <>
+                  <div class="rfi-cell rfi-hdr" key={'row-' + rowRank}>{rowRank}</div>
+                  {RANKS.map((colRank, c) => {
+                    let hand;
+                    if (r === c) hand = RANKS[r] + RANKS[c];
+                    else if (c > r) hand = RANKS[r] + RANKS[c] + 's';
+                    else hand = RANKS[c] + RANKS[r] + 'o';
+                    const is3bet = rangeSet.threebet.has(hand);
+                    const isCall = !is3bet && rangeSet.call.has(hand);
+                    return (
+                      <div class={`rfi-cell ${is3bet ? 'rfi-raise' : isCall ? 'rfi-call' : 'rfi-fold'}`} key={hand}>{hand}</div>
+                    );
+                  })}
+                </>
+              ))}
+            </div>
+            <div class="rfi-legend">
+              <span class="rfi-legend-item"><span class="rfi-swatch rfi-raise"></span> 3-Bet ({threebetCount}, {Math.round(threebetCount/totalCombos*100)}%)</span>
+              <span class="rfi-legend-item"><span class="rfi-swatch rfi-call"></span> Call ({callCount}, {Math.round(callCount/totalCombos*100)}%)</span>
+              <span class="rfi-legend-item"><span class="rfi-swatch rfi-fold"></span> Fold</span>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/sections/stats/Dashboard.jsx
+++ b/src/sections/stats/Dashboard.jsx
@@ -1,7 +1,8 @@
 import { useState } from 'preact/hooks';
 import { TERMS, CATS } from '../../data/terms.js';
 import { RFI_QUIZ_POSITIONS } from '../../data/rfi-ranges.js';
-import { getStudyProgress, initStudyProgress, getTermQuizStats, initTermQuizStats, getRfiQuizStats, initRfiQuizStats } from '../../utils/storage.js';
+import { getStudyProgress, initStudyProgress, getTermQuizStats, initTermQuizStats, getRfiQuizStats, initRfiQuizStats, getLimpQuizStats, initLimpQuizStats, getVsRaiseQuizStats, initVsRaiseQuizStats, getAllModesQuizStats, initAllModesQuizStats } from '../../utils/storage.js';
+import { LIMP_HERO_POSITIONS, RAISE_HERO_POSITIONS } from '../../data/preflop-ranges.js';
 import '../../styles/stats.css';
 
 export function Dashboard({ path }) {
@@ -10,7 +11,10 @@ export function Dashboard({ path }) {
 
   const study = getStudyProgress() || initStudyProgress();
   const termQuiz = getTermQuizStats() || initTermQuizStats();
-  const rfiQuiz = getRfiQuizStats() || initRfiQuizStats();
+  const rfiQuiz    = getRfiQuizStats()     || initRfiQuizStats();
+  const limpQuiz   = getLimpQuizStats()    || initLimpQuizStats();
+  const vsRaiseQuiz = getVsRaiseQuizStats() || initVsRaiseQuizStats();
+  const allModes   = getAllModesQuizStats() || initAllModesQuizStats();
 
   const totalTerms = TERMS.length;
   const cardsSeen = study.cardsSeen.length;
@@ -35,6 +39,21 @@ export function Dashboard({ path }) {
   function resetRfiQuiz() {
     if (!confirm('Reset all RFI quiz stats? This cannot be undone.')) return;
     localStorage.removeItem('rfi-quiz-stats');
+    refresh();
+  }
+  function resetLimpQuiz() {
+    if (!confirm('Reset all vs Limp quiz stats? This cannot be undone.')) return;
+    localStorage.removeItem('limp-quiz-stats');
+    refresh();
+  }
+  function resetVsRaiseQuiz() {
+    if (!confirm('Reset all vs Raise quiz stats? This cannot be undone.')) return;
+    localStorage.removeItem('vs-raise-quiz-stats');
+    refresh();
+  }
+  function resetAllModes() {
+    if (!confirm('Reset all All-Modes quiz stats? This cannot be undone.')) return;
+    localStorage.removeItem('all-modes-quiz-stats');
     refresh();
   }
 
@@ -196,6 +215,96 @@ export function Dashboard({ path }) {
                 })}
               </div>
             )}
+          </>
+        )}
+      </div>
+      {/* vs Limp Quiz */}
+      <div class="stats-section">
+        <div class="stats-section-header">
+          <h3>Preflop vs Limp Quiz</h3>
+          <button class="stats-reset" onClick={resetLimpQuiz}>Reset</button>
+        </div>
+        {limpQuiz.totalQuizzes === 0 ? (
+          <p class="stats-empty">No quizzes taken yet. <a href="#/preflop/quiz">Take a quiz</a></p>
+        ) : (
+          <>
+            <div class="stats-grid">
+              <div class="stats-card"><div class="stats-val">{limpQuiz.totalQuizzes}</div><div class="stats-lbl">Quizzes</div></div>
+              <div class="stats-card"><div class="stats-val">{Math.round(limpQuiz.totalCorrect/limpQuiz.totalQuestions*100)}%</div><div class="stats-lbl">Accuracy</div></div>
+              <div class="stats-card"><div class="stats-val">{limpQuiz.totalCorrect}/{limpQuiz.totalQuestions}</div><div class="stats-lbl">Correct</div></div>
+            </div>
+            {Object.keys(limpQuiz.byHeroPosition).length > 0 && (
+              <div class="stats-bars">
+                <div class="stats-bars-title">Accuracy by Your Position</div>
+                {LIMP_HERO_POSITIONS.map(pos => {
+                  const ps = limpQuiz.byHeroPosition[pos];
+                  if (!ps || ps.total === 0) return null;
+                  const pct = Math.round(ps.correct/ps.total*100);
+                  const clr = pct>=80?'#27ae60':pct>=60?'#c9a84c':'#c0392b';
+                  return (<div class="stats-cat-row" key={pos}><div class="stats-cat-label">{pos}</div><div class="stats-cat-bar"><div class="stats-cat-bar-fill" style={{width:pct+'%',background:clr}}></div><div class="stats-cat-bar-text">{pct}% ({ps.correct}/{ps.total})</div></div></div>);
+                })}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* vs Raise Quiz */}
+      <div class="stats-section">
+        <div class="stats-section-header">
+          <h3>Preflop vs Raise Quiz</h3>
+          <button class="stats-reset" onClick={resetVsRaiseQuiz}>Reset</button>
+        </div>
+        {vsRaiseQuiz.totalQuizzes === 0 ? (
+          <p class="stats-empty">No quizzes taken yet. <a href="#/preflop/quiz">Take a quiz</a></p>
+        ) : (
+          <>
+            <div class="stats-grid">
+              <div class="stats-card"><div class="stats-val">{vsRaiseQuiz.totalQuizzes}</div><div class="stats-lbl">Quizzes</div></div>
+              <div class="stats-card"><div class="stats-val">{Math.round(vsRaiseQuiz.totalCorrect/vsRaiseQuiz.totalQuestions*100)}%</div><div class="stats-lbl">Accuracy</div></div>
+              <div class="stats-card"><div class="stats-val">{vsRaiseQuiz.totalCorrect}/{vsRaiseQuiz.totalQuestions}</div><div class="stats-lbl">Correct</div></div>
+            </div>
+            {Object.keys(vsRaiseQuiz.byHeroPosition).length > 0 && (
+              <div class="stats-bars">
+                <div class="stats-bars-title">Accuracy by Your Position</div>
+                {RAISE_HERO_POSITIONS.map(pos => {
+                  const ps = vsRaiseQuiz.byHeroPosition[pos];
+                  if (!ps || ps.total === 0) return null;
+                  const pct = Math.round(ps.correct/ps.total*100);
+                  const clr = pct>=80?'#27ae60':pct>=60?'#c9a84c':'#c0392b';
+                  return (<div class="stats-cat-row" key={pos}><div class="stats-cat-label">{pos}</div><div class="stats-cat-bar"><div class="stats-cat-bar-fill" style={{width:pct+'%',background:clr}}></div><div class="stats-cat-bar-text">{pct}% ({ps.correct}/{ps.total})</div></div></div>);
+                })}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* All Modes Quiz */}
+      <div class="stats-section">
+        <div class="stats-section-header">
+          <h3>Preflop All-Modes Quiz</h3>
+          <button class="stats-reset" onClick={resetAllModes}>Reset</button>
+        </div>
+        {allModes.totalQuizzes === 0 ? (
+          <p class="stats-empty">No quizzes taken yet. <a href="#/preflop/quiz">Take a quiz</a></p>
+        ) : (
+          <>
+            <div class="stats-grid">
+              <div class="stats-card"><div class="stats-val">{allModes.totalQuizzes}</div><div class="stats-lbl">Quizzes</div></div>
+              <div class="stats-card"><div class="stats-val">{Math.round(allModes.totalCorrect/allModes.totalQuestions*100)}%</div><div class="stats-lbl">Accuracy</div></div>
+              <div class="stats-card"><div class="stats-val">{allModes.totalCorrect}/{allModes.totalQuestions}</div><div class="stats-lbl">Correct</div></div>
+            </div>
+            <div class="stats-bars">
+              <div class="stats-bars-title">Accuracy by Mode</div>
+              {[['rfi','RFI'],['limp','vs Limp'],['vsRaise','vs Raise']].map(([key,lbl]) => {
+                const ps = allModes.byMode[key];
+                if (!ps || ps.total === 0) return null;
+                const pct = Math.round(ps.correct/ps.total*100);
+                const clr = pct>=80?'#27ae60':pct>=60?'#c9a84c':'#c0392b';
+                return (<div class="stats-cat-row" key={key}><div class="stats-cat-label">{lbl}</div><div class="stats-cat-bar"><div class="stats-cat-bar-fill" style={{width:pct+'%',background:clr}}></div><div class="stats-cat-bar-text">{pct}% ({ps.correct}/{ps.total})</div></div></div>);
+              })}
+            </div>
           </>
         )}
       </div>

--- a/src/styles/charts.css
+++ b/src/styles/charts.css
@@ -33,3 +33,13 @@
 .rfi-legend .sw-fold{background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.1)}
 .rfi-note{color:var(--muted);font-size:.82rem;text-align:center;margin-top:.5rem;
   font-style:italic}
+.rfi-call{background:rgba(52,152,219,.22);color:#a8d8f0;border:1px solid rgba(52,152,219,.25)}
+.rfi-legend .sw-call{background:rgba(52,152,219,.22);border:1px solid rgba(52,152,219,.25)}
+.pos-selectors{display:flex;justify-content:center;gap:1.5rem;margin-bottom:1rem;flex-wrap:wrap}
+.pos-selector-group{display:flex;flex-direction:column;align-items:center;gap:.3rem}
+.pos-selector-label{font-size:.75rem;color:var(--muted);letter-spacing:.08em;text-transform:uppercase}
+.pos-selector-select{background:rgba(0,0,0,.4);color:var(--gold-bright);border:1px solid var(--gold-dark);
+  border-radius:8px;padding:.35rem .7rem;font-family:'Crimson Pro',serif;font-size:.95rem;cursor:pointer}
+.pos-selector-select:focus{outline:none;border-color:var(--gold)}
+.rfi-legend-item{display:flex;align-items:center;gap:.4rem}
+.rfi-swatch{width:14px;height:14px;border-radius:3px;display:inline-block}

--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -23,7 +23,7 @@ h1 em{font-style:italic;color:var(--gold)}
 .section-nav a:hover:not(.active){color:var(--text);background:rgba(255,255,255,0.07)}
 
 /* Sub nav */
-.sub-nav{display:flex;justify-content:center;gap:0;margin:1rem auto 0;max-width:400px;
+.sub-nav{display:flex;justify-content:center;gap:0;margin:1rem auto 0;max-width:520px;
   border:1px solid rgba(201,168,76,.25);border-radius:30px;overflow:hidden;background:rgba(0,0,0,0.2)}
 .sub-nav a{flex:1;padding:0.45rem 0.8rem;background:transparent;
   color:var(--muted);font-family:'Crimson Pro',serif;font-size:.9rem;cursor:pointer;

--- a/src/styles/quiz.css
+++ b/src/styles/quiz.css
@@ -60,6 +60,10 @@
 .rq-btn-raise:hover:not(:disabled){background:rgba(46,204,113,.25);border-color:#27ae60}
 .rq-btn-fold{background:rgba(192,57,43,.1);border-color:rgba(192,57,43,.4);color:#f0b8b0}
 .rq-btn-fold:hover:not(:disabled){background:rgba(192,57,43,.25);border-color:#c0392b}
+.rq-btn-call{background:rgba(52,152,219,.1);border-color:rgba(52,152,219,.4);color:#a8d8f0}
+.rq-btn-call:hover:not(:disabled){background:rgba(52,152,219,.25);border-color:#2980b9}
+.rq-btn-threebet{background:rgba(46,204,113,.1);border-color:rgba(46,204,113,.4);color:#a8f0c6}
+.rq-btn-threebet:hover:not(:disabled){background:rgba(46,204,113,.25);border-color:#27ae60}
 .rq-btn.correct{background:rgba(46,204,113,.3);border-color:#27ae60;color:#a8f0c6}
 .rq-btn.wrong{background:rgba(192,57,43,.3);border-color:#c0392b;color:#f0b8b0}
 .rq-btn:disabled{cursor:default;opacity:.7}
@@ -80,3 +84,23 @@
   border:none;border-radius:30px;font-family:'Crimson Pro',serif;font-size:1rem;
   cursor:pointer;letter-spacing:.04em;margin:0 .5rem}
 .rq-restart:hover{background:var(--gold)}
+.rq-stats{margin-top:1.5rem;border-top:1px solid rgba(201,168,76,.2);padding-top:1rem}
+.rq-stats-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:.75rem}
+.rq-stats-title{font-family:'Playfair Display',serif;font-size:1.1rem;color:var(--gold)}
+.rq-reset-stats{background:transparent;border:1px solid var(--gold-dark);color:var(--muted);
+  border-radius:20px;padding:.25rem .75rem;font-family:'Crimson Pro',serif;font-size:.8rem;cursor:pointer}
+.rq-reset-stats:hover{border-color:var(--gold);color:var(--text)}
+.rq-stats-grid{display:flex;gap:1rem;justify-content:center;margin-bottom:1rem;flex-wrap:wrap}
+.rq-stats-card{text-align:center;min-width:80px}
+.rq-stats-card .val{font-family:'Playfair Display',serif;font-size:1.4rem;color:var(--gold-bright);line-height:1}
+.rq-stats-card .lbl{font-size:.7rem;color:var(--muted);letter-spacing:.08em;text-transform:uppercase}
+.rq-pos-stats{margin-bottom:.75rem}
+.rq-pos-row{display:flex;align-items:center;gap:.75rem;margin-bottom:.4rem}
+.rq-pos-label{font-size:.8rem;color:var(--muted);min-width:40px;text-align:right;flex-shrink:0}
+.rq-pos-bar{flex:1;position:relative;background:rgba(255,255,255,.07);border-radius:4px;height:22px;overflow:hidden}
+.rq-pos-bar-fill{height:100%;border-radius:4px;transition:width .4s}
+.rq-pos-bar-text{position:absolute;inset:0;display:flex;align-items:center;padding-left:.5rem;
+  font-size:.75rem;color:var(--text)}
+.rq-history{margin-top:.5rem}
+.rq-history-title{font-size:.8rem;color:var(--muted);letter-spacing:.08em;text-transform:uppercase;margin-bottom:.4rem}
+.rq-history-row{display:flex;justify-content:space-between;font-size:.85rem;color:var(--muted);padding:.2rem 0;border-bottom:1px solid rgba(255,255,255,.05)}

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -22,6 +22,42 @@ export function initTermQuizStats() {
   return { totalQuizzes:0, totalQuestions:0, totalCorrect:0, bestStreak:0, recentScores:[] };
 }
 
+// Limp Quiz Stats
+export function getLimpQuizStats() {
+  try { const d = localStorage.getItem('limp-quiz-stats'); return d ? JSON.parse(d) : null; }
+  catch(e) { return null; }
+}
+export function saveLimpQuizStats(s) {
+  try { localStorage.setItem('limp-quiz-stats', JSON.stringify(s)); } catch(e) {}
+}
+export function initLimpQuizStats() {
+  return { totalQuizzes:0, totalQuestions:0, totalCorrect:0, byHeroPosition:{}, byVillainPosition:{}, recentScores:[] };
+}
+
+// vs-Raise Quiz Stats
+export function getVsRaiseQuizStats() {
+  try { const d = localStorage.getItem('vs-raise-quiz-stats'); return d ? JSON.parse(d) : null; }
+  catch(e) { return null; }
+}
+export function saveVsRaiseQuizStats(s) {
+  try { localStorage.setItem('vs-raise-quiz-stats', JSON.stringify(s)); } catch(e) {}
+}
+export function initVsRaiseQuizStats() {
+  return { totalQuizzes:0, totalQuestions:0, totalCorrect:0, byHeroPosition:{}, byVillainPosition:{}, recentScores:[] };
+}
+
+// All-Modes Quiz Stats
+export function getAllModesQuizStats() {
+  try { const d = localStorage.getItem('all-modes-quiz-stats'); return d ? JSON.parse(d) : null; }
+  catch(e) { return null; }
+}
+export function saveAllModesQuizStats(s) {
+  try { localStorage.setItem('all-modes-quiz-stats', JSON.stringify(s)); } catch(e) {}
+}
+export function initAllModesQuizStats() {
+  return { totalQuizzes:0, totalQuestions:0, totalCorrect:0, byMode:{ rfi:{total:0,correct:0}, limp:{total:0,correct:0}, vsRaise:{total:0,correct:0} }, recentScores:[] };
+}
+
 // Study Progress
 export function getStudyProgress() {
   try { const d = localStorage.getItem('study-progress'); return d ? JSON.parse(d) : null; }

--- a/src/utils/storage.test.js
+++ b/src/utils/storage.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  getLimpQuizStats, saveLimpQuizStats, initLimpQuizStats,
+  getVsRaiseQuizStats, saveVsRaiseQuizStats, initVsRaiseQuizStats,
+  getAllModesQuizStats, saveAllModesQuizStats, initAllModesQuizStats,
+} from './storage.js';
+
+// Provide a minimal localStorage shim for the node test environment
+const store = {};
+const localStorageMock = {
+  getItem: (k) => (k in store ? store[k] : null),
+  setItem: (k, v) => { store[k] = String(v); },
+  removeItem: (k) => { delete store[k]; },
+  clear: () => { Object.keys(store).forEach(k => delete store[k]); },
+};
+vi.stubGlobal('localStorage', localStorageMock);
+
+beforeEach(() => { localStorageMock.clear(); });
+
+describe('initLimpQuizStats', () => {
+  it('returns correct shape', () => {
+    const s = initLimpQuizStats();
+    expect(s.totalQuizzes).toBe(0);
+    expect(s.totalQuestions).toBe(0);
+    expect(s.totalCorrect).toBe(0);
+    expect(s.byHeroPosition).toEqual({});
+    expect(s.byVillainPosition).toEqual({});
+    expect(Array.isArray(s.recentScores)).toBe(true);
+  });
+
+  it('getLimpQuizStats returns null when nothing stored', () => {
+    expect(getLimpQuizStats()).toBeNull();
+  });
+
+  it('save/get round-trips correctly', () => {
+    const s = initLimpQuizStats();
+    s.totalQuizzes = 3;
+    s.totalCorrect = 25;
+    saveLimpQuizStats(s);
+    const loaded = getLimpQuizStats();
+    expect(loaded.totalQuizzes).toBe(3);
+    expect(loaded.totalCorrect).toBe(25);
+  });
+});
+
+describe('initVsRaiseQuizStats', () => {
+  it('returns correct shape', () => {
+    const s = initVsRaiseQuizStats();
+    expect(s.totalQuizzes).toBe(0);
+    expect(s.byHeroPosition).toEqual({});
+    expect(s.byVillainPosition).toEqual({});
+  });
+
+  it('getVsRaiseQuizStats returns null when nothing stored', () => {
+    expect(getVsRaiseQuizStats()).toBeNull();
+  });
+
+  it('save/get round-trips correctly', () => {
+    const s = initVsRaiseQuizStats();
+    s.totalQuizzes = 2;
+    saveVsRaiseQuizStats(s);
+    expect(getVsRaiseQuizStats().totalQuizzes).toBe(2);
+  });
+});
+
+describe('initAllModesQuizStats', () => {
+  it('returns correct shape with byMode keys', () => {
+    const s = initAllModesQuizStats();
+    expect(s.byMode).toHaveProperty('rfi');
+    expect(s.byMode).toHaveProperty('limp');
+    expect(s.byMode).toHaveProperty('vsRaise');
+    expect(s.byMode.rfi.total).toBe(0);
+    expect(s.byMode.rfi.correct).toBe(0);
+  });
+
+  it('getAllModesQuizStats returns null when nothing stored', () => {
+    expect(getAllModesQuizStats()).toBeNull();
+  });
+
+  it('save/get round-trips correctly', () => {
+    const s = initAllModesQuizStats();
+    s.byMode.rfi.total = 5;
+    s.byMode.rfi.correct = 4;
+    saveAllModesQuizStats(s);
+    const loaded = getAllModesQuizStats();
+    expect(loaded.byMode.rfi.total).toBe(5);
+    expect(loaded.byMode.rfi.correct).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary
Expands the preflop section with two new scenario types (vs Limp and vs Raise) alongside the existing RFI mode. Adds dedicated chart views for each scenario with opponent position selection, and extends the quiz system to support all three modes individually or combined in an "All Modes" quiz.

## Key Changes

**New Data & Ranges**
- Created `src/data/preflop-ranges.js` with GTO-approximate ranges for:
  - `LIMP_RANGES`: ISO raise/call decisions when facing a limp (by hero position, villain position, stack depth)
  - `VS_RAISE_RANGES`: 3-bet/call/fold decisions when facing a raise
  - Position validity maps (`VALID_LIMP_VILLAINS`, `VALID_RAISE_VILLAINS`) ensuring hero is left of villain
- Added comprehensive test suite (`src/data/preflop-ranges.test.js`) validating range structure, disjointness, and scaling

**Chart Views**
- `src/sections/preflop/LimpCharts.jsx`: Interactive chart for ISO raise ranges with hero/villain position selectors
- `src/sections/preflop/RaiseCharts.jsx`: Interactive chart for 3-bet/call ranges with hero/villain position selectors
- Updated `src/sections/preflop/Charts.jsx` tab navigation to include new routes

**Quiz System Overhaul**
- Refactored `src/sections/preflop/Quiz.jsx` to support multiple modes:
  - Hand generation now mode-aware (`generateRfiHand`, `generateLimpHand`, `generateVsRaiseHand`)
  - Quiz questions track `type`, `heroPos`, `villainPos`, and `correctAction` (raise/fold/call/threebet)
  - Mode selector buttons allow switching between RFI, vs Limp, vs Raise, and All Modes
  - Dynamic action buttons based on scenario type (RFI: raise/fold; Limp: raise/call/fold; vs Raise: 3-bet/call/fold)
  - Unified stats saving via `saveStats()` that routes results to appropriate storage buckets

**Storage & Stats**
- Extended `src/utils/storage.js` with new stat getters/setters/initializers:
  - `getLimpQuizStats`, `saveLimpQuizStats`, `initLimpQuizStats`
  - `getVsRaiseQuizStats`, `saveVsRaiseQuizStats`, `initVsRaiseQuizStats`
  - `getAllModesQuizStats`, `saveAllModesQuizStats`, `initAllModesQuizStats`
- Each mode tracks: total quizzes, questions, correct answers, accuracy by hero/villain position, recent scores
- Added test suite (`src/utils/storage.test.js`) for new storage functions

**Dashboard Updates**
- `src/sections/stats/Dashboard.jsx` now displays stats cards and accuracy breakdowns for all three quiz modes plus combined mode
- Reset buttons for each mode's stats

**Styling**
- Added `.rq-btn-call` and `.rq-btn-threebet` button styles in `quiz.css`
- Added `.rfi-call` and `.rfi-threebet` cell styles in `charts.css` for chart visualization
- Updated `header.css` sub-nav max-width from 400px to 520px to accommodate four tabs

**Routing**
- Added `/preflop/limp` and `/preflop/vs-raise` to `ROUTES_LIST` in `routing.js`
- Updated `app.jsx` to import and register new chart components
- Updated all preflop SubNav instances to show consistent four-tab navigation

## Implementation Details

- Hand generation uses a unified `randomHand()` function and mode-specific wrappers that return question objects with all necessary context
- Deck building balances action distribution (max 7 raise/fold per RFI mode, max 4 per other action in limp/vs-raise)
- Stats saving intelligently routes results: "All Modes" quiz increments all three mode

https://claude.ai/code/session_011RKUX37UgkMLApGEgUA1y1