### PR TITLE
Reorganize quiz routes under /quizzes namespace

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -27,12 +27,12 @@ function useHashRoute() {
 const ROUTES = {
   '/welcome': Welcome,
   '/terminology/study': Study,
-  '/terminology/quiz': TermQuiz,
   '/terminology/reference': Reference,
   '/preflop/charts': Charts,
   '/preflop/limp': LimpCharts,
   '/preflop/vs-raise': RaiseCharts,
-  '/preflop/quiz': PreflopQuiz,
+  '/quizzes/terminology': TermQuiz,
+  '/quizzes/preflop': PreflopQuiz,
   '/stats': Dashboard,
 };
 

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -26,6 +26,7 @@ export function Header() {
         <a href="#/welcome" class={section === 'welcome' ? 'active' : ''}>Home</a>
         <a href="#/terminology/study" class={section === 'terminology' ? 'active' : ''}>Terminology</a>
         <a href="#/preflop/charts" class={section === 'preflop' ? 'active' : ''}>Preflop</a>
+        <a href="#/quizzes/terminology" class={section === 'quizzes' ? 'active' : ''}>Quizzes</a>
         <a href="#/stats" class={section === 'stats' ? 'active' : ''}>Stats</a>
       </nav>
     </header>

--- a/src/routing.js
+++ b/src/routing.js
@@ -2,12 +2,12 @@
 export const ROUTES_LIST = [
   '/welcome',
   '/terminology/study',
-  '/terminology/quiz',
   '/terminology/reference',
   '/preflop/charts',
   '/preflop/limp',
   '/preflop/vs-raise',
-  '/preflop/quiz',
+  '/quizzes/terminology',
+  '/quizzes/preflop',
   '/stats',
 ];
 
@@ -15,6 +15,9 @@ export const REDIRECTS = {
   '/': '/welcome',
   '/terminology': '/terminology/study',
   '/preflop': '/preflop/charts',
+  '/quizzes': '/quizzes/terminology',
+  '/terminology/quiz': '/quizzes/terminology',
+  '/preflop/quiz': '/quizzes/preflop',
 };
 
 // Resolves a raw hash path to the effective route path (following redirects)

--- a/src/routing.test.js
+++ b/src/routing.test.js
@@ -53,6 +53,31 @@ describe('routing', () => {
     expect(resolveRoute('/preflop/vs-raise')).toBe('/preflop/vs-raise');
   });
 
+  it('/quizzes/terminology exists in routes list', () => {
+    expect(ROUTES_LIST).toContain('/quizzes/terminology');
+  });
+
+  it('/quizzes/preflop exists in routes list', () => {
+    expect(ROUTES_LIST).toContain('/quizzes/preflop');
+  });
+
+  it('resolves /quizzes shorthand to terminology quiz', () => {
+    expect(resolveRoute('/quizzes')).toBe('/quizzes/terminology');
+  });
+
+  it('old /terminology/quiz redirects to /quizzes/terminology — backward compat', () => {
+    expect(resolveRoute('/terminology/quiz')).toBe('/quizzes/terminology');
+  });
+
+  it('old /preflop/quiz redirects to /quizzes/preflop — backward compat', () => {
+    expect(resolveRoute('/preflop/quiz')).toBe('/quizzes/preflop');
+  });
+
+  it('/terminology/quiz and /preflop/quiz no longer exist as direct routes', () => {
+    expect(ROUTES_LIST).not.toContain('/terminology/quiz');
+    expect(ROUTES_LIST).not.toContain('/preflop/quiz');
+  });
+
   it('empty hash on initial load resolves to a renderable route — no blank page regression', () => {
     // Reproduces the startup sequence in useHashRoute:
     //   window.location.hash.slice(1) || '/'

--- a/src/sections/preflop/Charts.jsx
+++ b/src/sections/preflop/Charts.jsx
@@ -7,7 +7,6 @@ const TABS = [
   { path: '/preflop/charts', label: 'RFI' },
   { path: '/preflop/limp', label: 'vs Limp' },
   { path: '/preflop/vs-raise', label: 'vs Raise' },
-  { path: '/preflop/quiz', label: 'Quiz' },
 ];
 
 export function Charts({ path }) {

--- a/src/sections/preflop/LimpCharts.jsx
+++ b/src/sections/preflop/LimpCharts.jsx
@@ -8,7 +8,6 @@ const TABS = [
   { path: '/preflop/charts', label: 'RFI' },
   { path: '/preflop/limp', label: 'vs Limp' },
   { path: '/preflop/vs-raise', label: 'vs Raise' },
-  { path: '/preflop/quiz', label: 'Quiz' },
 ];
 
 export function LimpCharts() {

--- a/src/sections/preflop/Quiz.jsx
+++ b/src/sections/preflop/Quiz.jsx
@@ -7,10 +7,8 @@ import { handToCards } from '../../utils/illustrations.jsx';
 import '../../styles/quiz.css';
 
 const TABS = [
-  { path: '/preflop/charts', label: 'RFI' },
-  { path: '/preflop/limp', label: 'vs Limp' },
-  { path: '/preflop/vs-raise', label: 'vs Raise' },
-  { path: '/preflop/quiz', label: 'Quiz' },
+  { path: '/quizzes/terminology', label: 'Terminology' },
+  { path: '/quizzes/preflop', label: 'Preflop' },
 ];
 
 const MODES = [
@@ -256,7 +254,7 @@ export function PreflopQuiz() {
 
     return (
       <div>
-        <SubNav tabs={TABS} currentPath="/preflop/quiz" />
+        <SubNav tabs={TABS} currentPath="/quizzes/preflop" />
         <div class="rq-panel">
           <div class="rq-complete">
             <h2>{pct >= 70 ? '\uD83C\uDFC6' : '\uD83C\uDCCF'} Quiz Complete</h2>
@@ -278,7 +276,7 @@ export function PreflopQuiz() {
 
   return (
     <div>
-      <SubNav tabs={TABS} currentPath="/preflop/quiz" />
+      <SubNav tabs={TABS} currentPath="/quizzes/preflop" />
       <div class="rq-panel">
         <h2 class="rq-title">Preflop Quiz</h2>
 

--- a/src/sections/preflop/RaiseCharts.jsx
+++ b/src/sections/preflop/RaiseCharts.jsx
@@ -8,7 +8,6 @@ const TABS = [
   { path: '/preflop/charts', label: 'RFI' },
   { path: '/preflop/limp', label: 'vs Limp' },
   { path: '/preflop/vs-raise', label: 'vs Raise' },
-  { path: '/preflop/quiz', label: 'Quiz' },
 ];
 
 export function RaiseCharts() {

--- a/src/sections/terminology/Quiz.jsx
+++ b/src/sections/terminology/Quiz.jsx
@@ -9,9 +9,8 @@ import { getTermQuizStats, saveTermQuizStats, initTermQuizStats } from '../../ut
 import '../../styles/quiz.css';
 
 const TABS = [
-  { path: '/terminology/study', label: 'Study' },
-  { path: '/terminology/quiz', label: 'Quiz' },
-  { path: '/terminology/reference', label: 'Reference' }
+  { path: '/quizzes/terminology', label: 'Terminology' },
+  { path: '/quizzes/preflop', label: 'Preflop' },
 ];
 
 export function Quiz({ path }) {
@@ -98,7 +97,7 @@ export function Quiz({ path }) {
 
     return (
       <div>
-        <SubNav tabs={TABS} currentPath="/terminology/quiz" />
+        <SubNav tabs={TABS} currentPath="/quizzes/terminology" />
         <FilterChips activeCats={activeCats} onToggle={handleFilterToggle} />
         <div class="quiz-panel">
           <div class="quiz-complete">
@@ -118,7 +117,7 @@ export function Quiz({ path }) {
 
   return (
     <div>
-      <SubNav tabs={TABS} currentPath="/terminology/quiz" />
+      <SubNav tabs={TABS} currentPath="/quizzes/terminology" />
       <FilterChips activeCats={activeCats} onToggle={handleFilterToggle} />
       <div class="quiz-panel">
         <div class="quiz-status">

--- a/src/sections/terminology/Reference.jsx
+++ b/src/sections/terminology/Reference.jsx
@@ -8,8 +8,7 @@ import '../../styles/reference.css';
 
 const TABS = [
   { path: '/terminology/study', label: 'Study' },
-  { path: '/terminology/quiz', label: 'Quiz' },
-  { path: '/terminology/reference', label: 'Reference' }
+  { path: '/terminology/reference', label: 'Reference' },
 ];
 
 export function Reference({ path }) {

--- a/src/sections/terminology/Study.jsx
+++ b/src/sections/terminology/Study.jsx
@@ -10,8 +10,7 @@ import '../../styles/study.css';
 
 const TABS = [
   { path: '/terminology/study', label: 'Study' },
-  { path: '/terminology/quiz', label: 'Quiz' },
-  { path: '/terminology/reference', label: 'Reference' }
+  { path: '/terminology/reference', label: 'Reference' },
 ];
 
 export function Study({ path }) {

--- a/src/sections/welcome/Welcome.jsx
+++ b/src/sections/welcome/Welcome.jsx
@@ -18,12 +18,17 @@ const SECTIONS = [
   {
     href: '#/terminology/study',
     title: 'Terminology',
-    desc: 'Learn the language of poker with interactive flashcards, quizzes, and a searchable glossary of 78+ terms.',
+    desc: 'Learn the language of poker with interactive flashcards and a searchable glossary of 78+ terms.',
   },
   {
     href: '#/preflop/charts',
     title: 'Preflop Strategy',
-    desc: 'Study GTO-optimal preflop raise ranges for every position with interactive charts and a raise-or-fold quiz.',
+    desc: 'Study GTO-optimal preflop raise ranges for every position with interactive charts.',
+  },
+  {
+    href: '#/quizzes/terminology',
+    title: 'Quizzes',
+    desc: 'Test your knowledge with terminology and preflop decision quizzes across all positions and stack depths.',
   },
   {
     href: '#/stats',
@@ -35,6 +40,18 @@ const SECTIONS = [
 export function Welcome({ path }) {
   return (
     <div class="welcome">
+      <h2 class="sections-heading">Explore the Trainer</h2>
+
+      <div class="sections-grid">
+        {SECTIONS.map(s => (
+          <a class="section-card" href={s.href} key={s.href}>
+            <div class="section-card-title">{s.title}</div>
+            <div class="section-card-desc">{s.desc}</div>
+            <span class="section-card-link">Start learning &rarr;</span>
+          </a>
+        ))}
+      </div>
+
       <h2>Poker Hand Rankings</h2>
       <p class="welcome-intro">From strongest to weakest — know these by heart.</p>
 
@@ -46,18 +63,6 @@ export function Welcome({ path }) {
             <div class="ranking-illus" dangerouslySetInnerHTML={{ __html: ILLUS[h.key]() }} />
             <div class="ranking-desc">{h.desc}</div>
           </div>
-        ))}
-      </div>
-
-      <h2 class="sections-heading">Explore the Trainer</h2>
-
-      <div class="sections-grid">
-        {SECTIONS.map(s => (
-          <a class="section-card" href={s.href} key={s.href}>
-            <div class="section-card-title">{s.title}</div>
-            <div class="section-card-desc">{s.desc}</div>
-            <span class="section-card-link">Start learning &rarr;</span>
-          </a>
         ))}
       </div>
     </div>

--- a/src/styles/welcome.css
+++ b/src/styles/welcome.css
@@ -17,7 +17,7 @@
 
 /* Sections overview */
 .sections-heading{margin-top:2.5rem}
-.sections-grid{display:grid;gap:1rem;margin-top:.8rem}
+.sections-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;margin-top:.8rem}
 .section-card{display:block;background:rgba(0,0,0,.2);border:1px solid rgba(201,168,76,.15);
   border-radius:14px;padding:1.2rem 1.4rem;text-decoration:none;transition:all .25s}
 .section-card:hover{border-color:var(--gold);background:rgba(201,168,76,.08)}


### PR DESCRIPTION
## Summary
Reorganizes the quiz functionality by moving quiz routes from `/terminology/quiz` and `/preflop/quiz` to a new unified `/quizzes` namespace with `/quizzes/terminology` and `/quizzes/preflop` routes. This creates a clearer separation between study/reference content and quiz assessments.

## Key Changes
- **New route structure**: Created `/quizzes/terminology` and `/quizzes/preflop` routes to consolidate all quiz functionality
- **Backward compatibility**: Added redirect rules for old quiz routes (`/terminology/quiz` → `/quizzes/terminology`, `/preflop/quiz` → `/quizzes/preflop`)
- **Navigation updates**: 
  - Added new "Quizzes" section to main header navigation
  - Updated quiz component tab navigation to show both quiz types (Terminology and Preflop)
  - Removed quiz tabs from study/reference/chart components to reduce clutter
- **Route registration**: Updated `ROUTES_LIST` and `ROUTES` mapping to reflect new quiz paths
- **Test coverage**: Added comprehensive tests verifying new routes exist, old routes redirect properly, and old routes are no longer in the direct routes list

## Implementation Details
- The `/quizzes` shorthand resolves to `/quizzes/terminology` as the default quiz entry point
- Quiz components (`TermQuiz` and `PreflopQuiz`) now render with updated `currentPath` values matching their new routes
- Study and reference sections maintain their original routes (`/terminology/study`, `/terminology/reference`) and no longer expose quiz navigation
- Preflop chart views (RFI, vs Limp, vs Raise) are now cleanly separated from quiz functionality

https://claude.ai/code/session_01GsfSBQzSUNHFNYSS1Fr4TB