### PR TITLE
Add "Recommended Next Quiz" card to Stats dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - **RFI Quiz** — Practice raise/fold decisions against GTO-optimal preflop ranges with persistent progress tracking.
 
 ### Stats
-- **Dashboard** — Full statistics view showing study progress, terminology quiz accuracy, and RFI quiz performance by position.
+- **Dashboard** — Full statistics view showing study progress, terminology quiz accuracy, and RFI quiz performance by position. Surfaces a "Recommended Next Quiz" card that points you at your weakest area (or an untaken quiz for a baseline) with a one-click button to start it.
 
 ## Technology
 

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -11,17 +11,30 @@ import { Dashboard } from './sections/stats/Dashboard.jsx';
 import { Welcome } from './sections/welcome/Welcome.jsx';
 import { REDIRECTS } from './routing.js';
 
+function parseHash() {
+  const raw = window.location.hash.slice(1) || '/';
+  const qIdx = raw.indexOf('?');
+  if (qIdx < 0) return { path: raw, query: {} };
+  const path = raw.slice(0, qIdx);
+  const query = {};
+  for (const pair of raw.slice(qIdx + 1).split('&')) {
+    if (!pair) continue;
+    const [k, v = ''] = pair.split('=');
+    query[decodeURIComponent(k)] = decodeURIComponent(v);
+  }
+  return { path, query };
+}
+
 function useHashRoute() {
-  const getPath = () => window.location.hash.slice(1) || '/';
-  const [path, setPath] = useState(getPath);
+  const [route, setRoute] = useState(parseHash);
 
   useEffect(() => {
-    const onHash = () => setPath(getPath());
+    const onHash = () => setRoute(parseHash());
     window.addEventListener('hashchange', onHash);
     return () => window.removeEventListener('hashchange', onHash);
   }, []);
 
-  return path;
+  return route;
 }
 
 const ROUTES = {
@@ -37,7 +50,7 @@ const ROUTES = {
 };
 
 export function App() {
-  const path = useHashRoute();
+  const { path, query } = useHashRoute();
   const redirect = REDIRECTS[path];
 
   // Update the URL when a redirect is needed, but render the target immediately
@@ -53,7 +66,7 @@ export function App() {
   return (
     <>
       <Header />
-      <Page path={effectivePath} />
+      <Page path={effectivePath} query={query} />
     </>
   );
 }

--- a/src/sections/preflop/Quiz.jsx
+++ b/src/sections/preflop/Quiz.jsx
@@ -269,13 +269,14 @@ function saveStats(results, mode, score, stackDepth) {
 }
 
 // ---------- main component ----------
-export function PreflopQuiz() {
+export function PreflopQuiz({ query }) {
+  const initialMode = query?.mode && MODES.some(m => m.id === query.mode) ? query.mode : 'rfi';
   const [phase, setPhase]           = useState('setup'); // 'setup' | 'playing'
-  const [quizMode, setQuizMode]     = useState('rfi');
+  const [quizMode, setQuizMode]     = useState(initialMode);
   const [stackDepth, setStackDepth] = useState('100BB');
   const [selectedPos, setSelectedPos] = useState('all');
   const [selectedVillainPos, setSelectedVillainPos] = useState('all');
-  const [deck, setDeck]             = useState(() => buildDeck('rfi', '100BB', 'all', 'all'));
+  const [deck, setDeck]             = useState(() => buildDeck(initialMode, '100BB', 'all', 'all'));
   const [qIdx, setQIdx]             = useState(0);
   const [score, setScore]           = useState(0);
   const [answered, setAnswered]     = useState(false);

--- a/src/sections/stats/Dashboard.jsx
+++ b/src/sections/stats/Dashboard.jsx
@@ -3,6 +3,7 @@ import { TERMS, CATS } from '../../data/terms.js';
 import { RFI_QUIZ_POSITIONS } from '../../data/rfi-ranges.js';
 import { getStudyProgress, initStudyProgress, getTermQuizStats, initTermQuizStats, getRfiQuizStats, initRfiQuizStats, getLimpQuizStats, initLimpQuizStats, getVsRaiseQuizStats, initVsRaiseQuizStats, getAllModesQuizStats, initAllModesQuizStats } from '../../utils/storage.js';
 import { LIMP_HERO_POSITIONS, RAISE_HERO_POSITIONS } from '../../data/preflop-ranges.js';
+import { getRecommendation } from '../../utils/recommendation.js';
 import '../../styles/stats.css';
 
 export function Dashboard({ path }) {
@@ -25,6 +26,13 @@ export function Dashboard({ path }) {
 
   const rfiAccuracy = rfiQuiz.totalQuestions > 0
     ? Math.round(rfiQuiz.totalCorrect / rfiQuiz.totalQuestions * 100) : 0;
+
+  const recommendation = getRecommendation({
+    terminology: termQuiz,
+    rfi: rfiQuiz,
+    limp: limpQuiz,
+    vsRaise: vsRaiseQuiz,
+  });
 
   function resetStudy() {
     if (!confirm('Reset all study progress? This cannot be undone.')) return;
@@ -60,6 +68,17 @@ export function Dashboard({ path }) {
   return (
     <div class="stats-dashboard">
       <h2 class="stats-title">Your Stats</h2>
+
+      {recommendation && (
+        <div class="stats-recommendation" data-testid="stats-recommendation">
+          <div class="stats-rec-label">Recommended Next Quiz</div>
+          <div class="stats-rec-title">{recommendation.label}</div>
+          <div class="stats-rec-reason">{recommendation.reason}</div>
+          <a class="stats-rec-btn" href={recommendation.href}>
+            {recommendation.accuracy === null ? 'Start Quiz' : 'Practice Now'} &rarr;
+          </a>
+        </div>
+      )}
 
       {/* Study Progress */}
       <div class="stats-section">

--- a/src/styles/stats.css
+++ b/src/styles/stats.css
@@ -38,3 +38,16 @@
   border-radius:6px;font-size:.85rem;color:var(--text)}
 .stats-history-row:nth-child(even){background:rgba(255,255,255,.03)}
 .stats-empty{text-align:center;color:var(--muted);padding:1.5rem;font-style:italic}
+.stats-recommendation{margin-bottom:1.5rem;padding:1.2rem;
+  background:linear-gradient(135deg,rgba(201,168,76,.12),rgba(46,204,113,.08));
+  border:1px solid rgba(201,168,76,.4);border-radius:14px;text-align:center}
+.stats-rec-label{font-size:.72rem;color:var(--gold);letter-spacing:.1em;text-transform:uppercase;
+  margin-bottom:.35rem}
+.stats-rec-title{font-family:'Playfair Display',serif;font-size:1.25rem;color:var(--gold-bright);
+  margin-bottom:.4rem}
+.stats-rec-reason{color:var(--text);font-size:.92rem;margin-bottom:.9rem;line-height:1.4}
+.stats-rec-btn{display:inline-block;background:var(--gold);color:#1a1a2a;padding:.55rem 1.4rem;
+  border-radius:8px;font-weight:600;letter-spacing:.04em;text-decoration:none;font-size:.92rem;
+  border:1px solid var(--gold-bright);transition:background .2s,transform .1s}
+.stats-rec-btn:hover{background:var(--gold-bright)}
+.stats-rec-btn:active{transform:translateY(1px)}

--- a/src/utils/recommendation.js
+++ b/src/utils/recommendation.js
@@ -1,0 +1,49 @@
+// Pure logic for "next quiz to take" recommendation on the Stats dashboard.
+// Extracted from the UI so it can be unit-tested without DOM / localStorage.
+
+export const QUIZ_CATALOG = [
+  { key: 'terminology', label: 'Terminology Quiz',      href: '#/quizzes/terminology' },
+  { key: 'rfi',         label: 'Preflop RFI Quiz',      href: '#/quizzes/preflop?mode=rfi' },
+  { key: 'limp',        label: 'Preflop vs Limp Quiz',  href: '#/quizzes/preflop?mode=limp' },
+  { key: 'vsRaise',     label: 'Preflop vs Raise Quiz', href: '#/quizzes/preflop?mode=vsRaise' },
+];
+
+// `statsMap` keys match QUIZ_CATALOG keys; each value is a stats object
+// (with `totalQuestions` + `totalCorrect`) or null/undefined if untaken.
+// Returns { key, label, href, accuracy, reason } or null if the catalog is empty.
+export function getRecommendation(statsMap) {
+  const entries = QUIZ_CATALOG.map(q => {
+    const s = statsMap?.[q.key];
+    const total = s?.totalQuestions || 0;
+    const correct = s?.totalCorrect || 0;
+    const accuracy = total > 0 ? Math.round(correct / total * 100) : null;
+    return { ...q, total, correct, accuracy };
+  });
+
+  if (entries.length === 0) return null;
+
+  // Prefer an untaken quiz so the user builds a baseline before we rank accuracy.
+  const untaken = entries.find(e => e.total === 0);
+  if (untaken) {
+    return {
+      key: untaken.key,
+      label: untaken.label,
+      href: untaken.href,
+      accuracy: null,
+      reason: `You haven't tried the ${untaken.label} yet — take it to establish a baseline.`,
+    };
+  }
+
+  // All quizzes have data: pick the one with the lowest accuracy (ties → first in catalog order).
+  let weakest = entries[0];
+  for (const e of entries.slice(1)) {
+    if (e.accuracy < weakest.accuracy) weakest = e;
+  }
+  return {
+    key: weakest.key,
+    label: weakest.label,
+    href: weakest.href,
+    accuracy: weakest.accuracy,
+    reason: `Your weakest area is ${weakest.label} at ${weakest.accuracy}% accuracy — practice to bring it up.`,
+  };
+}

--- a/src/utils/recommendation.test.js
+++ b/src/utils/recommendation.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { getRecommendation, QUIZ_CATALOG } from './recommendation.js';
+
+function stats(totalQuestions, totalCorrect) {
+  return { totalQuestions, totalCorrect };
+}
+
+describe('getRecommendation', () => {
+  it('recommends an untaken quiz before ranking by accuracy', () => {
+    const rec = getRecommendation({
+      terminology: stats(10, 5),
+      rfi:         stats(10, 9),
+      limp:        null, // untaken
+      vsRaise:     stats(10, 4),
+    });
+    expect(rec.key).toBe('limp');
+    expect(rec.accuracy).toBeNull();
+    expect(rec.reason).toMatch(/baseline/i);
+  });
+
+  it('recommends the lowest-accuracy quiz when all have data', () => {
+    const rec = getRecommendation({
+      terminology: stats(20, 18), // 90%
+      rfi:         stats(20, 14), // 70%
+      limp:        stats(20,  8), // 40%  ← weakest
+      vsRaise:     stats(20, 12), // 60%
+    });
+    expect(rec.key).toBe('limp');
+    expect(rec.accuracy).toBe(40);
+    expect(rec.href).toBe('#/quizzes/preflop?mode=limp');
+  });
+
+  it('treats zero totalQuestions as untaken (not 0% accuracy)', () => {
+    const rec = getRecommendation({
+      terminology: { totalQuestions: 0, totalCorrect: 0 },
+      rfi:         stats(10, 9),
+      limp:        stats(10, 8),
+      vsRaise:     stats(10, 7),
+    });
+    expect(rec.key).toBe('terminology');
+    expect(rec.accuracy).toBeNull();
+  });
+
+  it('returns first catalog entry on a ties-at-lowest-accuracy case', () => {
+    const rec = getRecommendation({
+      terminology: stats(10, 5),
+      rfi:         stats(10, 5),
+      limp:        stats(10, 5),
+      vsRaise:     stats(10, 5),
+    });
+    // All 50%; tie-break picks the first in catalog order (terminology).
+    expect(rec.key).toBe('terminology');
+  });
+
+  it('handles undefined statsMap entries the same as null', () => {
+    const rec = getRecommendation({}); // everything untaken
+    expect(rec.key).toBe(QUIZ_CATALOG[0].key);
+    expect(rec.accuracy).toBeNull();
+  });
+
+  it('each catalog entry has a href that links to a real app route', () => {
+    // Regression: links must match the actual route strings in routing.js.
+    // Any mismatch here will break the "take me there" button.
+    const validPaths = new Set(['/quizzes/terminology', '/quizzes/preflop']);
+    for (const q of QUIZ_CATALOG) {
+      const hash = q.href.replace(/^#/, '');
+      const path = hash.split('?')[0];
+      expect(validPaths.has(path), `${q.key} href ${q.href} points to unknown route ${path}`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Surfaces the user's weakest quiz (or an untaken one for a baseline)
with a one-click button that deep-links into the right quiz + mode
via a new `?mode=` hash query param.

https://claude.ai/code/session_01SRzYhH2H7LvW85ZtxY1xi2