### PR TITLE
Show table with villain action chip in quiz playing screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ### Preflop
 - **Charts** — Interactive 13x13 preflop RFI (Raise First In) hand range grids for each table position (UTG, HJ, CO, BTN, SB).
-- **RFI Quiz** — Practice raise/fold decisions against GTO-optimal preflop ranges with persistent progress tracking. Each question shows the 6-max table with hero highlighted gold and (in vs Limp / vs Raise modes) the villain highlighted red, with a chip next to the villain seat indicating their action (↑ for raise, L for limp).
+- **RFI Quiz** — Practice raise/fold decisions against GTO-optimal preflop ranges with persistent progress tracking. Each question shows the 6-max table with hero highlighted gold and (in vs Limp / vs Raise modes) the villain highlighted red, with a chip next to the villain seat indicating their action (↑ for raise, ✓ for limp).
 
 ### Stats
 - **Dashboard** — Full statistics view showing study progress, terminology quiz accuracy, and RFI quiz performance by position. Surfaces a "Recommended Next Quiz" card that points you at your weakest area (or an untaken quiz for a baseline) with a one-click button to start it.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ### Preflop
 - **Charts** — Interactive 13x13 preflop RFI (Raise First In) hand range grids for each table position (UTG, HJ, CO, BTN, SB).
-- **RFI Quiz** — Practice raise/fold decisions against GTO-optimal preflop ranges with persistent progress tracking.
+- **RFI Quiz** — Practice raise/fold decisions against GTO-optimal preflop ranges with persistent progress tracking. Each question shows the 6-max table with hero highlighted gold and (in vs Limp / vs Raise modes) the villain highlighted red, with a chip next to the villain seat indicating their action (↑ for raise, L for limp).
 
 ### Stats
 - **Dashboard** — Full statistics view showing study progress, terminology quiz accuracy, and RFI quiz performance by position. Surfaces a "Recommended Next Quiz" card that points you at your weakest area (or an untaken quiz for a baseline) with a one-click button to start it.

--- a/src/components/PositionTable.jsx
+++ b/src/components/PositionTable.jsx
@@ -21,6 +21,24 @@ const HERO_STROKE = '#f0d060';
 const VILL_FILL   = '#7a2a1e';
 const VILL_STROKE = '#e85c4a';
 
+// Visual chip shown next to a villain seat to indicate their preflop action.
+// Keys here are the action ids accepted by the `villainAction` prop.
+const ACTION_CHIPS = {
+  raise: { symbol: '\u2191', label: 'Raise', fill: '#c0392b', stroke: '#f0b8b0', textColor: '#fff5ec' },
+  check: { symbol: '\u2713', label: 'Check', fill: '#2980b9', stroke: '#a8d8f0', textColor: '#eaf6ff' },
+  limp:  { symbol: 'L',      label: 'Limp',  fill: '#2980b9', stroke: '#a8d8f0', textColor: '#eaf6ff' },
+};
+
+// Place the chip a fixed distance from the seat toward the table center so it
+// reads as "next to that seat" without overlapping the seat label.
+function chipPosFor(seat) {
+  const cx = 200, cy = 115;
+  const dx = cx - seat.x, dy = cy - seat.y;
+  const len = Math.hypot(dx, dy) || 1;
+  const off = 30;
+  return { x: seat.x + (dx / len) * off, y: seat.y + (dy / len) * off };
+}
+
 export function PositionTable({
   heroSelected = 'all',
   villainSelected = 'all',
@@ -33,6 +51,8 @@ export function PositionTable({
   autoSwitchRole = true,
   heroLabel = 'Your Position',
   villainLabel = 'Villain',
+  readOnly = false,
+  villainAction = null,
 }) {
   const [activeRole, setActiveRole] = useState('hero');
 
@@ -46,6 +66,7 @@ export function PositionTable({
   const active = showVillain ? activeRole : 'hero';
 
   const handleSeatClick = (id) => {
+    if (readOnly) return;
     if (active === 'hero') {
       if (!heroAvailSet.has(id)) return;
       onHeroSelect(id);
@@ -62,7 +83,7 @@ export function PositionTable({
 
   return (
     <div class="pt-wrap">
-      {showVillain && (
+      {showVillain && !readOnly && (
         <div class="pt-roles" role="tablist">
           <button
             type="button"
@@ -115,7 +136,7 @@ export function PositionTable({
             const isVillain = !villainIsAll && villainSelected === seat.id;
             const roleAvail = active === 'hero' ? heroAvailSet : villainAvailSet;
             const enabled   = roleAvail.has(seat.id);
-            const dimmed    = !enabled && !isHero && !isVillain;
+            const dimmed    = !enabled && !isHero && !isVillain && !readOnly;
             const r         = (isHero || isVillain) ? 22 : 18;
 
             let fill, stroke, strokeWidth, textColor, fontWeight;
@@ -133,7 +154,7 @@ export function PositionTable({
               strokeWidth = 1.25; textColor = '#c9a84c'; fontWeight = 500;
             }
 
-            const clickable = enabled;
+            const clickable = enabled && !readOnly;
             return (
               <g key={seat.id}
                  class={`pt-seat${clickable ? ' pt-seat-enabled' : ''}${isHero ? ' pt-seat-hero' : ''}${isVillain ? ' pt-seat-villain' : ''}`}
@@ -158,10 +179,31 @@ export function PositionTable({
               </g>
             );
           })}
+
+          {/* Action chip next to the villain seat (e.g. "↑" for raise, "✓" for check). */}
+          {(() => {
+            const chip = ACTION_CHIPS[villainAction];
+            if (!chip) return null;
+            const seat = SEATS.find(s => s.id === villainSelected);
+            if (!seat) return null;
+            const pos = chipPosFor(seat);
+            return (
+              <g class="pt-action-chip" aria-label={`Villain action: ${chip.label}`}>
+                <circle cx={pos.x} cy={pos.y} r="11"
+                  fill="rgba(0,0,0,.45)"/>
+                <circle cx={pos.x} cy={pos.y} r="10"
+                  fill={chip.fill} stroke={chip.stroke} stroke-width="1.5"/>
+                <text x={pos.x} y={pos.y + 4} text-anchor="middle"
+                  font-size="12" font-weight="700" fill={chip.textColor}
+                  font-family="Georgia"
+                  style="pointer-events:none;user-select:none">{chip.symbol}</text>
+              </g>
+            );
+          })()}
         </svg>
       </div>
 
-      {showAllButtons && (
+      {showAllButtons && !readOnly && (
         <div class="pt-all-row">
           <button
             type="button"

--- a/src/components/PositionTable.jsx
+++ b/src/components/PositionTable.jsx
@@ -24,7 +24,7 @@ const VILL_STROKE = '#e85c4a';
 // Visual chip shown next to a villain seat to indicate their preflop action.
 // Keys here are the action ids accepted by the `villainAction` prop.
 const ACTION_CHIPS = {
-  raise: { symbol: '\u2191', label: 'Raise', fill: '#c0392b', stroke: '#f0b8b0', textColor: '#fff5ec' },
+  raise: { symbol: '\u2191', label: 'Raise', fill: '#27ae60', stroke: '#a8f0c6', textColor: '#ebfff1' },
   check: { symbol: '\u2713', label: 'Check', fill: '#2980b9', stroke: '#a8d8f0', textColor: '#eaf6ff' },
   limp:  { symbol: '\u2713', label: 'Limp',  fill: '#2980b9', stroke: '#a8d8f0', textColor: '#eaf6ff' },
 };

--- a/src/components/PositionTable.jsx
+++ b/src/components/PositionTable.jsx
@@ -26,7 +26,7 @@ const VILL_STROKE = '#e85c4a';
 const ACTION_CHIPS = {
   raise: { symbol: '\u2191', label: 'Raise', fill: '#c0392b', stroke: '#f0b8b0', textColor: '#fff5ec' },
   check: { symbol: '\u2713', label: 'Check', fill: '#2980b9', stroke: '#a8d8f0', textColor: '#eaf6ff' },
-  limp:  { symbol: 'L',      label: 'Limp',  fill: '#2980b9', stroke: '#a8d8f0', textColor: '#eaf6ff' },
+  limp:  { symbol: '\u2713', label: 'Limp',  fill: '#2980b9', stroke: '#a8d8f0', textColor: '#eaf6ff' },
 };
 
 // Place the chip a fixed distance from the seat toward the table center so it

--- a/src/components/PositionTable.test.js
+++ b/src/components/PositionTable.test.js
@@ -130,6 +130,11 @@ describe('PositionTable — visual position selector', () => {
     expect(source).toMatch(/check:\s*\{[^}]*symbol:\s*'\\u2713'/);
   });
 
+  it('limp chip uses a check mark (limp is a passive action, matches the check glyph)', () => {
+    // \u2713 = ✓ — regression: originally shipped as the letter "L", swapped to ✓.
+    expect(source).toMatch(/limp:\s*\{[^}]*symbol:\s*'\\u2713'/);
+  });
+
   it('chipPosFor offsets the chip from the seat toward the table center — keeps it next to, not on top of, the seat', () => {
     expect(source).toMatch(/function\s+chipPosFor/);
     expect(source).toMatch(/Math\.hypot\(dx,\s*dy\)/);

--- a/src/components/PositionTable.test.js
+++ b/src/components/PositionTable.test.js
@@ -90,6 +90,58 @@ describe('PositionTable — visual position selector', () => {
 
   it('the All-buttons row can be hidden via the showAllButtons prop (for chart use where "All" is not meaningful)', () => {
     expect(source).toMatch(/showAllButtons\s*=\s*true/);
-    expect(source).toMatch(/showAllButtons\s*&&\s*\(/);
+    // Row is gated on `showAllButtons` (currently combined with `!readOnly`).
+    expect(source).toMatch(/showAllButtons\s*&&[^)]*\(/);
+  });
+
+  // ── New behavior: read-only mode for displaying a fixed hero/villain pair ──
+  it('exposes a readOnly prop that defaults to false', () => {
+    expect(source).toMatch(/readOnly\s*=\s*false/);
+  });
+
+  it('readOnly mode short-circuits seat clicks — no role switching, no callbacks fire', () => {
+    expect(source).toMatch(/if\s*\(\s*readOnly\s*\)\s*return/);
+  });
+
+  it('readOnly mode hides the role tabs (hero/villain switch) — only one snapshot is being shown', () => {
+    expect(source).toMatch(/showVillain\s*&&\s*!readOnly/);
+  });
+
+  it('readOnly mode hides the "All" buttons — fixed selection, no clearing', () => {
+    expect(source).toMatch(/showAllButtons\s*&&\s*!readOnly/);
+  });
+
+  it('readOnly mode keeps non-selected seats visible (not dimmed) — they are context, not options', () => {
+    expect(source).toMatch(/!enabled\s*&&\s*!isHero\s*&&\s*!isVillain\s*&&\s*!readOnly/);
+  });
+
+  // ── New behavior: villain action chip (raise / check / limp) ───────────────
+  it('declares an action-chip table covering raise, check and limp — for use in quiz playing screen', () => {
+    expect(source).toMatch(/ACTION_CHIPS\s*=\s*\{[\s\S]*raise:[\s\S]*check:[\s\S]*limp:/);
+  });
+
+  it('raise chip uses an up-arrow symbol so it visually reads as aggression', () => {
+    // \u2191 = ↑
+    expect(source).toMatch(/raise:\s*\{[^}]*symbol:\s*'\\u2191'/);
+  });
+
+  it('check chip uses a check mark', () => {
+    // \u2713 = ✓
+    expect(source).toMatch(/check:\s*\{[^}]*symbol:\s*'\\u2713'/);
+  });
+
+  it('chipPosFor offsets the chip from the seat toward the table center — keeps it next to, not on top of, the seat', () => {
+    expect(source).toMatch(/function\s+chipPosFor/);
+    expect(source).toMatch(/Math\.hypot\(dx,\s*dy\)/);
+  });
+
+  it('villainAction prop drives chip rendering — chip only appears when set', () => {
+    expect(source).toMatch(/villainAction\s*=\s*null/);
+    expect(source).toMatch(/ACTION_CHIPS\[villainAction\]/);
+    expect(source).toMatch(/pt-action-chip/);
+  });
+
+  it('chip is anchored to the villain seat (not the hero)', () => {
+    expect(source).toMatch(/SEATS\.find\(s\s*=>\s*s\.id\s*===\s*villainSelected\)/);
   });
 });

--- a/src/sections/preflop/Quiz.jsx
+++ b/src/sections/preflop/Quiz.jsx
@@ -174,9 +174,9 @@ function actionLabel(action) {
 
 function promptText(q) {
   if (!q) return '';
-  if (q.type === 'rfi')     return 'Everyone folds to you. What do you do?';
-  if (q.type === 'limp')    return `${q.villainPos} limps. What do you do?`;
-  if (q.type === 'vsRaise') return `${q.villainPos} raises. What do you do?`;
+  if (q.type === 'rfi')     return 'Everyone folds to you.';
+  if (q.type === 'limp')    return `${q.villainPos} limps.`;
+  if (q.type === 'vsRaise') return `${q.villainPos} raises.`;
   return '';
 }
 

--- a/src/sections/preflop/Quiz.jsx
+++ b/src/sections/preflop/Quiz.jsx
@@ -271,7 +271,7 @@ function saveStats(results, mode, score, stackDepth) {
 
 // ---------- main component ----------
 export function PreflopQuiz({ query }) {
-  const initialMode = query?.mode && MODES.some(m => m.id === query.mode) ? query.mode : 'rfi';
+  const initialMode = query?.mode && MODES.some(m => m.id === query.mode) ? query.mode : 'all';
   const [phase, setPhase]           = useState('setup'); // 'setup' | 'playing'
   const [quizMode, setQuizMode]     = useState(initialMode);
   const [stackDepth, setStackDepth] = useState('100BB');

--- a/src/sections/preflop/Quiz.jsx
+++ b/src/sections/preflop/Quiz.jsx
@@ -444,6 +444,7 @@ export function PreflopQuiz({ query }) {
   const isCorrect = answered && current ? (choseAction === current.correctAction) : null;
   const buttons = current ? getButtons(current.type) : [];
   const modeLabel = MODES.find(m => m.id === quizMode)?.label ?? quizMode;
+  const villainAction = current?.type === 'vsRaise' ? 'raise' : current?.type === 'limp' ? 'limp' : null;
 
   return (
     <div class="rq-playing-wrapper">
@@ -466,6 +467,16 @@ export function PreflopQuiz({ query }) {
               <div class="rq-pos">Your Position: <strong style="font-size:1.1rem">{current.heroPos}</strong>
                 {current.villainPos && <span style="margin-left:.8rem;color:var(--muted)">Villain: <strong style="color:var(--text)">{current.villainPos}</strong></span>}
               </div>
+              <PositionTable
+                heroSelected={current.heroPos}
+                villainSelected={current.villainPos || 'all'}
+                heroAvailable={[]}
+                villainAvailable={[]}
+                showVillain={!!current.villainPos}
+                showAllButtons={false}
+                readOnly={true}
+                villainAction={villainAction}
+              />
               <div class="rq-hand-display" dangerouslySetInnerHTML={{ __html: handToCards(current.hand, current.suit) }} />
               <div style="font-size:1.1rem;color:var(--gold-bright);font-weight:600;margin-top:.3rem">{current.hand}</div>
               <div class="rq-prompt">{promptText(current)}</div>

--- a/src/sections/preflop/Quiz.test.js
+++ b/src/sections/preflop/Quiz.test.js
@@ -187,6 +187,17 @@ describe('PreflopQuiz — villain position selector', () => {
   });
 });
 
+describe('PreflopQuiz — default mode', () => {
+  it('initial mode defaults to "all" when no query mode is provided', () => {
+    // Mirrors the resolution in Quiz.jsx so the default never silently regresses to a single-mode quiz.
+    expect(quizSource).toMatch(/MODES\.some\(m\s*=>\s*m\.id\s*===\s*query\.mode\)\s*\?\s*query\.mode\s*:\s*'all'/);
+  });
+
+  it('initial deck is built with the resolved initialMode (so default-all hits all hand generators)', () => {
+    expect(quizSource).toMatch(/buildDeck\(initialMode,\s*'100BB',\s*'all',\s*'all'\)/);
+  });
+});
+
 describe('PreflopQuiz — playing screen position table', () => {
   it('renders the PositionTable inside the playing card — visual context for the question', () => {
     expect(quizSource).toMatch(/import\s*\{\s*PositionTable\s*\}/);

--- a/src/sections/preflop/Quiz.test.js
+++ b/src/sections/preflop/Quiz.test.js
@@ -1,7 +1,13 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
 import { RANKS, RFI_RANGES, RFI_QUIZ_LENGTH, RFI_QUIZ_POSITIONS, STACK_DEPTHS } from '../../data/rfi-ranges.js';
 import { LIMP_HERO_POSITIONS, RAISE_HERO_POSITIONS } from '../../data/preflop-ranges.js';
 import { getPositionsForMode, getVillainsForSelection, getHeroesForVillain } from './Quiz.jsx';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const quizSource = readFileSync(resolve(__dirname, 'Quiz.jsx'), 'utf8');
 
 // Replicate the pure logic from Quiz.jsx for testing
 const SUITS = ['♠','♥','♦','♣'];
@@ -178,5 +184,29 @@ describe('PreflopQuiz — villain position selector', () => {
   it('getHeroesForVillain vsRaise mirrors limp structure', () => {
     expect(getHeroesForVillain('vsRaise', 'SB')).toEqual(['BB']);
     expect(getHeroesForVillain('vsRaise', 'UTG').length).toBe(5);
+  });
+});
+
+describe('PreflopQuiz — playing screen position table', () => {
+  it('renders the PositionTable inside the playing card — visual context for the question', () => {
+    expect(quizSource).toMatch(/import\s*\{\s*PositionTable\s*\}/);
+    // Used inside the rq-card block (not just on the setup screen).
+    expect(quizSource).toMatch(/rq-card[\s\S]*?<PositionTable[\s\S]*?readOnly=\{true\}/);
+  });
+
+  it('passes readOnly=true on the playing screen — quiz table is for display, not selection', () => {
+    expect(quizSource).toMatch(/readOnly=\{true\}/);
+  });
+
+  it('maps quiz mode to the matching villain action symbol — vsRaise → raise, limp → limp', () => {
+    expect(quizSource).toMatch(/villainAction\s*=\s*current\?\.type\s*===\s*'vsRaise'\s*\?\s*'raise'\s*:\s*current\?\.type\s*===\s*'limp'\s*\?\s*'limp'\s*:\s*null/);
+  });
+
+  it('passes the per-question villain action into the PositionTable', () => {
+    expect(quizSource).toMatch(/<PositionTable[\s\S]*?villainAction=\{villainAction\}/);
+  });
+
+  it('only shows villain seat when the question has one — RFI questions still render the table without a villain', () => {
+    expect(quizSource).toMatch(/showVillain=\{!!current\.villainPos\}/);
   });
 });

--- a/src/styles/quiz.css
+++ b/src/styles/quiz.css
@@ -84,6 +84,7 @@
 .pt-seat-enabled:focus-visible circle{stroke:#f0d060;stroke-width:2.5}
 .pt-seat:not(.pt-seat-enabled){cursor:not-allowed}
 .pt-dealer-chip{pointer-events:none}
+.pt-action-chip{pointer-events:none;filter:drop-shadow(0 2px 3px rgba(0,0,0,.45))}
 .pt-all-row{text-align:center;margin-top:.5rem;display:flex;justify-content:center;
   gap:8px;flex-wrap:wrap}
 


### PR DESCRIPTION
Each preflop quiz question now renders the 6-max position table inside
the playing card, with hero and villain seats highlighted. In vs Limp
mode the villain seat gets an "L" chip; in vs Raise mode it gets an
upward arrow chip. The chip is placed toward the table center so it
reads as "next to" the seat without overlapping the seat label.

PositionTable gains two new props: readOnly (disables seat clicks,
hides role tabs and the All-buttons row) and villainAction
(raise | check | limp). Non-selected seats stay visible in readOnly
mode since they are context, not options.