### PR TITLE
Point Welcome Quizzes card to Preflop quiz setup

### DIFF
--- a/src/sections/welcome/Welcome.jsx
+++ b/src/sections/welcome/Welcome.jsx
@@ -26,7 +26,7 @@ const SECTIONS = [
     desc: 'Study GTO-optimal preflop raise ranges for every position with interactive charts.',
   },
   {
-    href: '#/quizzes/terminology',
+    href: '#/quizzes/preflop',
     title: 'Quizzes',
     desc: 'Test your knowledge with terminology and preflop decision quizzes across all positions and stack depths.',
   },

--- a/src/sections/welcome/Welcome.test.js
+++ b/src/sections/welcome/Welcome.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import { REDIRECTS, resolveRoute } from '../../routing.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(resolve(__dirname, 'Welcome.jsx'), 'utf8');
+
+describe('Welcome — section cards', () => {
+  it('Quizzes card links to the Preflop quiz — Preflop is the default quiz mode', () => {
+    // Regression: the Quizzes card previously pointed to /quizzes/terminology,
+    // but Preflop is the default quiz landing per the Quizzes nav and /quizzes redirect.
+    expect(source).toMatch(/href:\s*'#\/quizzes\/preflop'[\s\S]{0,80}title:\s*'Quizzes'/);
+    expect(source).not.toMatch(/href:\s*'#\/quizzes\/terminology'/);
+  });
+
+  it('Quizzes card href resolves to the same target as the /quizzes redirect — consistent default', () => {
+    const match = source.match(/href:\s*'#(\/quizzes\/[a-z]+)'[\s\S]{0,80}title:\s*'Quizzes'/);
+    expect(match).toBeTruthy();
+    const quizzesCardPath = match[1];
+    expect(resolveRoute(quizzesCardPath)).toBe(REDIRECTS['/quizzes']);
+  });
+});


### PR DESCRIPTION
Quizzes card on the landing page linked to /quizzes/terminology, but
Preflop is the default quiz mode (matches /quizzes redirect and the
main nav). Now clicking Quizzes from Welcome lands on the Preflop
quiz setup page consistently with the rest of the app.

https://claude.ai/code/session_01B5jiWtE7Epu4jwF8JLKmyu