### PR TITLE
Visualize quiz setup position selector with a table map

### DIFF
--- a/src/components/PositionTable.jsx
+++ b/src/components/PositionTable.jsx
@@ -1,0 +1,88 @@
+// 6-max poker table with clickable seats — used as a visual position selector.
+// Seat coordinates mirror the terminology table illustration layout.
+const SEATS = [
+  { id: 'BTN', x: 200, y: 22 },
+  { id: 'SB',  x: 340, y: 58 },
+  { id: 'BB',  x: 340, y: 168 },
+  { id: 'UTG', x: 200, y: 208 },
+  { id: 'HJ',  x:  60, y: 168 },
+  { id: 'CO',  x:  60, y:  58 },
+];
+
+export function PositionTable({
+  selected,
+  available,
+  onSelect,
+  allowAll = true,
+  title,
+  variant = 'hero',
+}) {
+  const availSet = new Set(available || []);
+  const isAll = selected === 'all' || selected == null;
+
+  return (
+    <div class={`pt-wrap pt-${variant}`}>
+      {title && <div class="pt-title">{title}</div>}
+      <div class="pt-svg-wrap">
+        <svg viewBox="0 0 400 240" class="pt-svg" role="group" aria-label="Position selector">
+          <ellipse cx="200" cy="115" rx="168" ry="96"
+            fill="#1e4a2e" stroke="#8B6914" stroke-width="6"/>
+          <ellipse cx="200" cy="115" rx="148" ry="78" fill="#2a6040"/>
+          <text x="200" y="111" text-anchor="middle" font-size="12"
+            fill="rgba(201,168,76,.6)" font-family="Georgia">TEXAS HOLD'EM</text>
+          <text x="200" y="127" text-anchor="middle" font-size="10"
+            fill="rgba(201,168,76,.4)" font-family="Georgia">No Limit</text>
+          {SEATS.map(seat => {
+            const enabled = availSet.has(seat.id);
+            const active = enabled && selected === seat.id;
+            const dimmed = !enabled;
+            const r = active ? 22 : 18;
+            const fill   = active ? '#c9a84c'
+                        : dimmed ? 'rgba(0,0,0,.35)'
+                        : 'rgba(0,0,0,.6)';
+            const stroke = active ? '#f0d060'
+                        : dimmed ? 'rgba(201,168,76,.2)'
+                        : 'rgba(201,168,76,.55)';
+            const strokeWidth = active ? 2.5 : 1.25;
+            const textColor = active ? '#1a2010'
+                           : dimmed ? 'rgba(201,168,76,.35)'
+                           : '#c9a84c';
+            const fontWeight = active ? 700 : 500;
+            return (
+              <g key={seat.id}
+                 class={`pt-seat${enabled ? ' pt-seat-enabled' : ''}${active ? ' pt-seat-active' : ''}`}
+                 onClick={enabled ? () => onSelect(seat.id) : undefined}
+                 role={enabled ? 'button' : undefined}
+                 tabIndex={enabled ? 0 : undefined}
+                 aria-label={seat.id}
+                 aria-pressed={active ? 'true' : 'false'}
+                 onKeyDown={enabled ? (e) => {
+                   if (e.key === 'Enter' || e.key === ' ') {
+                     e.preventDefault();
+                     onSelect(seat.id);
+                   }
+                 } : undefined}
+              >
+                <circle cx={seat.x} cy={seat.y} r={r}
+                  fill={fill} stroke={stroke} stroke-width={strokeWidth}/>
+                <text x={seat.x} y={seat.y + 5} text-anchor="middle"
+                  font-size={active ? 12 : 11} fill={textColor}
+                  font-weight={fontWeight} font-family="Georgia"
+                  style="pointer-events:none;user-select:none">{seat.id}</text>
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+      {allowAll && (
+        <div class="pt-all-row">
+          <button
+            type="button"
+            class={`rq-selector-btn${isAll ? ' active' : ''}`}
+            onClick={() => onSelect('all')}
+          >All Positions</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/PositionTable.jsx
+++ b/src/components/PositionTable.jsx
@@ -1,5 +1,7 @@
-// 6-max poker table with clickable seats — used as a visual position selector.
-// Seat coordinates mirror the terminology table illustration layout.
+import { useState, useEffect } from 'preact/hooks';
+
+// 6-max poker table with clickable seats — used as a visual position selector
+// for both hero and villain at the same time.
 const SEATS = [
   { id: 'BTN', x: 200, y: 22 },
   { id: 'SB',  x: 340, y: 58 },
@@ -9,20 +11,84 @@ const SEATS = [
   { id: 'CO',  x:  60, y:  58 },
 ];
 
+const BTN_SEAT = SEATS[0];
+// Dealer button chip sits just inside the rail, offset from the BTN seat toward
+// the table center so it's clearly *near* the seat without overlapping the label.
+const DEALER_CHIP = { x: BTN_SEAT.x + 30, y: BTN_SEAT.y + 28, r: 9 };
+
+const HERO_FILL   = '#c9a84c';
+const HERO_STROKE = '#f0d060';
+const VILL_FILL   = '#7a2a1e';
+const VILL_STROKE = '#e85c4a';
+
 export function PositionTable({
-  selected,
-  available,
-  onSelect,
-  allowAll = true,
-  title,
-  variant = 'hero',
+  heroSelected = 'all',
+  villainSelected = 'all',
+  heroAvailable,
+  villainAvailable,
+  onHeroSelect,
+  onVillainSelect,
+  showVillain = false,
+  heroLabel = 'Your Position',
+  villainLabel = 'Villain',
 }) {
-  const availSet = new Set(available || []);
-  const isAll = selected === 'all' || selected == null;
+  const [activeRole, setActiveRole] = useState('hero');
+
+  // Keep the active role valid when the villain tab disappears (e.g. RFI mode).
+  useEffect(() => {
+    if (!showVillain && activeRole !== 'hero') setActiveRole('hero');
+  }, [showVillain, activeRole]);
+
+  const heroAvailSet = new Set(heroAvailable || []);
+  const villainAvailSet = new Set(villainAvailable || []);
+  const active = showVillain ? activeRole : 'hero';
+
+  const handleSeatClick = (id) => {
+    if (active === 'hero') {
+      if (!heroAvailSet.has(id)) return;
+      onHeroSelect(id);
+    } else {
+      if (!villainAvailSet.has(id)) return;
+      onVillainSelect(id);
+    }
+  };
+
+  const setAllForActive = () => {
+    if (active === 'hero') onHeroSelect('all');
+    else onVillainSelect('all');
+  };
+
+  const heroIsAll    = heroSelected === 'all' || heroSelected == null;
+  const villainIsAll = villainSelected === 'all' || villainSelected == null;
+  const allActive    = active === 'hero' ? heroIsAll : villainIsAll;
 
   return (
-    <div class={`pt-wrap pt-${variant}`}>
-      {title && <div class="pt-title">{title}</div>}
+    <div class="pt-wrap">
+      {showVillain && (
+        <div class="pt-roles" role="tablist">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={active === 'hero'}
+            class={`pt-role pt-role-hero${active === 'hero' ? ' active' : ''}`}
+            onClick={() => setActiveRole('hero')}
+          >
+            <span class="pt-role-lbl">{heroLabel}</span>
+            <span class="pt-role-val">{heroIsAll ? 'All' : heroSelected}</span>
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={active === 'villain'}
+            class={`pt-role pt-role-villain${active === 'villain' ? ' active' : ''}`}
+            onClick={() => setActiveRole('villain')}
+          >
+            <span class="pt-role-lbl">{villainLabel}</span>
+            <span class="pt-role-val">{villainIsAll ? 'All' : villainSelected}</span>
+          </button>
+        </div>
+      )}
+
       <div class="pt-svg-wrap">
         <svg viewBox="0 0 400 240" class="pt-svg" role="group" aria-label="Position selector">
           <ellipse cx="200" cy="115" rx="168" ry="96"
@@ -32,41 +98,63 @@ export function PositionTable({
             fill="rgba(201,168,76,.6)" font-family="Georgia">TEXAS HOLD'EM</text>
           <text x="200" y="127" text-anchor="middle" font-size="10"
             fill="rgba(201,168,76,.4)" font-family="Georgia">No Limit</text>
+
+          {/* Dealer button chip (the "BTN" chip) near the Button seat. */}
+          <g class="pt-dealer-chip" aria-hidden="true">
+            <circle cx={DEALER_CHIP.x} cy={DEALER_CHIP.y} r={DEALER_CHIP.r + 1}
+              fill="rgba(0,0,0,.35)"/>
+            <circle cx={DEALER_CHIP.x} cy={DEALER_CHIP.y} r={DEALER_CHIP.r}
+              fill="#f5e27a" stroke="#8B6914" stroke-width="1.5"/>
+            <circle cx={DEALER_CHIP.x} cy={DEALER_CHIP.y} r={DEALER_CHIP.r - 3}
+              fill="none" stroke="#8B6914" stroke-width=".75"
+              stroke-dasharray="1.5 1.5"/>
+            <text x={DEALER_CHIP.x} y={DEALER_CHIP.y + 3.5} text-anchor="middle"
+              font-size="9" font-weight="700" fill="#3a2a10" font-family="Georgia">D</text>
+          </g>
+
           {SEATS.map(seat => {
-            const enabled = availSet.has(seat.id);
-            const active = enabled && selected === seat.id;
-            const dimmed = !enabled;
-            const r = active ? 22 : 18;
-            const fill   = active ? '#c9a84c'
-                        : dimmed ? 'rgba(0,0,0,.35)'
-                        : 'rgba(0,0,0,.6)';
-            const stroke = active ? '#f0d060'
-                        : dimmed ? 'rgba(201,168,76,.2)'
-                        : 'rgba(201,168,76,.55)';
-            const strokeWidth = active ? 2.5 : 1.25;
-            const textColor = active ? '#1a2010'
-                           : dimmed ? 'rgba(201,168,76,.35)'
-                           : '#c9a84c';
-            const fontWeight = active ? 700 : 500;
+            const isHero    = !heroIsAll    && heroSelected    === seat.id;
+            const isVillain = !villainIsAll && villainSelected === seat.id;
+            const roleAvail = active === 'hero' ? heroAvailSet : villainAvailSet;
+            const enabled   = roleAvail.has(seat.id);
+            const dimmed    = !enabled && !isHero && !isVillain;
+            const r         = (isHero || isVillain) ? 22 : 18;
+
+            let fill, stroke, strokeWidth, textColor, fontWeight;
+            if (isHero) {
+              fill = HERO_FILL; stroke = HERO_STROKE; strokeWidth = 2.5;
+              textColor = '#1a2010'; fontWeight = 700;
+            } else if (isVillain) {
+              fill = VILL_FILL; stroke = VILL_STROKE; strokeWidth = 2.5;
+              textColor = '#ffe7d9'; fontWeight = 700;
+            } else if (dimmed) {
+              fill = 'rgba(0,0,0,.35)'; stroke = 'rgba(201,168,76,.2)';
+              strokeWidth = 1; textColor = 'rgba(201,168,76,.35)'; fontWeight = 500;
+            } else {
+              fill = 'rgba(0,0,0,.6)'; stroke = 'rgba(201,168,76,.55)';
+              strokeWidth = 1.25; textColor = '#c9a84c'; fontWeight = 500;
+            }
+
+            const clickable = enabled;
             return (
               <g key={seat.id}
-                 class={`pt-seat${enabled ? ' pt-seat-enabled' : ''}${active ? ' pt-seat-active' : ''}`}
-                 onClick={enabled ? () => onSelect(seat.id) : undefined}
-                 role={enabled ? 'button' : undefined}
-                 tabIndex={enabled ? 0 : undefined}
-                 aria-label={seat.id}
-                 aria-pressed={active ? 'true' : 'false'}
-                 onKeyDown={enabled ? (e) => {
+                 class={`pt-seat${clickable ? ' pt-seat-enabled' : ''}${isHero ? ' pt-seat-hero' : ''}${isVillain ? ' pt-seat-villain' : ''}`}
+                 onClick={clickable ? () => handleSeatClick(seat.id) : undefined}
+                 role={clickable ? 'button' : undefined}
+                 tabIndex={clickable ? 0 : undefined}
+                 aria-label={`${seat.id}${isHero ? ' (hero)' : isVillain ? ' (villain)' : ''}`}
+                 aria-pressed={(isHero || isVillain) ? 'true' : 'false'}
+                 onKeyDown={clickable ? (e) => {
                    if (e.key === 'Enter' || e.key === ' ') {
                      e.preventDefault();
-                     onSelect(seat.id);
+                     handleSeatClick(seat.id);
                    }
                  } : undefined}
               >
                 <circle cx={seat.x} cy={seat.y} r={r}
                   fill={fill} stroke={stroke} stroke-width={strokeWidth}/>
                 <text x={seat.x} y={seat.y + 5} text-anchor="middle"
-                  font-size={active ? 12 : 11} fill={textColor}
+                  font-size={(isHero || isVillain) ? 12 : 11} fill={textColor}
                   font-weight={fontWeight} font-family="Georgia"
                   style="pointer-events:none;user-select:none">{seat.id}</text>
               </g>
@@ -74,15 +162,14 @@ export function PositionTable({
           })}
         </svg>
       </div>
-      {allowAll && (
-        <div class="pt-all-row">
-          <button
-            type="button"
-            class={`rq-selector-btn${isAll ? ' active' : ''}`}
-            onClick={() => onSelect('all')}
-          >All Positions</button>
-        </div>
-      )}
+
+      <div class="pt-all-row">
+        <button
+          type="button"
+          class={`rq-selector-btn${allActive ? ' active' : ''}`}
+          onClick={setAllForActive}
+        >{active === 'hero' ? `All ${heroLabel.toLowerCase()}s` : `All ${villainLabel.toLowerCase()}s`}</button>
+      </div>
     </div>
   );
 }

--- a/src/components/PositionTable.test.js
+++ b/src/components/PositionTable.test.js
@@ -13,28 +13,53 @@ describe('PositionTable — visual position selector', () => {
     }
   });
 
-  it('calls onSelect only for available seats — disabled seats cannot be clicked', () => {
-    expect(source).toMatch(/enabled\s*\?\s*\(\)\s*=>\s*onSelect\(seat\.id\)\s*:\s*undefined/);
+  it('selects hero and villain on the same chart — no second table instance', () => {
+    expect(source).toMatch(/heroSelected/);
+    expect(source).toMatch(/villainSelected/);
+    expect(source).toMatch(/onHeroSelect/);
+    expect(source).toMatch(/onVillainSelect/);
+  });
+
+  it('renders a dealer button chip near the BTN seat — so the button position is obvious', () => {
+    expect(source).toMatch(/pt-dealer-chip/);
+    // Chip must be derived from BTN_SEAT coordinates, not a magic pair.
+    expect(source).toMatch(/BTN_SEAT\.x\s*\+/);
+    expect(source).toMatch(/BTN_SEAT\.y\s*\+/);
+    // And it must actually be a filled yellow circle.
+    expect(source).toMatch(/fill="#f5e27a"/);
+  });
+
+  it('role tabs toggle which role a seat click targets', () => {
+    expect(source).toMatch(/role="tablist"/);
+    expect(source).toMatch(/setActiveRole\('hero'\)/);
+    expect(source).toMatch(/setActiveRole\('villain'\)/);
+    expect(source).toMatch(/active\s*===\s*'hero'/);
+  });
+
+  it('forces active role back to hero when villain is not applicable (e.g. RFI mode)', () => {
+    expect(source).toMatch(/!showVillain[\s\S]{0,120}setActiveRole\('hero'\)/);
+  });
+
+  it('ignores clicks on seats that are not in the active role\'s available set', () => {
+    expect(source).toMatch(/if\s*\(\s*!heroAvailSet\.has\(id\)\s*\)\s*return/);
+    expect(source).toMatch(/if\s*\(\s*!villainAvailSet\.has\(id\)\s*\)\s*return/);
   });
 
   it('supports keyboard activation (Enter/Space) for a11y', () => {
     expect(source).toMatch(/e\.key\s*===\s*'Enter'\s*\|\|\s*e\.key\s*===\s*' '/);
-    expect(source).toMatch(/onSelect\(seat\.id\)/);
+    expect(source).toMatch(/handleSeatClick\(seat\.id\)/);
   });
 
-  it('renders an "All Positions" option when allowAll is true', () => {
-    expect(source).toMatch(/allowAll\s*=\s*true/);
-    expect(source).toMatch(/All Positions/);
-    expect(source).toMatch(/onSelect\('all'\)/);
+  it('renders an "All" button for the currently active role', () => {
+    expect(source).toMatch(/setAllForActive/);
+    expect(source).toMatch(/onHeroSelect\('all'\)/);
+    expect(source).toMatch(/onVillainSelect\('all'\)/);
   });
 
-  it('highlights the selected seat and marks it aria-pressed', () => {
-    expect(source).toMatch(/aria-pressed/);
-    expect(source).toMatch(/active\s*=\s*enabled\s*&&\s*selected\s*===\s*seat\.id/);
-  });
-
-  it('visually dims seats that are not in the available set — no dead-click feedback', () => {
-    expect(source).toMatch(/availSet\.has\(seat\.id\)/);
-    expect(source).toMatch(/dimmed/);
+  it('distinguishes hero (gold) and villain (red) seats visually', () => {
+    expect(source).toMatch(/HERO_FILL\s*=\s*'#c9a84c'/);
+    expect(source).toMatch(/VILL_FILL/);
+    expect(source).toMatch(/pt-seat-hero/);
+    expect(source).toMatch(/pt-seat-villain/);
   });
 });

--- a/src/components/PositionTable.test.js
+++ b/src/components/PositionTable.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(resolve(__dirname, 'PositionTable.jsx'), 'utf8');
+
+describe('PositionTable — visual position selector', () => {
+  it('renders all six 6-max seats (UTG, HJ, CO, BTN, SB, BB)', () => {
+    for (const pos of ['UTG', 'HJ', 'CO', 'BTN', 'SB', 'BB']) {
+      expect(source).toMatch(new RegExp(`id:\\s*'${pos}'`));
+    }
+  });
+
+  it('calls onSelect only for available seats — disabled seats cannot be clicked', () => {
+    expect(source).toMatch(/enabled\s*\?\s*\(\)\s*=>\s*onSelect\(seat\.id\)\s*:\s*undefined/);
+  });
+
+  it('supports keyboard activation (Enter/Space) for a11y', () => {
+    expect(source).toMatch(/e\.key\s*===\s*'Enter'\s*\|\|\s*e\.key\s*===\s*' '/);
+    expect(source).toMatch(/onSelect\(seat\.id\)/);
+  });
+
+  it('renders an "All Positions" option when allowAll is true', () => {
+    expect(source).toMatch(/allowAll\s*=\s*true/);
+    expect(source).toMatch(/All Positions/);
+    expect(source).toMatch(/onSelect\('all'\)/);
+  });
+
+  it('highlights the selected seat and marks it aria-pressed', () => {
+    expect(source).toMatch(/aria-pressed/);
+    expect(source).toMatch(/active\s*=\s*enabled\s*&&\s*selected\s*===\s*seat\.id/);
+  });
+
+  it('visually dims seats that are not in the available set — no dead-click feedback', () => {
+    expect(source).toMatch(/availSet\.has\(seat\.id\)/);
+    expect(source).toMatch(/dimmed/);
+  });
+});

--- a/src/sections/preflop/Quiz.jsx
+++ b/src/sections/preflop/Quiz.jsx
@@ -387,25 +387,18 @@ export function PreflopQuiz({ query }) {
             ))}
           </div>
 
-          <div class="rq-setup-label">Your Position</div>
+          <div class="rq-setup-label">Positions</div>
           <PositionTable
-            selected={selectedPos}
-            available={getPositionsForMode(quizMode)}
-            onSelect={changePosition}
-            variant="hero"
+            heroSelected={selectedPos}
+            villainSelected={selectedVillainPos}
+            heroAvailable={getPositionsForMode(quizMode)}
+            villainAvailable={getVillainsForSelection(quizMode, selectedPos)}
+            onHeroSelect={changePosition}
+            onVillainSelect={changeVillainPosition}
+            showVillain={quizMode === 'limp' || quizMode === 'vsRaise'}
+            heroLabel="Your Position"
+            villainLabel={quizMode === 'limp' ? 'Limper' : 'Raiser'}
           />
-
-          {(quizMode === 'limp' || quizMode === 'vsRaise') && (
-            <>
-              <div class="rq-setup-label">{quizMode === 'limp' ? 'Limper' : 'Raiser'} Position</div>
-              <PositionTable
-                selected={selectedVillainPos}
-                available={getVillainsForSelection(quizMode, selectedPos)}
-                onSelect={changeVillainPosition}
-                variant="villain"
-              />
-            </>
-          )}
 
           <div class="rq-start-row">
             <button class="rq-start-btn" onClick={startQuiz}>Start Quiz</button>

--- a/src/sections/preflop/Quiz.jsx
+++ b/src/sections/preflop/Quiz.jsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect } from 'preact/hooks';
 import { SubNav } from '../../components/SubNav.jsx';
+import { PositionTable } from '../../components/PositionTable.jsx';
 import { RANKS, RFI_RANGES, RFI_QUIZ_LENGTH, RFI_QUIZ_POSITIONS, STACK_DEPTHS } from '../../data/rfi-ranges.js';
 import { LIMP_RANGES, LIMP_HERO_POSITIONS, VALID_LIMP_VILLAINS, VS_RAISE_RANGES, RAISE_HERO_POSITIONS, VALID_RAISE_VILLAINS } from '../../data/preflop-ranges.js';
 
@@ -387,36 +388,22 @@ export function PreflopQuiz({ query }) {
           </div>
 
           <div class="rq-setup-label">Your Position</div>
-          <div class="rq-selector-group">
-            <button
-              class={`rq-selector-btn${'all' === selectedPos ? ' active' : ''}`}
-              onClick={() => changePosition('all')}
-            >All</button>
-            {getPositionsForMode(quizMode).map(pos => (
-              <button
-                key={pos}
-                class={`rq-selector-btn${pos === selectedPos ? ' active' : ''}`}
-                onClick={() => changePosition(pos)}
-              >{pos}</button>
-            ))}
-          </div>
+          <PositionTable
+            selected={selectedPos}
+            available={getPositionsForMode(quizMode)}
+            onSelect={changePosition}
+            variant="hero"
+          />
 
           {(quizMode === 'limp' || quizMode === 'vsRaise') && (
             <>
               <div class="rq-setup-label">{quizMode === 'limp' ? 'Limper' : 'Raiser'} Position</div>
-              <div class="rq-selector-group">
-                <button
-                  class={`rq-selector-btn${'all' === selectedVillainPos ? ' active' : ''}`}
-                  onClick={() => changeVillainPosition('all')}
-                >All</button>
-                {getVillainsForSelection(quizMode, selectedPos).map(pos => (
-                  <button
-                    key={pos}
-                    class={`rq-selector-btn${pos === selectedVillainPos ? ' active' : ''}`}
-                    onClick={() => changeVillainPosition(pos)}
-                  >{pos}</button>
-                ))}
-              </div>
+              <PositionTable
+                selected={selectedVillainPos}
+                available={getVillainsForSelection(quizMode, selectedPos)}
+                onSelect={changeVillainPosition}
+                variant="villain"
+              />
             </>
           )}
 

--- a/src/styles/quiz.css
+++ b/src/styles/quiz.css
@@ -57,6 +57,19 @@
 .rq-selector-btn:hover:not(.active){color:var(--text);background:rgba(255,255,255,.07)}
 .rq-selector-btn.active{background:var(--gold-dark);color:var(--gold-bright);font-weight:600;
   border-color:var(--gold)}
+/* Visual position selector (table map) */
+.pt-wrap{margin:0 auto .6rem;max-width:420px}
+.pt-svg-wrap{position:relative;width:100%;line-height:0}
+.pt-svg{width:100%;height:auto;display:block;filter:drop-shadow(0 6px 14px rgba(0,0,0,.35))}
+.pt-seat{transition:transform .15s ease}
+.pt-seat-enabled{cursor:pointer}
+.pt-seat-enabled:hover circle{stroke:#f0d060;stroke-width:2}
+.pt-seat-enabled:focus{outline:none}
+.pt-seat-enabled:focus-visible circle{stroke:#f0d060;stroke-width:2.5}
+.pt-seat:not(.pt-seat-enabled){cursor:not-allowed}
+.pt-all-row{text-align:center;margin-top:.5rem}
+.pt-villain .pt-svg{filter:drop-shadow(0 6px 14px rgba(0,0,0,.35)) hue-rotate(-10deg)}
+
 .rq-start-row{text-align:center;margin:1.5rem 0 1rem}
 .rq-start-btn{padding:.7rem 2.5rem;background:var(--gold-dark);color:var(--gold-bright);
   border:none;border-radius:30px;font-family:'Crimson Pro',serif;font-size:1.1rem;

--- a/src/styles/quiz.css
+++ b/src/styles/quiz.css
@@ -58,7 +58,23 @@
 .rq-selector-btn.active{background:var(--gold-dark);color:var(--gold-bright);font-weight:600;
   border-color:var(--gold)}
 /* Visual position selector (table map) */
-.pt-wrap{margin:0 auto .6rem;max-width:420px}
+.pt-wrap{margin:0 auto .6rem;max-width:460px}
+.pt-roles{display:flex;gap:8px;justify-content:center;margin-bottom:.5rem;flex-wrap:wrap}
+.pt-role{display:inline-flex;flex-direction:column;align-items:center;gap:2px;
+  padding:.35rem .9rem;border-radius:14px;border:1px solid var(--gold-dark);
+  background:rgba(0,0,0,.3);color:var(--muted);
+  font-family:'Crimson Pro',serif;cursor:pointer;transition:all .2s;
+  min-width:120px}
+.pt-role:hover:not(.active){color:var(--text);background:rgba(255,255,255,.07)}
+.pt-role .pt-role-lbl{font-size:.7rem;letter-spacing:.08em;text-transform:uppercase;
+  color:var(--muted)}
+.pt-role .pt-role-val{font-size:1rem;font-weight:600;color:var(--text);line-height:1.1}
+.pt-role.active .pt-role-lbl{color:rgba(26,32,16,.75)}
+.pt-role-hero.active{background:var(--gold-dark);border-color:var(--gold);color:var(--gold-bright)}
+.pt-role-hero.active .pt-role-val{color:var(--gold-bright)}
+.pt-role-villain.active{background:#5a1e15;border-color:#e85c4a;color:#ffe7d9}
+.pt-role-villain.active .pt-role-lbl{color:rgba(255,231,217,.7)}
+.pt-role-villain.active .pt-role-val{color:#ffe7d9}
 .pt-svg-wrap{position:relative;width:100%;line-height:0}
 .pt-svg{width:100%;height:auto;display:block;filter:drop-shadow(0 6px 14px rgba(0,0,0,.35))}
 .pt-seat{transition:transform .15s ease}
@@ -67,8 +83,8 @@
 .pt-seat-enabled:focus{outline:none}
 .pt-seat-enabled:focus-visible circle{stroke:#f0d060;stroke-width:2.5}
 .pt-seat:not(.pt-seat-enabled){cursor:not-allowed}
+.pt-dealer-chip{pointer-events:none}
 .pt-all-row{text-align:center;margin-top:.5rem}
-.pt-villain .pt-svg{filter:drop-shadow(0 6px 14px rgba(0,0,0,.35)) hue-rotate(-10deg)}
 
 .rq-start-row{text-align:center;margin:1.5rem 0 1rem}
 .rq-start-btn{padding:.7rem 2.5rem;background:var(--gold-dark);color:var(--gold-bright);


### PR DESCRIPTION
Replaces the flat position chip rows in the Preflop Quiz setup with an
interactive 6-max poker table. Seats are clickable (and keyboard-activatable);
unavailable seats — e.g. villains that can't precede the chosen hero — are
dimmed and unclickable so the user can immediately see valid combinations.