### PR TITLE
Add descriptive paragraph below each preflop chart

### DIFF
--- a/src/sections/preflop/Charts.jsx
+++ b/src/sections/preflop/Charts.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'preact/hooks';
 import { SubNav } from '../../components/SubNav.jsx';
 import { RANKS, RFI_RANGES, POS_LIST, STACK_DEPTHS } from '../../data/rfi-ranges.js';
+import { describeRfi } from '../../utils/range-description.js';
 import '../../styles/charts.css';
 
 const TABS = [
@@ -72,6 +73,10 @@ export function Charts({ path }) {
           <span class="rfi-legend-item"><span class="rfi-swatch rfi-raise"></span> Raise ({raiseCount} combos, {pct}%)</span>
           <span class="rfi-legend-item"><span class="rfi-swatch rfi-fold"></span> Fold</span>
         </div>
+        <p class="range-desc">
+          <span class="range-desc-label">{activePos} · {stackDepth}:</span>{' '}
+          {describeRfi(range)}
+        </p>
       </div>
     </div>
   );

--- a/src/sections/preflop/LimpCharts.jsx
+++ b/src/sections/preflop/LimpCharts.jsx
@@ -2,6 +2,7 @@ import { useState } from 'preact/hooks';
 import { SubNav } from '../../components/SubNav.jsx';
 import { RANKS, STACK_DEPTHS } from '../../data/rfi-ranges.js';
 import { LIMP_HERO_POSITIONS, VALID_LIMP_VILLAINS, LIMP_RANGES } from '../../data/preflop-ranges.js';
+import { describeLimp } from '../../utils/range-description.js';
 import '../../styles/charts.css';
 
 const TABS = [
@@ -83,6 +84,10 @@ export function LimpCharts() {
               <span class="rfi-legend-item"><span class="rfi-swatch rfi-call"></span> {heroPos === 'BB' ? 'Check' : 'Call'} ({callCount}, {Math.round(callCount/totalCombos*100)}%)</span>
               <span class="rfi-legend-item"><span class="rfi-swatch rfi-fold"></span> Fold</span>
             </div>
+            <p class="range-desc">
+              <span class="range-desc-label">{heroPos} vs {villainPos} limp · {stackDepth}:</span>{' '}
+              {describeLimp(rangeSet, heroPos === 'BB')}
+            </p>
           </>
         )}
       </div>

--- a/src/sections/preflop/RaiseCharts.jsx
+++ b/src/sections/preflop/RaiseCharts.jsx
@@ -2,6 +2,7 @@ import { useState } from 'preact/hooks';
 import { SubNav } from '../../components/SubNav.jsx';
 import { RANKS, STACK_DEPTHS } from '../../data/rfi-ranges.js';
 import { RAISE_HERO_POSITIONS, VALID_RAISE_VILLAINS, VS_RAISE_RANGES } from '../../data/preflop-ranges.js';
+import { describeVsRaise } from '../../utils/range-description.js';
 import '../../styles/charts.css';
 
 const TABS = [
@@ -83,6 +84,10 @@ export function RaiseCharts() {
               <span class="rfi-legend-item"><span class="rfi-swatch rfi-call"></span> Call ({callCount}, {Math.round(callCount/totalCombos*100)}%)</span>
               <span class="rfi-legend-item"><span class="rfi-swatch rfi-fold"></span> Fold</span>
             </div>
+            <p class="range-desc">
+              <span class="range-desc-label">{heroPos} vs {villainPos} raise · {stackDepth}:</span>{' '}
+              {describeVsRaise(rangeSet)}
+            </p>
           </>
         )}
       </div>

--- a/src/styles/charts.css
+++ b/src/styles/charts.css
@@ -43,3 +43,8 @@
 .pos-selector-select:focus{outline:none;border-color:var(--gold)}
 .rfi-legend-item{display:flex;align-items:center;gap:.4rem}
 .rfi-swatch{width:14px;height:14px;border-radius:3px;display:inline-block}
+.range-desc{color:var(--text);font-family:'Crimson Pro',serif;font-size:.9rem;line-height:1.5;
+  max-width:860px;margin:1rem auto 0;padding:.85rem 1.1rem;
+  background:rgba(0,0,0,.25);border:1px solid var(--gold-dark);border-radius:10px;
+  text-align:left}
+.range-desc-label{color:var(--gold-bright);font-weight:600;letter-spacing:.03em}

--- a/src/utils/range-description.js
+++ b/src/utils/range-description.js
@@ -1,0 +1,91 @@
+// Convert a Set of poker hands (e.g. {'AA','KK','AKs','A5s','AKo'}) to a
+// compact human-readable description using standard poker "+" / dash notation.
+// Handles pairs, suited (s), and offsuit (o) groupings.
+
+const RANK_ORDER = ['A','K','Q','J','T','9','8','7','6','5','4','3','2'];
+const RANK_IDX = Object.fromEntries(RANK_ORDER.map((r, i) => [r, i]));
+
+function formatGroup(hands, isPair) {
+  if (hands.length === 0) return '';
+
+  const runs = [];
+  let cur = [hands[0]];
+  for (let i = 1; i < hands.length; i++) {
+    const prev = hands[i - 1];
+    const next = hands[i];
+    const prevKicker = isPair ? prev[0] : prev[1];
+    const nextKicker = isPair ? next[0] : next[1];
+    if (RANK_IDX[nextKicker] === RANK_IDX[prevKicker] + 1) {
+      cur.push(next);
+    } else {
+      runs.push(cur);
+      cur = [next];
+    }
+  }
+  runs.push(cur);
+
+  return runs.map((run, idx) => {
+    if (run.length === 1) return run[0];
+    if (idx === 0) {
+      const first = run[0];
+      const topKicker = isPair ? 'A' : 'K';
+      const firstKicker = isPair ? first[0] : first[1];
+      if (firstKicker === topKicker) {
+        return `${run[run.length - 1]}+`;
+      }
+    }
+    return `${run[0]}–${run[run.length - 1]}`;
+  }).join(', ');
+}
+
+export function describeHands(handsSet) {
+  if (!handsSet || handsSet.size === 0) return 'none';
+
+  const pairs = [];
+  const suited = {};
+  const offsuit = {};
+
+  for (const h of handsSet) {
+    if (h.length === 2) {
+      pairs.push(h);
+    } else if (h.endsWith('s')) {
+      const t = h[0];
+      (suited[t] = suited[t] || []).push(h);
+    } else if (h.endsWith('o')) {
+      const t = h[0];
+      (offsuit[t] = offsuit[t] || []).push(h);
+    }
+  }
+
+  pairs.sort((a, b) => RANK_IDX[a[0]] - RANK_IDX[b[0]]);
+  for (const t in suited) suited[t].sort((a, b) => RANK_IDX[a[1]] - RANK_IDX[b[1]]);
+  for (const t in offsuit) offsuit[t].sort((a, b) => RANK_IDX[a[1]] - RANK_IDX[b[1]]);
+
+  const sections = [];
+  if (pairs.length > 0) sections.push(formatGroup(pairs, true));
+  for (const t of RANK_ORDER) {
+    if (suited[t]) sections.push(formatGroup(suited[t], false));
+  }
+  for (const t of RANK_ORDER) {
+    if (offsuit[t]) sections.push(formatGroup(offsuit[t], false));
+  }
+
+  return sections.join('; ');
+}
+
+export function describeRfi(rangeSet) {
+  return `Open-raise ${describeHands(rangeSet)}; fold everything else.`;
+}
+
+export function describeLimp(rangeSet, heroIsBB) {
+  const raise = describeHands(rangeSet.raise);
+  const call = describeHands(rangeSet.call);
+  const callVerb = heroIsBB ? 'Check' : 'Call';
+  return `Iso-raise ${raise}. ${callVerb} behind with ${call}. Fold everything else.`;
+}
+
+export function describeVsRaise(rangeSet) {
+  const threebet = describeHands(rangeSet.threebet);
+  const call = describeHands(rangeSet.call);
+  return `3-bet ${threebet}. Flat-call ${call}. Fold everything else.`;
+}

--- a/src/utils/range-description.js
+++ b/src/utils/range-description.js
@@ -1,91 +1,255 @@
-// Convert a Set of poker hands (e.g. {'AA','KK','AKs','A5s','AKo'}) to a
-// compact human-readable description using standard poker "+" / dash notation.
-// Handles pairs, suited (s), and offsuit (o) groupings.
+// Convert a Set of poker hands (e.g. {'AA','KK','AKs','A5s','AKo'}) into
+// a memorization-friendly natural-language description that groups hands
+// into recognizable poker categories (pairs, broadways, wheel aces,
+// suited connectors, one-gappers, etc.).
 
 const RANK_ORDER = ['A','K','Q','J','T','9','8','7','6','5','4','3','2'];
 const RANK_IDX = Object.fromEntries(RANK_ORDER.map((r, i) => [r, i]));
+const BROADWAY = new Set(['A','K','Q','J','T']);
 
-function formatGroup(hands, isPair) {
+// Collapse a sorted (highest-kicker-first) list of hands sharing one top card
+// into prose like "ATs+", "K9s–K5s", or "97s, 75s".
+//   topPlusKicker: which kicker triggers the "+" notation (e.g. 'K' for Axs).
+function compactRun(hands, isPair, topPlusKicker) {
   if (hands.length === 0) return '';
-
   const runs = [];
   let cur = [hands[0]];
   for (let i = 1; i < hands.length; i++) {
-    const prev = hands[i - 1];
-    const next = hands[i];
-    const prevKicker = isPair ? prev[0] : prev[1];
-    const nextKicker = isPair ? next[0] : next[1];
-    if (RANK_IDX[nextKicker] === RANK_IDX[prevKicker] + 1) {
-      cur.push(next);
-    } else {
-      runs.push(cur);
-      cur = [next];
-    }
+    const prevK = isPair ? hands[i - 1][0] : hands[i - 1][1];
+    const nextK = isPair ? hands[i][0] : hands[i][1];
+    if (RANK_IDX[nextK] === RANK_IDX[prevK] + 1) cur.push(hands[i]);
+    else { runs.push(cur); cur = [hands[i]]; }
   }
   runs.push(cur);
 
   return runs.map((run, idx) => {
     if (run.length === 1) return run[0];
-    if (idx === 0) {
-      const first = run[0];
-      const topKicker = isPair ? 'A' : 'K';
-      const firstKicker = isPair ? first[0] : first[1];
-      if (firstKicker === topKicker) {
-        return `${run[run.length - 1]}+`;
-      }
-    }
+    const firstK = isPair ? run[0][0] : run[0][1];
+    if (idx === 0 && firstK === topPlusKicker) return `${run[run.length - 1]}+`;
     return `${run[0]}–${run[run.length - 1]}`;
   }).join(', ');
 }
 
+function joinList(items, conj = 'and') {
+  const xs = items.filter(Boolean);
+  if (xs.length === 0) return '';
+  if (xs.length === 1) return xs[0];
+  if (xs.length === 2) return `${xs[0]} ${conj} ${xs[1]}`;
+  return `${xs.slice(0, -1).join(', ')}, ${conj} ${xs[xs.length - 1]}`;
+}
+
+// --- bucket builders -------------------------------------------------------
+
+function pairsClause(pairs) {
+  if (pairs.length === 0) return null;
+  if (pairs.length === 13) return 'all pairs';
+  const sorted = [...pairs].sort((a, b) => RANK_IDX[a[0]] - RANK_IDX[b[0]]);
+  return `pairs ${compactRun(sorted, true, 'A')}`;
+}
+
+function axsClause(axs) {
+  if (axs.length === 0) return null;
+  const sorted = [...axs].sort((a, b) => RANK_IDX[a[1]] - RANK_IDX[b[1]]);
+  const top = sorted.filter(h => RANK_IDX[h[1]] <= RANK_IDX['T']); // AKs..ATs
+  const mid = sorted.filter(h => RANK_IDX[h[1]] > RANK_IDX['T'] && RANK_IDX[h[1]] < RANK_IDX['5']); // A9s..A6s
+  const wheel = sorted.filter(h => RANK_IDX[h[1]] >= RANK_IDX['5']); // A5s..A2s
+
+  if (sorted.length === 12) return 'every suited ace';
+
+  const parts = [];
+  if (top.length) parts.push(`suited aces ${compactRun(top, false, 'K')}`);
+  if (mid.length) parts.push(compactRun(mid, false, 'K'));
+  if (wheel.length === 4) parts.push('the wheel suited aces (A5s–A2s)');
+  else if (wheel.length) parts.push(`wheel ${compactRun(wheel, false, 'K')}`);
+  return joinList(parts, 'plus');
+}
+
+function suitedBroadwaysClause(suitedByTop) {
+  const broad = ['K', 'Q', 'J'].flatMap(t =>
+    (suitedByTop[t] || []).filter(h => BROADWAY.has(h[1]))
+  );
+  if (broad.length === 0) return null;
+  if (broad.length === 6) return 'all suited broadways (KQs–JTs)';
+
+  const parts = [];
+  for (const t of ['K', 'Q', 'J']) {
+    const list = (suitedByTop[t] || []).filter(h => BROADWAY.has(h[1]))
+      .sort((a, b) => RANK_IDX[a[1]] - RANK_IDX[b[1]]);
+    if (list.length === 0) continue;
+    parts.push(compactRun(list, false, { K: 'Q', Q: 'J', J: 'T' }[t]));
+  }
+  return `suited broadways ${parts.join(', ')}`;
+}
+
+// Suited high-card hands with one broadway + one non-broadway kicker
+// (K9s–K2s, Q9s–Q2s, J9s–J2s). T-top hands belong in connectors below.
+function suitedHighNonBroadwayClause(suitedByTop) {
+  const parts = [];
+  for (const t of ['K', 'Q', 'J']) {
+    const list = (suitedByTop[t] || [])
+      .filter(h => !BROADWAY.has(h[1]))
+      .sort((a, b) => RANK_IDX[a[1]] - RANK_IDX[b[1]]);
+    if (list.length === 0) continue;
+    parts.push(compactRun(list, false, '9'));
+  }
+  if (parts.length === 0) return null;
+  return `suited ${parts.join(', ')}`;
+}
+
+// Suited connectors / gappers — hands whose top card is T or lower
+// (T9s, 98s, 87s, ... and their gap variants).
+function suitedConnectorsClause(suitedByTop) {
+  const lows = [];
+  for (const t of RANK_ORDER) {
+    if (t === 'A' || t === 'K' || t === 'Q' || t === 'J') continue;
+    for (const h of suitedByTop[t] || []) lows.push(h);
+  }
+  if (lows.length === 0) return null;
+
+  const byGap = { 0: [], 1: [], 2: [], 3: [] };
+  for (const h of lows) {
+    const gap = RANK_IDX[h[1]] - RANK_IDX[h[0]] - 1;
+    if (gap >= 0 && gap <= 3) byGap[gap].push(h);
+  }
+  // Sort each by top rank descending (98s first, 32s last).
+  for (const g of [0, 1, 2, 3]) {
+    byGap[g].sort((a, b) => RANK_IDX[a[0]] - RANK_IDX[b[0]]);
+  }
+
+  const labels = { 0: 'suited connectors', 1: 'one-gappers', 2: 'two-gappers', 3: 'three-gappers' };
+  const parts = [];
+  for (const g of [0, 1, 2, 3]) {
+    const list = byGap[g];
+    if (list.length === 0) continue;
+    if (list.length === 1) {
+      parts.push(`${labels[g]} ${list[0]}`);
+    } else {
+      // Try to express as a contiguous "98s–54s" if tops form a run.
+      const tops = list.map(h => RANK_IDX[h[0]]);
+      let contiguous = true;
+      for (let i = 1; i < tops.length; i++) if (tops[i] !== tops[i - 1] + 1) { contiguous = false; break; }
+      if (contiguous) parts.push(`${labels[g]} ${list[0]}–${list[list.length - 1]}`);
+      else parts.push(`${labels[g]} ${list.join(', ')}`);
+    }
+  }
+  return joinList(parts, 'plus');
+}
+
+function axoClause(axo) {
+  if (axo.length === 0) return null;
+  const sorted = [...axo].sort((a, b) => RANK_IDX[a[1]] - RANK_IDX[b[1]]);
+  if (sorted.length === 12) return 'every offsuit ace';
+  const strong = sorted.filter(h => RANK_IDX[h[1]] <= RANK_IDX['T']);
+  const weak = sorted.filter(h => RANK_IDX[h[1]] > RANK_IDX['T']);
+
+  const parts = [];
+  if (strong.length) parts.push(`offsuit aces ${compactRun(strong, false, 'K')}`);
+  if (weak.length) parts.push(`weak offsuit aces ${compactRun(weak, false, '9')}`);
+  return joinList(parts, 'plus');
+}
+
+function offsuitBroadwaysClause(offsuitByTop) {
+  const broad = ['K', 'Q', 'J'].flatMap(t =>
+    (offsuitByTop[t] || []).filter(h => BROADWAY.has(h[1]))
+  );
+  if (broad.length === 0) return null;
+  if (broad.length === 6) return 'all offsuit broadways (KQo–JTo)';
+
+  const parts = [];
+  for (const t of ['K', 'Q', 'J']) {
+    const list = (offsuitByTop[t] || []).filter(h => BROADWAY.has(h[1]))
+      .sort((a, b) => RANK_IDX[a[1]] - RANK_IDX[b[1]]);
+    if (list.length === 0) continue;
+    parts.push(compactRun(list, false, { K: 'Q', Q: 'J', J: 'T' }[t]));
+  }
+  return `offsuit broadways ${parts.join(', ')}`;
+}
+
+function offsuitHighNonBroadwayClause(offsuitByTop) {
+  const parts = [];
+  for (const t of ['K', 'Q', 'J']) {
+    const list = (offsuitByTop[t] || [])
+      .filter(h => !BROADWAY.has(h[1]))
+      .sort((a, b) => RANK_IDX[a[1]] - RANK_IDX[b[1]]);
+    if (list.length === 0) continue;
+    parts.push(compactRun(list, false, '9'));
+  }
+  if (parts.length === 0) return null;
+  return `offsuit ${parts.join(', ')}`;
+}
+
+function offsuitConnectorsClause(offsuitByTop) {
+  const lows = [];
+  for (const t of RANK_ORDER) {
+    if (t === 'A' || t === 'K' || t === 'Q' || t === 'J') continue;
+    for (const h of offsuitByTop[t] || []) lows.push(h);
+  }
+  if (lows.length === 0) return null;
+
+  const byGap = { 0: [], 1: [], 2: [], 3: [] };
+  for (const h of lows) {
+    const gap = RANK_IDX[h[1]] - RANK_IDX[h[0]] - 1;
+    if (gap >= 0 && gap <= 3) byGap[gap].push(h);
+  }
+  for (const g of [0, 1, 2, 3]) {
+    byGap[g].sort((a, b) => RANK_IDX[a[0]] - RANK_IDX[b[0]]);
+  }
+
+  const labels = { 0: 'offsuit connectors', 1: 'offsuit one-gappers', 2: 'offsuit two-gappers', 3: 'offsuit three-gappers' };
+  const parts = [];
+  for (const g of [0, 1, 2, 3]) {
+    const list = byGap[g];
+    if (list.length === 0) continue;
+    if (list.length === 1) { parts.push(`${labels[g]} ${list[0]}`); continue; }
+    const tops = list.map(h => RANK_IDX[h[0]]);
+    let contiguous = true;
+    for (let i = 1; i < tops.length; i++) if (tops[i] !== tops[i - 1] + 1) { contiguous = false; break; }
+    parts.push(contiguous
+      ? `${labels[g]} ${list[0]}–${list[list.length - 1]}`
+      : `${labels[g]} ${list.join(', ')}`);
+  }
+  return joinList(parts, 'plus');
+}
+
+// --- public API ------------------------------------------------------------
+
 export function describeHands(handsSet) {
-  if (!handsSet || handsSet.size === 0) return 'none';
+  if (!handsSet || handsSet.size === 0) return 'nothing';
 
   const pairs = [];
   const suited = {};
   const offsuit = {};
-
   for (const h of handsSet) {
-    if (h.length === 2) {
-      pairs.push(h);
-    } else if (h.endsWith('s')) {
-      const t = h[0];
-      (suited[t] = suited[t] || []).push(h);
-    } else if (h.endsWith('o')) {
-      const t = h[0];
-      (offsuit[t] = offsuit[t] || []).push(h);
-    }
+    if (h.length === 2) pairs.push(h);
+    else if (h.endsWith('s')) (suited[h[0]] = suited[h[0]] || []).push(h);
+    else if (h.endsWith('o')) (offsuit[h[0]] = offsuit[h[0]] || []).push(h);
   }
 
-  pairs.sort((a, b) => RANK_IDX[a[0]] - RANK_IDX[b[0]]);
-  for (const t in suited) suited[t].sort((a, b) => RANK_IDX[a[1]] - RANK_IDX[b[1]]);
-  for (const t in offsuit) offsuit[t].sort((a, b) => RANK_IDX[a[1]] - RANK_IDX[b[1]]);
+  const clauses = [
+    pairsClause(pairs),
+    axsClause(suited['A'] || []),
+    suitedBroadwaysClause(suited),
+    suitedHighNonBroadwayClause(suited),
+    suitedConnectorsClause(suited),
+    axoClause(offsuit['A'] || []),
+    offsuitBroadwaysClause(offsuit),
+    offsuitHighNonBroadwayClause(offsuit),
+    offsuitConnectorsClause(offsuit),
+  ].filter(Boolean);
 
-  const sections = [];
-  if (pairs.length > 0) sections.push(formatGroup(pairs, true));
-  for (const t of RANK_ORDER) {
-    if (suited[t]) sections.push(formatGroup(suited[t], false));
-  }
-  for (const t of RANK_ORDER) {
-    if (offsuit[t]) sections.push(formatGroup(offsuit[t], false));
-  }
-
-  return sections.join('; ');
+  if (clauses.length === 0) return 'nothing';
+  return clauses.join('; ');
 }
 
 export function describeRfi(rangeSet) {
-  return `Open-raise ${describeHands(rangeSet)}; fold everything else.`;
+  return `Open ${describeHands(rangeSet)}. Fold everything else.`;
 }
 
 export function describeLimp(rangeSet, heroIsBB) {
-  const raise = describeHands(rangeSet.raise);
-  const call = describeHands(rangeSet.call);
-  const callVerb = heroIsBB ? 'Check' : 'Call';
-  return `Iso-raise ${raise}. ${callVerb} behind with ${call}. Fold everything else.`;
+  const callVerb = heroIsBB ? 'Check behind with' : 'Call behind with';
+  return `Iso-raise ${describeHands(rangeSet.raise)}. ${callVerb} ${describeHands(rangeSet.call)}. Fold the rest.`;
 }
 
 export function describeVsRaise(rangeSet) {
-  const threebet = describeHands(rangeSet.threebet);
-  const call = describeHands(rangeSet.call);
-  return `3-bet ${threebet}. Flat-call ${call}. Fold everything else.`;
+  return `3-bet ${describeHands(rangeSet.threebet)}. Flat-call ${describeHands(rangeSet.call)}. Fold the rest.`;
 }

--- a/src/utils/range-description.test.js
+++ b/src/utils/range-description.test.js
@@ -1,42 +1,76 @@
 import { describe, it, expect } from 'vitest';
 import { describeHands, describeRfi, describeLimp, describeVsRaise } from './range-description.js';
+import { RFI_RANGES } from '../data/rfi-ranges.js';
 
 describe('describeHands', () => {
-  it('returns "none" for empty set', () => {
-    expect(describeHands(new Set())).toBe('none');
-    expect(describeHands(null)).toBe('none');
+  it('returns "nothing" for empty or missing sets', () => {
+    expect(describeHands(new Set())).toBe('nothing');
+    expect(describeHands(null)).toBe('nothing');
   });
 
-  it('collapses contiguous pairs from AA into "XX+"', () => {
+  it('collapses a contiguous pair run from AA into "pairs XX+"', () => {
     const s = new Set(['AA', 'KK', 'QQ', 'JJ', 'TT', '99']);
-    expect(describeHands(s)).toBe('99+');
+    expect(describeHands(s)).toBe('pairs 99+');
   });
 
-  it('uses dash range for non-prefix pair runs', () => {
+  it('uses "all pairs" when all 13 pocket pairs are present', () => {
+    const all = new Set(['AA','KK','QQ','JJ','TT','99','88','77','66','55','44','33','22']);
+    expect(describeHands(all)).toBe('all pairs');
+  });
+
+  it('uses dash notation for non-prefix pair runs', () => {
     const s = new Set(['JJ', 'TT', '99', '77']);
-    expect(describeHands(s)).toBe('JJ–99, 77');
+    expect(describeHands(s)).toBe('pairs JJ–99, 77');
   });
 
-  it('collapses contiguous suited aces from AKs into "AXs+"', () => {
+  it('collapses contiguous top suited aces into "ATs+"', () => {
     const s = new Set(['AKs', 'AQs', 'AJs', 'ATs']);
-    expect(describeHands(s)).toBe('ATs+');
+    expect(describeHands(s)).toBe('suited aces ATs+');
   });
 
-  it('separates wheel suited aces from top suited aces', () => {
+  it('names the wheels when A5s–A4s are present alongside top aces', () => {
     const s = new Set(['AKs', 'AQs', 'AJs', 'ATs', 'A5s', 'A4s']);
-    expect(describeHands(s)).toBe('ATs+, A5s–A4s');
+    expect(describeHands(s)).toBe('suited aces ATs+ plus wheel A5s–A4s');
   });
 
-  it('handles mixed pairs, suited, and offsuit', () => {
-    const s = new Set(['AA', 'KK', 'QQ', 'AKs', 'AQs', 'AKo', 'AQo']);
-    expect(describeHands(s)).toBe('QQ+; AQs+; AQo+');
+  it('collapses all four wheel suited aces into a named group', () => {
+    const s = new Set(['AKs', 'AQs', 'AJs', 'ATs', 'A5s', 'A4s', 'A3s', 'A2s']);
+    expect(describeHands(s)).toContain('the wheel suited aces (A5s–A2s)');
   });
 
-  it('orders by top rank A → 2', () => {
-    const s = new Set(['KQs', 'AKs', 'QJs']);
+  it('collapses all 12 suited aces into "every suited ace"', () => {
+    const all = new Set(['AKs','AQs','AJs','ATs','A9s','A8s','A7s','A6s','A5s','A4s','A3s','A2s']);
+    expect(describeHands(all)).toBe('every suited ace');
+  });
+
+  it('collapses all 6 suited broadways', () => {
+    const s = new Set(['KQs', 'KJs', 'KTs', 'QJs', 'QTs', 'JTs']);
+    expect(describeHands(s)).toBe('all suited broadways (KQs–JTs)');
+  });
+
+  it('lists partial suited broadways by top card', () => {
+    const s = new Set(['KQs', 'KJs', 'KTs', 'QJs', 'QTs', 'JTs'].slice(0, 3).concat(['JTs']));
+    // KQs, KJs, KTs, JTs → "suited broadways KTs+, JTs"
+    expect(describeHands(s)).toBe('suited broadways KTs+, JTs');
+  });
+
+  it('classifies T9s/T8s as suited connectors and one-gappers (not Tx)', () => {
+    const s = new Set(['T9s', 'T8s', '98s']);
     const out = describeHands(s);
-    expect(out.indexOf('AKs')).toBeLessThan(out.indexOf('KQs'));
-    expect(out.indexOf('KQs')).toBeLessThan(out.indexOf('QJs'));
+    expect(out).toMatch(/suited connectors T9s–98s/);
+    expect(out).toMatch(/one-gappers? T8s/);
+  });
+
+  it('labels 97s/75s as "one-gappers"', () => {
+    const s = new Set(['97s', '75s']);
+    const out = describeHands(s);
+    expect(out).toMatch(/one-gappers 97s, 75s|one-gappers 97s.*75s/);
+  });
+
+  it('handles a wide offsuit range with connectors', () => {
+    const s = new Set(['98o', '87o', '76o']);
+    const out = describeHands(s);
+    expect(out).toMatch(/offsuit connectors 98o–76o/);
   });
 
   it('places pairs before suited and suited before offsuit', () => {
@@ -46,43 +80,63 @@ describe('describeHands', () => {
     expect(out.indexOf('AKs')).toBeLessThan(out.indexOf('AKo'));
   });
 
-  it('single hand renders as just the hand', () => {
-    expect(describeHands(new Set(['AA']))).toBe('AA');
-    expect(describeHands(new Set(['A5s']))).toBe('A5s');
+  it('labels weak offsuit aces separately from strong ones', () => {
+    const s = new Set(['AKo', 'AQo', 'AJo', 'ATo', 'A9o', 'A8o']);
+    const out = describeHands(s);
+    expect(out).toMatch(/offsuit aces ATo\+/);
+    expect(out).toMatch(/weak offsuit aces/);
   });
 });
 
-describe('describeRfi', () => {
-  it('wraps range in an "Open-raise ... fold everything else." sentence', () => {
-    const s = new Set(['AA', 'KK', 'AKs', 'AKo']);
-    const out = describeRfi(s);
-    expect(out).toMatch(/^Open-raise /);
-    expect(out).toMatch(/fold everything else\.$/);
-    expect(out).toContain('KK+');
+describe('describeRfi — sentence shape', () => {
+  it('starts with "Open" and ends with fold sentence', () => {
+    const out = describeRfi(new Set(['AA', 'KK']));
+    expect(out).toMatch(/^Open /);
+    expect(out).toMatch(/Fold everything else\.$/);
+  });
+
+  it('100BB UTG mentions pairs 66+, wheels, and KQo', () => {
+    const out = describeRfi(RFI_RANGES['100BB'].UTG);
+    expect(out).toContain('pairs 66+');
+    expect(out).toContain('wheel A5s–A4s');
+    expect(out).toContain('all suited broadways');
+    expect(out).toContain('KQo');
+  });
+
+  it('100BB BTN uses "all pairs" and "every suited ace"', () => {
+    const out = describeRfi(RFI_RANGES['100BB'].BTN);
+    expect(out).toContain('all pairs');
+    expect(out).toContain('every suited ace');
+    expect(out).toContain('all suited broadways');
+  });
+
+  it('25BB UTG is short and has no connectors section', () => {
+    const out = describeRfi(RFI_RANGES['25BB'].UTG);
+    expect(out).toContain('pairs 99+');
+    expect(out).not.toMatch(/connector/i);
+    expect(out).not.toMatch(/gapper/i);
   });
 });
 
 describe('describeLimp', () => {
-  it('uses Call verb for non-BB hero', () => {
+  it('uses Call for non-BB and Check for BB', () => {
     const rs = { raise: new Set(['AA']), call: new Set(['KK']) };
-    const out = describeLimp(rs, false);
-    expect(out).toMatch(/Iso-raise AA/);
-    expect(out).toMatch(/Call behind with KK/);
+    expect(describeLimp(rs, false)).toMatch(/Call behind with/);
+    expect(describeLimp(rs, true)).toMatch(/Check behind with/);
   });
 
-  it('uses Check verb for BB hero', () => {
+  it('ends with fold sentence', () => {
     const rs = { raise: new Set(['AA']), call: new Set(['KK']) };
-    const out = describeLimp(rs, true);
-    expect(out).toMatch(/Check behind with KK/);
+    expect(describeLimp(rs, false)).toMatch(/Fold the rest\.$/);
   });
 });
 
 describe('describeVsRaise', () => {
-  it('produces a 3-bet / flat-call / fold description', () => {
+  it('has 3-bet, flat-call, and fold clauses', () => {
     const rs = { threebet: new Set(['AA', 'KK']), call: new Set(['QQ', 'JJ']) };
     const out = describeVsRaise(rs);
-    expect(out).toMatch(/^3-bet KK\+/);
-    expect(out).toMatch(/Flat-call QQ–JJ/);
-    expect(out).toMatch(/Fold everything else\.$/);
+    expect(out).toMatch(/^3-bet /);
+    expect(out).toMatch(/Flat-call /);
+    expect(out).toMatch(/Fold the rest\.$/);
   });
 });

--- a/src/utils/range-description.test.js
+++ b/src/utils/range-description.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { describeHands, describeRfi, describeLimp, describeVsRaise } from './range-description.js';
+
+describe('describeHands', () => {
+  it('returns "none" for empty set', () => {
+    expect(describeHands(new Set())).toBe('none');
+    expect(describeHands(null)).toBe('none');
+  });
+
+  it('collapses contiguous pairs from AA into "XX+"', () => {
+    const s = new Set(['AA', 'KK', 'QQ', 'JJ', 'TT', '99']);
+    expect(describeHands(s)).toBe('99+');
+  });
+
+  it('uses dash range for non-prefix pair runs', () => {
+    const s = new Set(['JJ', 'TT', '99', '77']);
+    expect(describeHands(s)).toBe('JJ–99, 77');
+  });
+
+  it('collapses contiguous suited aces from AKs into "AXs+"', () => {
+    const s = new Set(['AKs', 'AQs', 'AJs', 'ATs']);
+    expect(describeHands(s)).toBe('ATs+');
+  });
+
+  it('separates wheel suited aces from top suited aces', () => {
+    const s = new Set(['AKs', 'AQs', 'AJs', 'ATs', 'A5s', 'A4s']);
+    expect(describeHands(s)).toBe('ATs+, A5s–A4s');
+  });
+
+  it('handles mixed pairs, suited, and offsuit', () => {
+    const s = new Set(['AA', 'KK', 'QQ', 'AKs', 'AQs', 'AKo', 'AQo']);
+    expect(describeHands(s)).toBe('QQ+; AQs+; AQo+');
+  });
+
+  it('orders by top rank A → 2', () => {
+    const s = new Set(['KQs', 'AKs', 'QJs']);
+    const out = describeHands(s);
+    expect(out.indexOf('AKs')).toBeLessThan(out.indexOf('KQs'));
+    expect(out.indexOf('KQs')).toBeLessThan(out.indexOf('QJs'));
+  });
+
+  it('places pairs before suited and suited before offsuit', () => {
+    const s = new Set(['AA', 'AKs', 'AKo']);
+    const out = describeHands(s);
+    expect(out.indexOf('AA')).toBeLessThan(out.indexOf('AKs'));
+    expect(out.indexOf('AKs')).toBeLessThan(out.indexOf('AKo'));
+  });
+
+  it('single hand renders as just the hand', () => {
+    expect(describeHands(new Set(['AA']))).toBe('AA');
+    expect(describeHands(new Set(['A5s']))).toBe('A5s');
+  });
+});
+
+describe('describeRfi', () => {
+  it('wraps range in an "Open-raise ... fold everything else." sentence', () => {
+    const s = new Set(['AA', 'KK', 'AKs', 'AKo']);
+    const out = describeRfi(s);
+    expect(out).toMatch(/^Open-raise /);
+    expect(out).toMatch(/fold everything else\.$/);
+    expect(out).toContain('KK+');
+  });
+});
+
+describe('describeLimp', () => {
+  it('uses Call verb for non-BB hero', () => {
+    const rs = { raise: new Set(['AA']), call: new Set(['KK']) };
+    const out = describeLimp(rs, false);
+    expect(out).toMatch(/Iso-raise AA/);
+    expect(out).toMatch(/Call behind with KK/);
+  });
+
+  it('uses Check verb for BB hero', () => {
+    const rs = { raise: new Set(['AA']), call: new Set(['KK']) };
+    const out = describeLimp(rs, true);
+    expect(out).toMatch(/Check behind with KK/);
+  });
+});
+
+describe('describeVsRaise', () => {
+  it('produces a 3-bet / flat-call / fold description', () => {
+    const rs = { threebet: new Set(['AA', 'KK']), call: new Set(['QQ', 'JJ']) };
+    const out = describeVsRaise(rs);
+    expect(out).toMatch(/^3-bet KK\+/);
+    expect(out).toMatch(/Flat-call QQ–JJ/);
+    expect(out).toMatch(/Fold everything else\.$/);
+  });
+});


### PR DESCRIPTION
Each RFI, vs-Limp, and vs-Raise chart now renders a short human-readable
description of the active range (e.g. "Open-raise 66+; ATs+, A5s–A4s; ...")
under the legend, auto-generated from the hand set via a new
range-description utility.