### PR TITLE
Replace main nav with hamburger menu drawer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ poker-trainer/
 │   ├── app.jsx                         # Header + hash router with route table
 │   ├── styles/
 │   │   ├── base.css                    # :root vars, body, fonts, global reset
-│   │   ├── header.css                  # Header, section nav, sub-nav tabs
+│   │   ├── header.css                  # Header, hamburger menu drawer, sub-nav tabs
 │   │   ├── welcome.css                 # Welcome page hand rankings, section cards
 │   │   ├── study.css                   # Flashcard scene, 3D flip, card nav
 │   │   ├── quiz.css                    # Term quiz + RFI quiz styles
@@ -52,7 +52,7 @@ poker-trainer/
 │   │   ├── useFilters.js               # activeCats state + toggle logic
 │   │   └── useDeck.js                  # deck, idx, flipped, nav, shuffle
 │   ├── components/
-│   │   ├── Header.jsx                  # App header + section nav (Home | Terminology | Preflop | Stats)
+│   │   ├── Header.jsx                  # App header + hamburger menu drawer (Home | Terminology | Preflop | Quizzes | Stats)
 │   │   ├── SubNav.jsx                  # Sub-navigation tabs within a section
 │   │   ├── FilterChips.jsx             # Category filter chip bar
 │   │   ├── ProgressBar.jsx             # Study progress bar

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,19 +1,73 @@
 import { useState, useEffect } from 'preact/hooks';
 import '../styles/header.css';
 
+const NAV_ITEMS = [
+  { href: '#/welcome', label: 'Home', section: 'welcome' },
+  { href: '#/terminology/study', label: 'Terminology', section: 'terminology' },
+  { href: '#/preflop/charts', label: 'Preflop', section: 'preflop' },
+  { href: '#/quizzes/preflop', label: 'Quizzes', section: 'quizzes' },
+  { href: '#/stats', label: 'Stats', section: 'stats' },
+];
+
 export function Header() {
-  const [currentPath, setCurrentPath] = useState(window.location.hash.slice(1) || '/terminology/study');
+  const [currentPath, setCurrentPath] = useState(window.location.hash.slice(1) || '/welcome');
+  const [menuOpen, setMenuOpen] = useState(false);
 
   useEffect(() => {
-    const onHash = () => setCurrentPath(window.location.hash.slice(1) || '/terminology/study');
+    const onHash = () => {
+      setCurrentPath(window.location.hash.slice(1) || '/welcome');
+      setMenuOpen(false);
+    };
     window.addEventListener('hashchange', onHash);
     return () => window.removeEventListener('hashchange', onHash);
   }, []);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onKey = (e) => { if (e.key === 'Escape') setMenuOpen(false); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [menuOpen]);
 
   const section = currentPath.split('/')[1] || 'welcome';
 
   return (
     <header>
+      <button
+        type="button"
+        class={`hamburger${menuOpen ? ' is-open' : ''}`}
+        aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+        aria-expanded={menuOpen}
+        aria-controls="primary-nav"
+        onClick={() => setMenuOpen(o => !o)}
+      >
+        <span class="hamburger-bar"></span>
+        <span class="hamburger-bar"></span>
+        <span class="hamburger-bar"></span>
+      </button>
+
+      {menuOpen && (
+        <div class="nav-backdrop" onClick={() => setMenuOpen(false)} aria-hidden="true"></div>
+      )}
+
+      <nav
+        id="primary-nav"
+        class={`section-nav${menuOpen ? ' is-open' : ''}`}
+        aria-hidden={!menuOpen}
+      >
+        {NAV_ITEMS.map(item => (
+          <a
+            key={item.href}
+            href={item.href}
+            class={section === item.section ? 'active' : ''}
+            tabIndex={menuOpen ? 0 : -1}
+            onClick={() => setMenuOpen(false)}
+          >
+            {item.label}
+          </a>
+        ))}
+      </nav>
+
       <div class="suits-row">
         <span class="s">{'\u2660'}</span>
         <span class="h">{'\u2665'}</span>
@@ -22,13 +76,6 @@ export function Header() {
       </div>
       <h1><em>Texas Hold'em</em> Poker Trainer</h1>
       <p class="subtitle">Master the language of the felt</p>
-      <nav class="section-nav">
-        <a href="#/welcome" class={section === 'welcome' ? 'active' : ''}>Home</a>
-        <a href="#/terminology/study" class={section === 'terminology' ? 'active' : ''}>Terminology</a>
-        <a href="#/preflop/charts" class={section === 'preflop' ? 'active' : ''}>Preflop</a>
-        <a href="#/quizzes/preflop" class={section === 'quizzes' ? 'active' : ''}>Quizzes</a>
-        <a href="#/stats" class={section === 'stats' ? 'active' : ''}>Stats</a>
-      </nav>
     </header>
   );
 }

--- a/src/components/Header.test.js
+++ b/src/components/Header.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(resolve(__dirname, 'Header.jsx'), 'utf8');
+
+describe('Header — hamburger menu', () => {
+  it('renders a hamburger toggle button with accessible label', () => {
+    expect(source).toMatch(/class=\{?`?hamburger/);
+    expect(source).toMatch(/aria-label=\{[^}]*menu/i);
+    expect(source).toMatch(/aria-expanded=\{menuOpen\}/);
+  });
+
+  it('toggles menuOpen state when the hamburger is clicked', () => {
+    expect(source).toMatch(/setMenuOpen\(o\s*=>\s*!o\)/);
+  });
+
+  it('closes the menu when a nav link is clicked — avoids leaving drawer open after navigation', () => {
+    expect(source).toMatch(/onClick=\{\(\)\s*=>\s*setMenuOpen\(false\)\}/);
+  });
+
+  it('closes the menu on Escape key', () => {
+    expect(source).toMatch(/e\.key\s*===\s*'Escape'/);
+  });
+
+  it('closes the menu on hashchange — so the drawer disappears after client-side navigation', () => {
+    expect(source).toMatch(/hashchange/);
+    // setMenuOpen(false) must appear inside the hashchange handler block
+    expect(source).toMatch(/onHash[\s\S]{0,200}setMenuOpen\(false\)/);
+  });
+
+  it('includes all five top-level sections in the drawer', () => {
+    for (const label of ['Home', 'Terminology', 'Preflop', 'Quizzes', 'Stats']) {
+      expect(source).toContain(label);
+    }
+  });
+
+  it('includes a backdrop that closes the menu when clicked outside', () => {
+    expect(source).toMatch(/nav-backdrop/);
+    // The backdrop's onClick must also call setMenuOpen(false)
+    expect(source).toMatch(/nav-backdrop[\s\S]{0,200}setMenuOpen\(false\)/);
+  });
+});

--- a/src/styles/header-mobile.test.js
+++ b/src/styles/header-mobile.test.js
@@ -6,17 +6,33 @@ import { dirname, resolve } from 'path';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const css = readFileSync(resolve(__dirname, 'header.css'), 'utf8');
 
-describe('header.css mobile nav', () => {
-  it('section-nav wraps to multiple rows on small screens — prevents mobile truncation', () => {
-    expect(css).toContain('flex-wrap:wrap');
+describe('header.css hamburger nav', () => {
+  it('hamburger button is pinned to the top-left corner on all screens', () => {
+    expect(css).toMatch(/\.hamburger\s*\{[^}]*position:fixed/);
+    expect(css).toMatch(/\.hamburger\s*\{[^}]*top:1rem/);
+    expect(css).toMatch(/\.hamburger\s*\{[^}]*left:1rem/);
   });
 
-  it('has a mobile media query for section-nav', () => {
-    expect(css).toMatch(/@media\s*\(max-width:\s*540px\)/);
+  it('drawer is hidden off-screen by default and slides in when open', () => {
+    // Default drawer state translates off-screen
+    expect(css).toMatch(/\.section-nav\s*\{[^}]*transform:translateX\(-100%\)/);
+    // Open state slides it in
+    expect(css).toMatch(/\.section-nav\.is-open\s*\{[^}]*transform:translateX\(0\)/);
   });
 
-  it('last two nav items are wider on mobile to balance the 3+2 row layout', () => {
-    expect(css).toContain('nth-last-child(2)');
-    expect(css).toContain('flex:1 0 50%');
+  it('hamburger sits above drawer and backdrop so it stays clickable to close menu', () => {
+    const hamburgerZ = css.match(/\.hamburger\s*\{[^}]*z-index:(\d+)/);
+    const navZ = css.match(/\.section-nav\s*\{[^}]*z-index:(\d+)/);
+    const backdropZ = css.match(/\.nav-backdrop\s*\{[^}]*z-index:(\d+)/);
+    expect(hamburgerZ).not.toBeNull();
+    expect(navZ).not.toBeNull();
+    expect(backdropZ).not.toBeNull();
+    expect(Number(hamburgerZ[1])).toBeGreaterThan(Number(navZ[1]));
+    expect(Number(navZ[1])).toBeGreaterThan(Number(backdropZ[1]));
+  });
+
+  it('backdrop covers the full viewport behind the drawer', () => {
+    expect(css).toMatch(/\.nav-backdrop\s*\{[^}]*position:fixed/);
+    expect(css).toMatch(/\.nav-backdrop\s*\{[^}]*inset:0/);
   });
 });

--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -1,4 +1,5 @@
 header{
+  position:relative;
   text-align:center;padding:2.5rem 1rem 1.5rem;
   border-bottom:1px solid rgba(201,168,76,0.3);
   background:linear-gradient(180deg,rgba(0,0,0,0.35) 0%,transparent 100%)
@@ -13,21 +14,42 @@ h1{font-family:'Playfair Display',Georgia,serif;font-size:clamp(1.8rem,5vw,3rem)
 h1 em{font-style:italic;color:var(--gold)}
 .subtitle{color:var(--muted);font-size:1.05rem;margin-top:0.4rem}
 
-/* Section nav */
-.section-nav{display:flex;justify-content:center;gap:0;margin:1.5rem auto 0;max-width:600px;
-  border:1px solid var(--gold-dark);border-radius:40px;overflow:hidden;background:rgba(0,0,0,0.3)}
-.section-nav a{flex:1;padding:0.6rem 1rem;border:none;background:transparent;
-  color:var(--muted);font-family:'Crimson Pro',serif;font-size:1rem;cursor:pointer;
-  transition:all .25s;letter-spacing:.04em;text-decoration:none;text-align:center}
+/* Hamburger button — fixed to the top-left corner on all screens */
+.hamburger{
+  position:fixed;top:1rem;left:1rem;z-index:60;
+  width:44px;height:44px;padding:0;
+  display:flex;flex-direction:column;justify-content:center;align-items:center;gap:5px;
+  background:rgba(0,0,0,0.45);border:1px solid var(--gold-dark);border-radius:8px;
+  cursor:pointer;transition:background .2s,border-color .2s}
+.hamburger:hover{background:rgba(0,0,0,0.65);border-color:var(--gold)}
+.hamburger:focus-visible{outline:2px solid var(--gold-bright);outline-offset:2px}
+.hamburger-bar{display:block;width:22px;height:2px;background:var(--gold-bright);
+  border-radius:2px;transition:transform .25s ease,opacity .2s ease}
+.hamburger.is-open .hamburger-bar:nth-child(1){transform:translateY(7px) rotate(45deg)}
+.hamburger.is-open .hamburger-bar:nth-child(2){opacity:0}
+.hamburger.is-open .hamburger-bar:nth-child(3){transform:translateY(-7px) rotate(-45deg)}
+
+/* Backdrop when menu is open */
+.nav-backdrop{position:fixed;inset:0;z-index:50;background:rgba(0,0,0,0.5);
+  animation:backdropFade .2s ease}
+@keyframes backdropFade{from{opacity:0}to{opacity:1}}
+
+/* Section nav as a slide-in drawer from the left */
+.section-nav{
+  position:fixed;top:0;left:0;z-index:55;
+  display:flex;flex-direction:column;gap:4px;
+  width:min(260px,80vw);height:100vh;
+  padding:4.5rem 1rem 1.5rem;
+  background:linear-gradient(180deg,rgba(12,36,22,0.98) 0%,rgba(23,53,39,0.98) 100%);
+  border-right:1px solid var(--gold-dark);
+  transform:translateX(-100%);transition:transform .25s ease;
+  overflow-y:auto;box-shadow:2px 0 16px rgba(0,0,0,0.4)}
+.section-nav.is-open{transform:translateX(0)}
+.section-nav a{padding:0.75rem 1rem;border:none;background:transparent;border-radius:6px;
+  color:var(--muted);font-family:'Crimson Pro',serif;font-size:1.05rem;cursor:pointer;
+  transition:all .2s;letter-spacing:.04em;text-decoration:none;text-align:left}
 .section-nav a.active{background:var(--gold-dark);color:var(--gold-bright);font-weight:600}
 .section-nav a:hover:not(.active){color:var(--text);background:rgba(255,255,255,0.07)}
-
-@media (max-width: 540px) {
-  .section-nav{max-width:100%;flex-wrap:wrap;border-radius:12px}
-  .section-nav a{flex:1 0 33.33%;font-size:.82rem;padding:.5rem .3rem;
-    letter-spacing:0;box-sizing:border-box}
-  .section-nav a:nth-last-child(2),.section-nav a:last-child{flex:1 0 50%}
-}
 
 /* Sub nav — gap-based so tabs never get clipped by overflow:hidden on narrow screens */
 .sub-nav{display:flex;justify-content:center;gap:6px;flex-wrap:wrap;


### PR DESCRIPTION
Swap the inline section nav for a fixed top-left hamburger button that
opens a slide-in drawer containing Home, Terminology, Preflop, Quizzes,
and Stats. The drawer closes on link click, Escape, backdrop click, and
hashchange so it never lingers after navigation.

https://claude.ai/code/session_0192kLr94JqUv1Av4f24jxj5