### PR TITLE
Unify charts position selector with quiz table map

### DIFF
--- a/src/components/PositionTable.jsx
+++ b/src/components/PositionTable.jsx
@@ -29,6 +29,8 @@ export function PositionTable({
   onHeroSelect,
   onVillainSelect,
   showVillain = false,
+  showAllButtons = true,
+  autoSwitchRole = true,
   heroLabel = 'Your Position',
   villainLabel = 'Villain',
 }) {
@@ -47,20 +49,16 @@ export function PositionTable({
     if (active === 'hero') {
       if (!heroAvailSet.has(id)) return;
       onHeroSelect(id);
+      if (showVillain && autoSwitchRole) setActiveRole('villain');
     } else {
       if (!villainAvailSet.has(id)) return;
       onVillainSelect(id);
+      if (showVillain && autoSwitchRole) setActiveRole('hero');
     }
-  };
-
-  const setAllForActive = () => {
-    if (active === 'hero') onHeroSelect('all');
-    else onVillainSelect('all');
   };
 
   const heroIsAll    = heroSelected === 'all' || heroSelected == null;
   const villainIsAll = villainSelected === 'all' || villainSelected == null;
-  const allActive    = active === 'hero' ? heroIsAll : villainIsAll;
 
   return (
     <div class="pt-wrap">
@@ -163,13 +161,22 @@ export function PositionTable({
         </svg>
       </div>
 
-      <div class="pt-all-row">
-        <button
-          type="button"
-          class={`rq-selector-btn${allActive ? ' active' : ''}`}
-          onClick={setAllForActive}
-        >{active === 'hero' ? `All ${heroLabel.toLowerCase()}s` : `All ${villainLabel.toLowerCase()}s`}</button>
-      </div>
+      {showAllButtons && (
+        <div class="pt-all-row">
+          <button
+            type="button"
+            class={`rq-selector-btn pt-all-hero${heroIsAll ? ' active' : ''}`}
+            onClick={() => onHeroSelect('all')}
+          >All {heroLabel.toLowerCase()}s</button>
+          {showVillain && (
+            <button
+              type="button"
+              class={`rq-selector-btn pt-all-villain${villainIsAll ? ' active' : ''}`}
+              onClick={() => onVillainSelect('all')}
+            >All {villainLabel.toLowerCase()}s</button>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/PositionTable.test.js
+++ b/src/components/PositionTable.test.js
@@ -50,16 +50,46 @@ describe('PositionTable — visual position selector', () => {
     expect(source).toMatch(/handleSeatClick\(seat\.id\)/);
   });
 
-  it('renders an "All" button for the currently active role', () => {
-    expect(source).toMatch(/setAllForActive/);
-    expect(source).toMatch(/onHeroSelect\('all'\)/);
-    expect(source).toMatch(/onVillainSelect\('all'\)/);
-  });
-
   it('distinguishes hero (gold) and villain (red) seats visually', () => {
     expect(source).toMatch(/HERO_FILL\s*=\s*'#c9a84c'/);
     expect(source).toMatch(/VILL_FILL/);
     expect(source).toMatch(/pt-seat-hero/);
     expect(source).toMatch(/pt-seat-villain/);
+  });
+
+  // ── New behavior: auto-switch active role after a seat click ────────────
+  it('auto-switches to villain after a hero seat is picked — so user flows hero → villain without clicking the role tab', () => {
+    expect(source).toMatch(/onHeroSelect\(id\);[\s\S]{0,120}setActiveRole\('villain'\)/);
+  });
+
+  it('auto-switches back to hero after a villain seat is picked — so user flows villain → hero next', () => {
+    expect(source).toMatch(/onVillainSelect\(id\);[\s\S]{0,120}setActiveRole\('hero'\)/);
+  });
+
+  it('auto-switch only fires when showVillain is true — otherwise there is no other role to switch to', () => {
+    expect(source).toMatch(/showVillain\s*&&\s*autoSwitchRole/);
+  });
+
+  it('auto-switch can be disabled via the autoSwitchRole prop', () => {
+    expect(source).toMatch(/autoSwitchRole\s*=\s*true/);
+  });
+
+  // ── New behavior: two separate "All" buttons (hero + villain) ──────────
+  it('renders separate "All" buttons for hero and villain — both accessible without toggling the active role', () => {
+    // Hero "All" button calls onHeroSelect('all').
+    expect(source).toMatch(/onHeroSelect\('all'\)/);
+    // Villain "All" button calls onVillainSelect('all').
+    expect(source).toMatch(/onVillainSelect\('all'\)/);
+    // Both buttons must live inside the same pt-all-row container.
+    expect(source).toMatch(/pt-all-row[\s\S]+onHeroSelect\('all'\)[\s\S]+onVillainSelect\('all'\)/);
+  });
+
+  it('the villain "All" button only renders when showVillain is true', () => {
+    expect(source).toMatch(/showVillain\s*&&\s*\(\s*<button[\s\S]+?onVillainSelect\('all'\)/);
+  });
+
+  it('the All-buttons row can be hidden via the showAllButtons prop (for chart use where "All" is not meaningful)', () => {
+    expect(source).toMatch(/showAllButtons\s*=\s*true/);
+    expect(source).toMatch(/showAllButtons\s*&&\s*\(/);
   });
 });

--- a/src/sections/preflop/Charts.jsx
+++ b/src/sections/preflop/Charts.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'preact/hooks';
 import { SubNav } from '../../components/SubNav.jsx';
+import { PositionTable } from '../../components/PositionTable.jsx';
 import { RANKS, RFI_RANGES, POS_LIST, STACK_DEPTHS } from '../../data/rfi-ranges.js';
 import '../../styles/charts.css';
 
@@ -33,17 +34,14 @@ export function Charts({ path }) {
             </button>
           ))}
         </div>
-        <div class="pos-tabs">
-          {POS_LIST.map(p => (
-            <button
-              key={p}
-              class={`pos-tab${p === activePos ? ' active' : ''}`}
-              onClick={() => setActivePos(p)}
-            >
-              {p}
-            </button>
-          ))}
-        </div>
+        <PositionTable
+          heroSelected={activePos}
+          heroAvailable={POS_LIST}
+          onHeroSelect={setActivePos}
+          showVillain={false}
+          showAllButtons={false}
+          heroLabel="Your Position"
+        />
         <div class="rfi-grid">
           <div class="rfi-cell rfi-hdr"></div>
           {RANKS.map(r => (

--- a/src/sections/preflop/LimpCharts.jsx
+++ b/src/sections/preflop/LimpCharts.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'preact/hooks';
 import { SubNav } from '../../components/SubNav.jsx';
+import { PositionTable } from '../../components/PositionTable.jsx';
 import { RANKS, STACK_DEPTHS } from '../../data/rfi-ranges.js';
 import { LIMP_HERO_POSITIONS, VALID_LIMP_VILLAINS, LIMP_RANGES } from '../../data/preflop-ranges.js';
 import '../../styles/charts.css';
@@ -38,20 +39,18 @@ export function LimpCharts() {
           ))}
         </div>
 
-        <div class="pos-selectors">
-          <div class="pos-selector-group">
-            <span class="pos-selector-label">Your Position</span>
-            <select class="pos-selector-select" value={heroPos} onChange={e => changeHero(e.target.value)}>
-              {LIMP_HERO_POSITIONS.map(p => <option key={p} value={p}>{p}</option>)}
-            </select>
-          </div>
-          <div class="pos-selector-group">
-            <span class="pos-selector-label">Limper Position</span>
-            <select class="pos-selector-select" value={villainPos} onChange={e => setVillainPos(e.target.value)}>
-              {validVillains.map(p => <option key={p} value={p}>{p}</option>)}
-            </select>
-          </div>
-        </div>
+        <PositionTable
+          heroSelected={heroPos}
+          villainSelected={villainPos}
+          heroAvailable={LIMP_HERO_POSITIONS}
+          villainAvailable={validVillains}
+          onHeroSelect={changeHero}
+          onVillainSelect={setVillainPos}
+          showVillain={true}
+          showAllButtons={false}
+          heroLabel="Your Position"
+          villainLabel="Limper"
+        />
 
         {!rangeSet ? (
           <p style="text-align:center;color:var(--muted);padding:2rem">Select positions above to view chart.</p>

--- a/src/sections/preflop/RaiseCharts.jsx
+++ b/src/sections/preflop/RaiseCharts.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'preact/hooks';
 import { SubNav } from '../../components/SubNav.jsx';
+import { PositionTable } from '../../components/PositionTable.jsx';
 import { RANKS, STACK_DEPTHS } from '../../data/rfi-ranges.js';
 import { RAISE_HERO_POSITIONS, VALID_RAISE_VILLAINS, VS_RAISE_RANGES } from '../../data/preflop-ranges.js';
 import '../../styles/charts.css';
@@ -38,20 +39,18 @@ export function RaiseCharts() {
           ))}
         </div>
 
-        <div class="pos-selectors">
-          <div class="pos-selector-group">
-            <span class="pos-selector-label">Your Position</span>
-            <select class="pos-selector-select" value={heroPos} onChange={e => changeHero(e.target.value)}>
-              {RAISE_HERO_POSITIONS.map(p => <option key={p} value={p}>{p}</option>)}
-            </select>
-          </div>
-          <div class="pos-selector-group">
-            <span class="pos-selector-label">Raiser Position</span>
-            <select class="pos-selector-select" value={villainPos} onChange={e => setVillainPos(e.target.value)}>
-              {validVillains.map(p => <option key={p} value={p}>{p}</option>)}
-            </select>
-          </div>
-        </div>
+        <PositionTable
+          heroSelected={heroPos}
+          villainSelected={villainPos}
+          heroAvailable={RAISE_HERO_POSITIONS}
+          villainAvailable={validVillains}
+          onHeroSelect={changeHero}
+          onVillainSelect={setVillainPos}
+          showVillain={true}
+          showAllButtons={false}
+          heroLabel="Your Position"
+          villainLabel="Raiser"
+        />
 
         {!rangeSet ? (
           <p style="text-align:center;color:var(--muted);padding:2rem">Select positions above to view chart.</p>

--- a/src/styles/charts.css
+++ b/src/styles/charts.css
@@ -13,15 +13,6 @@
 .charts-title{font-family:'Playfair Display',serif;font-size:clamp(1.3rem,3vw,1.8rem);
   color:var(--gold-bright);text-align:center;margin-bottom:.3rem}
 .charts-sub{color:var(--muted);text-align:center;font-size:.95rem;margin-bottom:1.2rem}
-.pos-tabs{display:flex;justify-content:center;gap:8px;margin-bottom:1.2rem;
-  flex-wrap:wrap;max-width:500px;margin-left:auto;margin-right:auto}
-.pos-tab{padding:.5rem .9rem;border-radius:20px;border:1px solid var(--gold-dark);
-  background:rgba(0,0,0,.3);color:var(--muted);font-family:'Crimson Pro',serif;
-  font-size:.9rem;cursor:pointer;transition:all .25s;letter-spacing:.03em;
-  white-space:nowrap}
-.pos-tab.active{background:var(--gold-dark);color:var(--gold-bright);font-weight:600;
-  border-color:var(--gold)}
-.pos-tab:hover:not(.active){color:var(--text);background:rgba(255,255,255,.07)}
 .rfi-grid{display:grid;grid-template-columns:repeat(14,1fr);gap:2px;margin-bottom:1rem;
   font-size:clamp(.55rem,1.4vw,.8rem);text-align:center}
 .rfi-cell{padding:clamp(2px,0.5vw,6px) 1px;border-radius:3px;font-family:'Crimson Pro',serif;
@@ -38,11 +29,5 @@
   font-style:italic}
 .rfi-call{background:rgba(52,152,219,.22);color:#a8d8f0;border:1px solid rgba(52,152,219,.25)}
 .rfi-legend .sw-call{background:rgba(52,152,219,.22);border:1px solid rgba(52,152,219,.25)}
-.pos-selectors{display:flex;justify-content:center;gap:1.5rem;margin-bottom:1rem;flex-wrap:wrap}
-.pos-selector-group{display:flex;flex-direction:column;align-items:center;gap:.3rem}
-.pos-selector-label{font-size:.75rem;color:var(--muted);letter-spacing:.08em;text-transform:uppercase}
-.pos-selector-select{background:rgba(0,0,0,.4);color:var(--gold-bright);border:1px solid var(--gold-dark);
-  border-radius:8px;padding:.35rem .7rem;font-family:'Crimson Pro',serif;font-size:.95rem;cursor:pointer}
-.pos-selector-select:focus{outline:none;border-color:var(--gold)}
 .rfi-legend-item{display:flex;align-items:center;gap:.4rem}
 .rfi-swatch{width:14px;height:14px;border-radius:3px;display:inline-block}

--- a/src/styles/quiz.css
+++ b/src/styles/quiz.css
@@ -84,7 +84,8 @@
 .pt-seat-enabled:focus-visible circle{stroke:#f0d060;stroke-width:2.5}
 .pt-seat:not(.pt-seat-enabled){cursor:not-allowed}
 .pt-dealer-chip{pointer-events:none}
-.pt-all-row{text-align:center;margin-top:.5rem}
+.pt-all-row{text-align:center;margin-top:.5rem;display:flex;justify-content:center;
+  gap:8px;flex-wrap:wrap}
 
 .rq-start-row{text-align:center;margin:1.5rem 0 1rem}
 .rq-start-btn{padding:.7rem 2.5rem;background:var(--gold-dark);color:var(--gold-bright);


### PR DESCRIPTION
Charts (RFI, vs Limp, vs Raise) now use the same PositionTable visual
selector as the quiz setup, replacing the button pill bar and the
dropdown pair. PositionTable now auto-switches the active role to the
opposite side after a seat click (hero → villain, villain → hero) so
users can pick both sides without toggling the role tab, and it
exposes hero and villain "All" buttons as two separate controls
instead of one context-sensitive button.