### PR TITLE
Fix suit flip on suited hands during preflop quiz (#21)

### DIFF
--- a/src/sections/preflop/Quiz.jsx
+++ b/src/sections/preflop/Quiz.jsx
@@ -21,6 +21,9 @@ const MODES = [
 ];
 
 // ---------- hand generators ----------
+const SUITS = ['♠','♥','♦','♣'];
+function randomSuit() { return SUITS[Math.floor(Math.random() * SUITS.length)]; }
+
 function randomHand() {
   const r = Math.floor(Math.random() * 13);
   const c = Math.floor(Math.random() * 13);
@@ -32,7 +35,7 @@ function randomHand() {
 function generateRfiHand(stackDepth) {
   const pos = RFI_QUIZ_POSITIONS[Math.floor(Math.random() * RFI_QUIZ_POSITIONS.length)];
   const hand = randomHand();
-  return { type: 'rfi', hand, heroPos: pos, villainPos: null, stackDepth, correctAction: RFI_RANGES[stackDepth][pos].has(hand) ? 'raise' : 'fold' };
+  return { type: 'rfi', hand, heroPos: pos, villainPos: null, stackDepth, suit: randomSuit(), correctAction: RFI_RANGES[stackDepth][pos].has(hand) ? 'raise' : 'fold' };
 }
 
 function generateLimpHand(stackDepth) {
@@ -43,7 +46,7 @@ function generateLimpHand(stackDepth) {
   const range = LIMP_RANGES[stackDepth]?.[heroPos]?.[villainPos];
   if (!range) return generateLimpHand(stackDepth);
   const correctAction = range.raise.has(hand) ? 'raise' : range.call.has(hand) ? 'call' : 'fold';
-  return { type: 'limp', hand, heroPos, villainPos, stackDepth, correctAction };
+  return { type: 'limp', hand, heroPos, villainPos, stackDepth, suit: randomSuit(), correctAction };
 }
 
 function generateVsRaiseHand(stackDepth) {
@@ -54,7 +57,7 @@ function generateVsRaiseHand(stackDepth) {
   const range = VS_RAISE_RANGES[stackDepth]?.[heroPos]?.[villainPos];
   if (!range) return generateVsRaiseHand(stackDepth);
   const correctAction = range.threebet.has(hand) ? 'threebet' : range.call.has(hand) ? 'call' : 'fold';
-  return { type: 'vsRaise', hand, heroPos, villainPos, stackDepth, correctAction };
+  return { type: 'vsRaise', hand, heroPos, villainPos, stackDepth, suit: randomSuit(), correctAction };
 }
 
 function buildDeck(mode, stackDepth) {
@@ -317,7 +320,7 @@ export function PreflopQuiz() {
               <div class="rq-pos">Your Position: <strong style="font-size:1.1rem">{current.heroPos}</strong>
                 {current.villainPos && <span style="margin-left:.8rem;color:var(--muted)">Villain: <strong style="color:var(--text)">{current.villainPos}</strong></span>}
               </div>
-              <div class="rq-hand-display" dangerouslySetInnerHTML={{ __html: handToCards(current.hand) }} />
+              <div class="rq-hand-display" dangerouslySetInnerHTML={{ __html: handToCards(current.hand, current.suit) }} />
               <div style="font-size:1.1rem;color:var(--gold-bright);font-weight:600;margin-top:.3rem">{current.hand}</div>
               <div class="rq-prompt">{promptText(current)}</div>
             </div>

--- a/src/utils/illustrations.jsx
+++ b/src/utils/illustrations.jsx
@@ -441,12 +441,12 @@ export function getIllus(t) {
 }
 
 
-export function handToCards(h) {
+export function handToCards(h, suit) {
   const rank1 = h[0], rank2 = h[1];
   const type = h.length===2 ? 'pair' : h[2]==='s' ? 'suited' : 'offsuit';
   if (type==='pair') return cardSvg(rank1,'♠',64,90)+cardSvg(rank2,'♥',64,90);
   if (type==='suited') {
-    const s = ['♠','♥','♦','♣'][Math.floor(Math.random()*4)];
+    const s = suit || ['♠','♥','♦','♣'][Math.floor(Math.random()*4)];
     return cardSvg(rank1,s,64,90)+cardSvg(rank2,s,64,90);
   }
   return cardSvg(rank1,'♠',64,90)+cardSvg(rank2,'♥',64,90);

--- a/src/utils/illustrations.test.js
+++ b/src/utils/illustrations.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { handToCards } from './illustrations.jsx';
+
+describe('handToCards', () => {
+  it('suited hand renders the same SVG across repeated calls when a suit is supplied — no suit-flip regression for #21', () => {
+    // Regression: previously handToCards called Math.random() on every invocation,
+    // so each re-render of the quiz (e.g. after clicking an answer) rolled a new
+    // suit for suited hands like AKs. With an explicit suit it must be stable.
+    const first = handToCards('AKs', '♠');
+    for (let i = 0; i < 20; i++) {
+      expect(handToCards('AKs', '♠')).toBe(first);
+    }
+  });
+
+  it('suited hand uses the suit that was supplied', () => {
+    const spades = handToCards('AKs', '♠');
+    const hearts = handToCards('AKs', '♥');
+    const diamonds = handToCards('AKs', '♦');
+    const clubs = handToCards('AKs', '♣');
+    // All four must differ from each other — if the suit arg were ignored they'd match.
+    expect(new Set([spades, hearts, diamonds, clubs]).size).toBe(4);
+    // And each must contain its suit glyph.
+    expect(spades).toContain('♠');
+    expect(hearts).toContain('♥');
+    expect(diamonds).toContain('♦');
+    expect(clubs).toContain('♣');
+  });
+
+  it('suited hand without a suit arg still returns a valid suited SVG (backward compat)', () => {
+    const out = handToCards('AKs');
+    expect(typeof out).toBe('string');
+    expect(out.length).toBeGreaterThan(0);
+    // Both cards share the same suit — exactly one of the four glyphs should appear, twice.
+    const glyphs = ['♠','♥','♦','♣'].filter(g => out.includes(g));
+    expect(glyphs).toHaveLength(1);
+  });
+
+  it('pair is deterministic and ignores the suit argument', () => {
+    const a = handToCards('AA');
+    const b = handToCards('AA', '♦');
+    expect(a).toBe(b);
+    expect(a).toContain('♠');
+    expect(a).toContain('♥');
+  });
+
+  it('offsuit is deterministic and ignores the suit argument', () => {
+    const a = handToCards('AKo');
+    const b = handToCards('AKo', '♦');
+    expect(a).toBe(b);
+    expect(a).toContain('♠');
+    expect(a).toContain('♥');
+  });
+});


### PR DESCRIPTION
handToCards() rolled a new random suit on every call, so any re-render
triggered by state updates (answer click, score/feedback) would hop the
suit of suited hands like AKs while the hand text stayed the same.

Move the randomness to question-generation time: each generated question
now carries a stable `suit` field, and handToCards(hand, suit) uses it
for suited hands (falling back to random if no suit is supplied, so the
function stays backward-compatible). Pairs and offsuit were already
deterministic and are unchanged.

Adds regression tests in src/utils/illustrations.test.js.