### PR TITLE
fix: wrap section-nav to two rows on mobile to prevent truncation

### DIFF
--- a/src/styles/header-mobile.test.js
+++ b/src/styles/header-mobile.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(resolve(__dirname, 'header.css'), 'utf8');
+
+describe('header.css mobile nav', () => {
+  it('section-nav wraps to multiple rows on small screens — prevents mobile truncation', () => {
+    expect(css).toContain('flex-wrap:wrap');
+  });
+
+  it('has a mobile media query for section-nav', () => {
+    expect(css).toMatch(/@media\s*\(max-width:\s*540px\)/);
+  });
+
+  it('last two nav items are wider on mobile to balance the 3+2 row layout', () => {
+    expect(css).toContain('nth-last-child(2)');
+    expect(css).toContain('flex:1 0 50%');
+  });
+});

--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -22,6 +22,13 @@ h1 em{font-style:italic;color:var(--gold)}
 .section-nav a.active{background:var(--gold-dark);color:var(--gold-bright);font-weight:600}
 .section-nav a:hover:not(.active){color:var(--text);background:rgba(255,255,255,0.07)}
 
+@media (max-width: 540px) {
+  .section-nav{max-width:100%;flex-wrap:wrap;border-radius:12px}
+  .section-nav a{flex:1 0 33.33%;font-size:.82rem;padding:.5rem .3rem;
+    letter-spacing:0;box-sizing:border-box}
+  .section-nav a:nth-last-child(2),.section-nav a:last-child{flex:1 0 50%}
+}
+
 /* Sub nav */
 .sub-nav{display:flex;justify-content:center;gap:0;margin:1rem auto 0;max-width:520px;
   border:1px solid rgba(201,168,76,.25);border-radius:30px;overflow:hidden;background:rgba(0,0,0,0.2)}


### PR DESCRIPTION
On screens ≤540px the 5-item nav (including "Terminology") overflows
its container and gets clipped. Switch to a 3+2 row layout using
flex-wrap, reduced font-size, and box-sizing:border-box so all items
are fully visible without scrolling.

https://claude.ai/code/session_01X6U5pbnFxCgLS7GCNsZPrW