### PR TITLE
Hide title/subtitle on non-welcome screens; align suits logo with hamburger

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -30,9 +30,10 @@ export function Header() {
   }, [menuOpen]);
 
   const section = currentPath.split('/')[1] || 'welcome';
+  const isWelcome = section === 'welcome';
 
   return (
-    <header>
+    <header class={isWelcome ? '' : 'is-compact'}>
       <button
         type="button"
         class={`hamburger${menuOpen ? ' is-open' : ''}`}
@@ -74,8 +75,12 @@ export function Header() {
         <span class="d">{'\u2666'}</span>
         <span class="c">{'\u2663'}</span>
       </div>
-      <h1><em>Texas Hold'em</em> Poker Trainer</h1>
-      <p class="subtitle">Master the language of the felt</p>
+      {isWelcome && (
+        <>
+          <h1><em>Texas Hold'em</em> Poker Trainer</h1>
+          <p class="subtitle">Master the language of the felt</p>
+        </>
+      )}
     </header>
   );
 }

--- a/src/components/Header.test.js
+++ b/src/components/Header.test.js
@@ -42,4 +42,14 @@ describe('Header — hamburger menu', () => {
     // The backdrop's onClick must also call setMenuOpen(false)
     expect(source).toMatch(/nav-backdrop[\s\S]{0,200}setMenuOpen\(false\)/);
   });
+
+  it('renders the Texas Hold\'em title and subtitle only on the welcome screen', () => {
+    // Title and subtitle must be guarded by an isWelcome check so they hide on other screens.
+    expect(source).toMatch(/const\s+isWelcome\s*=\s*section\s*===\s*'welcome'/);
+    expect(source).toMatch(/isWelcome\s*&&[\s\S]{0,200}Texas Hold'em[\s\S]{0,200}Master the language of the felt/);
+  });
+
+  it('applies an is-compact class to the header on non-welcome screens — used to align the suits-row with the hamburger', () => {
+    expect(source).toMatch(/class=\{isWelcome\s*\?\s*''\s*:\s*'is-compact'\}/);
+  });
 });

--- a/src/styles/header-mobile.test.js
+++ b/src/styles/header-mobile.test.js
@@ -35,4 +35,10 @@ describe('header.css hamburger nav', () => {
     expect(css).toMatch(/\.nav-backdrop\s*\{[^}]*position:fixed/);
     expect(css).toMatch(/\.nav-backdrop\s*\{[^}]*inset:0/);
   });
+
+  it('compact header reduces top padding so the suits-row aligns vertically with the hamburger', () => {
+    // header.is-compact must override the default 2.5rem top padding with a smaller value
+    // so the suits-row sits at roughly the same vertical position as the hamburger button.
+    expect(css).toMatch(/header\.is-compact\s*\{[^}]*padding:1\.2rem/);
+  });
 });

--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -14,6 +14,11 @@ h1{font-family:'Playfair Display',Georgia,serif;font-size:clamp(1.8rem,5vw,3rem)
 h1 em{font-style:italic;color:var(--gold)}
 .subtitle{color:var(--muted);font-size:1.05rem;margin-top:0.4rem}
 
+/* Compact header (non-welcome screens) — only the suits-row is shown,
+   vertically aligned with the hamburger button (top:1rem, height:44px → center y ≈ 38px). */
+header.is-compact{padding:1.2rem 1rem 1rem}
+header.is-compact .suits-row{margin-bottom:0}
+
 /* Hamburger button — fixed to the top-left corner on all screens */
 .hamburger{
   position:fixed;top:1rem;left:1rem;z-index:60;


### PR DESCRIPTION
The "Texas Hold'em Poker Trainer" title and "Master the language of
the felt" subtitle now render only on the welcome screen. On other
screens the header collapses to just the suits row, and its padding
is reduced so the row sits at roughly the same vertical position as
the fixed top-left hamburger button.