### PR TITLE
Show 10 instead of T on ten card face in preflop quiz

### DIFF
--- a/src/utils/illustrations.jsx
+++ b/src/utils/illustrations.jsx
@@ -442,7 +442,8 @@ export function getIllus(t) {
 
 
 export function handToCards(h, suit) {
-  const rank1 = h[0], rank2 = h[1];
+  const toRank = r => r==='T' ? '10' : r;
+  const rank1 = toRank(h[0]), rank2 = toRank(h[1]);
   const type = h.length===2 ? 'pair' : h[2]==='s' ? 'suited' : 'offsuit';
   if (type==='pair') return cardSvg(rank1,'♠',64,90)+cardSvg(rank2,'♥',64,90);
   if (type==='suited') {

--- a/src/utils/illustrations.test.js
+++ b/src/utils/illustrations.test.js
@@ -50,4 +50,16 @@ describe('handToCards', () => {
     expect(a).toContain('♠');
     expect(a).toContain('♥');
   });
+
+  it('T notation renders as 10 on the card face — not the letter T', () => {
+    const tt = handToCards('TT');
+    const t9s = handToCards('T9s', '♠');
+    const ato = handToCards('ATo');
+    expect(tt).toContain('>10<');
+    expect(t9s).toContain('>10<');
+    expect(ato).toContain('>10<');
+    expect(tt).not.toContain('>T<');
+    expect(t9s).not.toContain('>T<');
+    expect(ato).not.toContain('>T<');
+  });
 });


### PR DESCRIPTION
handToCards was passing 'T' (poker shorthand) straight to cardSvg, so
the card face rendered the letter T. Convert 'T' → '10' before
rendering. Adds regression tests for TT, T9s, and ATo.

https://claude.ai/code/session_015TUqx8D6TiGrttk9hGg1HN