### PR TITLE
Explain the GTO logic under each preflop quiz answer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,8 @@ poker-trainer/
 │   ├── utils/
 │   │   ├── illustrations.jsx           # cardSvg(), hand(), ILLUS, getIllus(), handToCards()
 │   │   ├── shuffle.js                  # Immutable Fisher-Yates shuffle
-│   │   └── storage.js                  # localStorage helpers for all 3 stat stores
+│   │   ├── storage.js                  # localStorage helpers for all 3 stat stores
+│   │   └── explain.js                  # Quiz feedback rationale (hand features + action logic)
 │   ├── hooks/
 │   │   ├── useFilters.js               # activeCats state + toggle logic
 │   │   └── useDeck.js                  # deck, idx, flipped, nav, shuffle

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,8 +68,10 @@ poker-trainer/
 │       ├── preflop/
 │       │   ├── Charts.jsx              # RFI hand range grid with position tabs
 │       │   └── Quiz.jsx                # Raise/fold RFI quiz
-│       └── stats/
-│           └── Dashboard.jsx           # Full stats dashboard
+│       ├── stats/
+│       │   └── Dashboard.jsx           # Full stats dashboard
+│       └── settings/
+│           └── Settings.jsx            # User preferences (auto-advance, card size)
 ├── .github/workflows/deploy.yml        # Build + deploy to GitHub Pages
 ├── CLAUDE.md                           # This file
 └── README.md                           # User-facing docs
@@ -90,6 +92,7 @@ Hash-based routing (`#/path`) for GitHub Pages compatibility.
 | `#/preflop/charts` | Charts.jsx | RFI hand range grids |
 | `#/preflop/quiz` | Quiz.jsx | Raise/fold RFI quiz |
 | `#/stats` | Dashboard.jsx | Full stats dashboard |
+| `#/settings` | Settings.jsx | User preferences (auto-advance, card image size) |
 
 Redirects: `/` → `/welcome`, `/terminology` → `/terminology/study`, `/preflop` → `/preflop/charts`
 
@@ -143,6 +146,7 @@ Fonts: `'Playfair Display'` for headings, `'Crimson Pro'` for body text.
 | `rfi-quiz-stats` | `{ totalQuizzes, totalQuestions, totalCorrect, byPosition, recentScores }` |
 | `term-quiz-stats` | `{ totalQuizzes, totalQuestions, totalCorrect, bestStreak, recentScores }` |
 | `study-progress` | `{ cardsSeen: [], totalFlips, byCategory: {} }` |
+| `settings` | `{ autoAdvance, autoAdvanceSeconds, cardSize }` |
 
 ---
 

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -9,6 +9,7 @@ import { RaiseCharts } from './sections/preflop/RaiseCharts.jsx';
 import { PreflopQuiz } from './sections/preflop/Quiz.jsx';
 import { Dashboard } from './sections/stats/Dashboard.jsx';
 import { Welcome } from './sections/welcome/Welcome.jsx';
+import { Settings } from './sections/settings/Settings.jsx';
 import { REDIRECTS } from './routing.js';
 
 function parseHash() {
@@ -47,6 +48,7 @@ const ROUTES = {
   '/quizzes/terminology': TermQuiz,
   '/quizzes/preflop': PreflopQuiz,
   '/stats': Dashboard,
+  '/settings': Settings,
 };
 
 export function App() {

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -7,6 +7,7 @@ const NAV_ITEMS = [
   { href: '#/preflop/charts', label: 'Preflop', section: 'preflop' },
   { href: '#/quizzes/preflop', label: 'Quizzes', section: 'quizzes' },
   { href: '#/stats', label: 'Stats', section: 'stats' },
+  { href: '#/settings', label: 'Settings', section: 'settings' },
 ];
 
 export function Header() {

--- a/src/components/Header.test.js
+++ b/src/components/Header.test.js
@@ -31,8 +31,8 @@ describe('Header — hamburger menu', () => {
     expect(source).toMatch(/onHash[\s\S]{0,200}setMenuOpen\(false\)/);
   });
 
-  it('includes all five top-level sections in the drawer', () => {
-    for (const label of ['Home', 'Terminology', 'Preflop', 'Quizzes', 'Stats']) {
+  it('includes all top-level sections in the drawer', () => {
+    for (const label of ['Home', 'Terminology', 'Preflop', 'Quizzes', 'Stats', 'Settings']) {
       expect(source).toContain(label);
     }
   });

--- a/src/routing.js
+++ b/src/routing.js
@@ -9,6 +9,7 @@ export const ROUTES_LIST = [
   '/quizzes/terminology',
   '/quizzes/preflop',
   '/stats',
+  '/settings',
 ];
 
 export const REDIRECTS = {

--- a/src/routing.test.js
+++ b/src/routing.test.js
@@ -78,6 +78,11 @@ describe('routing', () => {
     expect(ROUTES_LIST).not.toContain('/preflop/quiz');
   });
 
+  it('/settings exists as a top-level route', () => {
+    expect(ROUTES_LIST).toContain('/settings');
+    expect(resolveRoute('/settings')).toBe('/settings');
+  });
+
   it('empty hash on initial load resolves to a renderable route — no blank page regression', () => {
     // Reproduces the startup sequence in useHashRoute:
     //   window.location.hash.slice(1) || '/'

--- a/src/sections/preflop/Quiz.jsx
+++ b/src/sections/preflop/Quiz.jsx
@@ -284,7 +284,7 @@ export function PreflopQuiz({ query }) {
   const [answered, setAnswered]     = useState(false);
   const [choseAction, setChoseAction] = useState(null);
   const [results, setResults]       = useState([]);
-  const [countdown, setCountdown]   = useState(5);
+  const [countdown, setCountdown]   = useState(10);
 
   function resetQuiz(mode, depth, pos, villainPos) {
     setDeck(buildDeck(mode, depth, pos, villainPos));
@@ -340,11 +340,11 @@ export function PreflopQuiz({ query }) {
     setChoseAction(null);
   }
 
-  // Auto-advance 5s after answering; cleanup cancels timer when next() is called manually
+  // Auto-advance 10s after answering; cleanup cancels timer when next() is called manually
   useEffect(() => {
     if (!answered || phase !== 'playing') return;
-    setCountdown(5);
-    let secs = 5;
+    setCountdown(10);
+    let secs = 10;
     const id = setInterval(() => {
       secs -= 1;
       setCountdown(secs);
@@ -468,16 +468,27 @@ export function PreflopQuiz({ query }) {
               <div class="rq-pos">Your Position: <strong style="font-size:1.1rem">{current.heroPos}</strong>
                 {current.villainPos && <span style="margin-left:.8rem;color:var(--muted)">Villain: <strong style="color:var(--text)">{current.villainPos}</strong></span>}
               </div>
-              <PositionTable
-                heroSelected={current.heroPos}
-                villainSelected={current.villainPos || 'all'}
-                heroAvailable={[]}
-                villainAvailable={[]}
-                showVillain={!!current.villainPos}
-                showAllButtons={false}
-                readOnly={true}
-                villainAction={villainAction}
-              />
+              <div class="rq-table-wrap">
+                <PositionTable
+                  heroSelected={current.heroPos}
+                  villainSelected={current.villainPos || 'all'}
+                  heroAvailable={[]}
+                  villainAvailable={[]}
+                  showVillain={!!current.villainPos}
+                  showAllButtons={false}
+                  readOnly={true}
+                  villainAction={villainAction}
+                />
+                {answered && (
+                  <div class={`rq-explain-overlay${isCorrect ? ' correct' : ' wrong'}`} role="status" aria-live="polite">
+                    <div class="rq-explain-verdict">
+                      {isCorrect ? 'Correct!' : 'Incorrect.'}{' '}
+                      {current.hand} from {current.heroPos} is a <strong>{actionLabel(current.correctAction)}</strong>.
+                    </div>
+                    <div class="rq-explain-text">{explainQuestion(current)}</div>
+                  </div>
+                )}
+              </div>
               <div class="rq-hand-display" dangerouslySetInnerHTML={{ __html: handToCards(current.hand, current.suit) }} />
               <div style="font-size:1.1rem;color:var(--gold-bright);font-weight:600;margin-top:.3rem">{current.hand}</div>
               <div class="rq-prompt">{promptText(current)}</div>
@@ -499,16 +510,6 @@ export function PreflopQuiz({ query }) {
                 );
               })}
             </div>
-
-            {answered && (
-              <div class="rq-feedback">
-                {isCorrect
-                  ? <span style="color:#27ae60">Correct! {current.hand} from {current.heroPos} is a <strong>{actionLabel(current.correctAction)}</strong>.</span>
-                  : <span style="color:#c0392b">Incorrect. {current.hand} from {current.heroPos} is a <strong>{actionLabel(current.correctAction)}</strong>.</span>
-                }
-                <div class="rq-explain">{explainQuestion(current)}</div>
-              </div>
-            )}
 
             <div class="rq-next-row">
               {answered && (

--- a/src/sections/preflop/Quiz.jsx
+++ b/src/sections/preflop/Quiz.jsx
@@ -40,6 +40,7 @@ export function getHeroesForVillain(mode, villainPos) {
 }
 import { getRfiQuizStats, saveRfiQuizStats, initRfiQuizStats, getLimpQuizStats, saveLimpQuizStats, initLimpQuizStats, getVsRaiseQuizStats, saveVsRaiseQuizStats, initVsRaiseQuizStats, getAllModesQuizStats, saveAllModesQuizStats, initAllModesQuizStats } from '../../utils/storage.js';
 import { handToCards } from '../../utils/illustrations.jsx';
+import { explainQuestion } from '../../utils/explain.js';
 import '../../styles/quiz.css';
 
 const TABS = [
@@ -505,6 +506,7 @@ export function PreflopQuiz({ query }) {
                   ? <span style="color:#27ae60">Correct! {current.hand} from {current.heroPos} is a <strong>{actionLabel(current.correctAction)}</strong>.</span>
                   : <span style="color:#c0392b">Incorrect. {current.hand} from {current.heroPos} is a <strong>{actionLabel(current.correctAction)}</strong>.</span>
                 }
+                <div class="rq-explain">{explainQuestion(current)}</div>
               </div>
             )}
 

--- a/src/sections/preflop/Quiz.jsx
+++ b/src/sections/preflop/Quiz.jsx
@@ -38,7 +38,7 @@ export function getHeroesForVillain(mode, villainPos) {
   const map = mode === 'limp' ? VALID_LIMP_VILLAINS : VALID_RAISE_VILLAINS;
   return Object.entries(map).filter(([, v]) => v.includes(villainPos)).map(([h]) => h);
 }
-import { getRfiQuizStats, saveRfiQuizStats, initRfiQuizStats, getLimpQuizStats, saveLimpQuizStats, initLimpQuizStats, getVsRaiseQuizStats, saveVsRaiseQuizStats, initVsRaiseQuizStats, getAllModesQuizStats, saveAllModesQuizStats, initAllModesQuizStats } from '../../utils/storage.js';
+import { getRfiQuizStats, saveRfiQuizStats, initRfiQuizStats, getLimpQuizStats, saveLimpQuizStats, initLimpQuizStats, getVsRaiseQuizStats, saveVsRaiseQuizStats, initVsRaiseQuizStats, getAllModesQuizStats, saveAllModesQuizStats, initAllModesQuizStats, getSettings, CARD_SIZES } from '../../utils/storage.js';
 import { handToCards } from '../../utils/illustrations.jsx';
 import { explainQuestion } from '../../utils/explain.js';
 import '../../styles/quiz.css';
@@ -284,7 +284,8 @@ export function PreflopQuiz({ query }) {
   const [answered, setAnswered]     = useState(false);
   const [choseAction, setChoseAction] = useState(null);
   const [results, setResults]       = useState([]);
-  const [countdown, setCountdown]   = useState(10);
+  const [settings]                  = useState(() => getSettings());
+  const [countdown, setCountdown]   = useState(settings.autoAdvanceSeconds);
 
   function resetQuiz(mode, depth, pos, villainPos) {
     setDeck(buildDeck(mode, depth, pos, villainPos));
@@ -340,11 +341,14 @@ export function PreflopQuiz({ query }) {
     setChoseAction(null);
   }
 
-  // Auto-advance 10s after answering; cleanup cancels timer when next() is called manually
+  // Auto-advance after answering — only runs when the user has enabled it in settings.
+  // Cleanup cancels the timer when next() is called manually.
   useEffect(() => {
     if (!answered || phase !== 'playing') return;
-    setCountdown(10);
-    let secs = 10;
+    if (!settings.autoAdvance) return;
+    const start = settings.autoAdvanceSeconds;
+    setCountdown(start);
+    let secs = start;
     const id = setInterval(() => {
       secs -= 1;
       setCountdown(secs);
@@ -356,7 +360,7 @@ export function PreflopQuiz({ query }) {
       }
     }, 1000);
     return () => clearInterval(id);
-  }, [answered, phase]);
+  }, [answered, phase, settings.autoAdvance, settings.autoAdvanceSeconds]);
 
   // ── Setup screen ──────────────────────────────────────────────────────────
   if (phase === 'setup') {
@@ -489,7 +493,7 @@ export function PreflopQuiz({ query }) {
                   </div>
                 )}
               </div>
-              <div class="rq-hand-display" dangerouslySetInnerHTML={{ __html: handToCards(current.hand, current.suit) }} />
+              <div class="rq-hand-display" dangerouslySetInnerHTML={{ __html: handToCards(current.hand, current.suit, CARD_SIZES[settings.cardSize]) }} />
               <div style="font-size:1.1rem;color:var(--gold-bright);font-weight:600;margin-top:.3rem">{current.hand}</div>
               <div class="rq-prompt">{promptText(current)}</div>
             </div>
@@ -515,7 +519,9 @@ export function PreflopQuiz({ query }) {
               {answered && (
                 <>
                   <button class="rq-next" style="display:inline-block" onClick={next}>Next Question {'\u2192'}</button>
-                  <div class="rq-countdown">Auto-advancing in {countdown}s</div>
+                  {settings.autoAdvance && (
+                    <div class="rq-countdown">Auto-advancing in {countdown}s</div>
+                  )}
                 </>
               )}
             </div>

--- a/src/sections/preflop/Quiz.test.js
+++ b/src/sections/preflop/Quiz.test.js
@@ -52,20 +52,20 @@ describe('PreflopQuiz — setup phase logic', () => {
 });
 
 describe('PreflopQuiz — auto-advance countdown', () => {
-  it('countdown starts at 5 seconds', () => {
-    const INITIAL_COUNTDOWN = 5;
-    expect(INITIAL_COUNTDOWN).toBe(5);
+  it('countdown starts at 10 seconds', () => {
+    const INITIAL_COUNTDOWN = 10;
+    expect(INITIAL_COUNTDOWN).toBe(10);
   });
 
   it('countdown decrements to 0 before advancing', () => {
-    let secs = 5;
+    let secs = 10;
     const steps = [];
     while (secs > 0) {
       secs -= 1;
       steps.push(secs);
     }
     expect(steps[steps.length - 1]).toBe(0);
-    expect(steps.length).toBe(5);
+    expect(steps.length).toBe(10);
   });
 });
 

--- a/src/sections/settings/Settings.jsx
+++ b/src/sections/settings/Settings.jsx
@@ -1,0 +1,84 @@
+import { useState } from 'preact/hooks';
+import { getSettings, saveSettings, resetSettings, DEFAULT_SETTINGS, CARD_SIZES } from '../../utils/storage.js';
+import { handToCards } from '../../utils/illustrations.jsx';
+import '../../styles/settings.css';
+
+export function Settings() {
+  const [settings, setSettings] = useState(() => getSettings());
+  const [justSaved, setJustSaved] = useState(false);
+
+  function update(patch) {
+    const next = { ...settings, ...patch };
+    setSettings(next);
+    saveSettings(next);
+    setJustSaved(true);
+    setTimeout(() => setJustSaved(false), 1200);
+  }
+
+  function onReset() {
+    resetSettings();
+    setSettings({ ...DEFAULT_SETTINGS });
+    setJustSaved(true);
+    setTimeout(() => setJustSaved(false), 1200);
+  }
+
+  const currentSize = CARD_SIZES[settings.cardSize];
+
+  return (
+    <div class="rq-panel settings-panel">
+      <h2 class="rq-title">Settings</h2>
+      <p class="settings-sub">Preferences are saved to this browser.</p>
+
+      <section class="settings-section">
+        <div class="rq-setup-label">Auto-advance</div>
+        <label class="settings-toggle">
+          <input
+            type="checkbox"
+            checked={settings.autoAdvance}
+            onChange={(e) => update({ autoAdvance: e.currentTarget.checked })}
+          />
+          <span>Advance to the next quiz question automatically</span>
+        </label>
+
+        <div class={`settings-timeout${settings.autoAdvance ? '' : ' disabled'}`}>
+          <label for="settings-timeout-input">Delay (seconds)</label>
+          <input
+            id="settings-timeout-input"
+            type="number"
+            min="1"
+            max="60"
+            step="1"
+            disabled={!settings.autoAdvance}
+            value={settings.autoAdvanceSeconds}
+            onInput={(e) => {
+              const n = Number(e.currentTarget.value);
+              if (Number.isFinite(n) && n >= 1 && n <= 60) update({ autoAdvanceSeconds: n });
+            }}
+          />
+        </div>
+      </section>
+
+      <section class="settings-section">
+        <div class="rq-setup-label">Card image size</div>
+        <div class="rq-selector-group">
+          {Object.entries(CARD_SIZES).map(([key, meta]) => (
+            <button
+              key={key}
+              type="button"
+              class={`rq-selector-btn${settings.cardSize === key ? ' active' : ''}`}
+              onClick={() => update({ cardSize: key })}
+            >{meta.label}</button>
+          ))}
+        </div>
+        <div class="settings-card-preview"
+          dangerouslySetInnerHTML={{ __html: handToCards('AKs', '\u2660', currentSize) }}
+        />
+      </section>
+
+      <div class="settings-actions">
+        <button type="button" class="rq-selector-btn" onClick={onReset}>Reset to defaults</button>
+        <span class={`settings-saved${justSaved ? ' show' : ''}`}>Saved</span>
+      </div>
+    </div>
+  );
+}

--- a/src/styles/quiz.css
+++ b/src/styles/quiz.css
@@ -141,10 +141,10 @@
   animation:rq-overlay-in .2s ease-out;z-index:2;pointer-events:none}
 .rq-explain-overlay.correct{border:1.5px solid #27ae60}
 .rq-explain-overlay.wrong{border:1.5px solid #c0392b}
-.rq-explain-verdict{font-size:1rem;line-height:1.3;margin-bottom:.4rem}
+.rq-explain-verdict{font-size:1.2rem;line-height:1.3;margin-bottom:.5rem}
 .rq-explain-overlay.correct .rq-explain-verdict{color:#a8f0c6}
 .rq-explain-overlay.wrong   .rq-explain-verdict{color:#f0b8b0}
-.rq-explain-text{font-size:.85rem;line-height:1.4;color:var(--text);font-style:italic}
+.rq-explain-text{font-size:1.2rem;line-height:1.35;color:var(--text);font-style:italic}
 @keyframes rq-overlay-in{from{opacity:0;transform:translate(-50%,-44%)}
   to{opacity:1;transform:translate(-50%,-50%)}}
 .rq-next{display:none;margin:0 auto;padding:.65rem 2rem;background:var(--gold-dark);

--- a/src/styles/quiz.css
+++ b/src/styles/quiz.css
@@ -144,7 +144,7 @@
 .rq-explain-verdict{font-size:1.2rem;line-height:1.3;margin-bottom:.5rem}
 .rq-explain-overlay.correct .rq-explain-verdict{color:#a8f0c6}
 .rq-explain-overlay.wrong   .rq-explain-verdict{color:#f0b8b0}
-.rq-explain-text{font-size:1.2rem;line-height:1.35;color:var(--text);font-style:italic}
+.rq-explain-text{font-size:1.2rem;line-height:1.35;color:var(--text)}
 @keyframes rq-overlay-in{from{opacity:0;transform:translate(-50%,-44%)}
   to{opacity:1;transform:translate(-50%,-50%)}}
 .rq-next{display:none;margin:0 auto;padding:.65rem 2rem;background:var(--gold-dark);

--- a/src/styles/quiz.css
+++ b/src/styles/quiz.css
@@ -133,9 +133,20 @@
 .rq-btn.correct{background:rgba(46,204,113,.3);border-color:#27ae60;color:#a8f0c6}
 .rq-btn.wrong{background:rgba(192,57,43,.3);border-color:#c0392b;color:#f0b8b0}
 .rq-btn:disabled{cursor:default;opacity:.7}
-.rq-feedback{text-align:center;font-size:1rem;margin-bottom:.8rem;min-height:1.5rem}
-.rq-explain{margin:.4rem auto 0;max-width:560px;font-size:.85rem;line-height:1.4;
-  color:var(--muted);font-style:italic}
+.rq-table-wrap{position:relative}
+.rq-explain-overlay{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);
+  width:min(90%,420px);padding:.9rem 1rem;border-radius:12px;
+  background:rgba(10,22,14,.94);backdrop-filter:blur(4px);
+  box-shadow:0 6px 24px rgba(0,0,0,.5);text-align:center;
+  animation:rq-overlay-in .2s ease-out;z-index:2;pointer-events:none}
+.rq-explain-overlay.correct{border:1.5px solid #27ae60}
+.rq-explain-overlay.wrong{border:1.5px solid #c0392b}
+.rq-explain-verdict{font-size:1rem;line-height:1.3;margin-bottom:.4rem}
+.rq-explain-overlay.correct .rq-explain-verdict{color:#a8f0c6}
+.rq-explain-overlay.wrong   .rq-explain-verdict{color:#f0b8b0}
+.rq-explain-text{font-size:.85rem;line-height:1.4;color:var(--text);font-style:italic}
+@keyframes rq-overlay-in{from{opacity:0;transform:translate(-50%,-44%)}
+  to{opacity:1;transform:translate(-50%,-50%)}}
 .rq-next{display:none;margin:0 auto;padding:.65rem 2rem;background:var(--gold-dark);
   color:var(--gold-bright);border:none;border-radius:30px;font-family:'Crimson Pro',serif;
   font-size:1rem;cursor:pointer;transition:background .2s;letter-spacing:.04em}

--- a/src/styles/quiz.css
+++ b/src/styles/quiz.css
@@ -134,6 +134,8 @@
 .rq-btn.wrong{background:rgba(192,57,43,.3);border-color:#c0392b;color:#f0b8b0}
 .rq-btn:disabled{cursor:default;opacity:.7}
 .rq-feedback{text-align:center;font-size:1rem;margin-bottom:.8rem;min-height:1.5rem}
+.rq-explain{margin:.4rem auto 0;max-width:560px;font-size:.85rem;line-height:1.4;
+  color:var(--muted);font-style:italic}
 .rq-next{display:none;margin:0 auto;padding:.65rem 2rem;background:var(--gold-dark);
   color:var(--gold-bright);border:none;border-radius:30px;font-family:'Crimson Pro',serif;
   font-size:1rem;cursor:pointer;transition:background .2s;letter-spacing:.04em}

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -1,0 +1,29 @@
+.settings-panel{max-width:640px}
+.settings-sub{text-align:center;color:var(--muted);font-size:.9rem;margin:0 0 1.2rem}
+
+.settings-section{margin:1.4rem 0;padding:1rem 1rem 1.2rem;
+  border:1px solid rgba(201,168,76,.2);border-radius:12px;
+  background:rgba(0,0,0,.2)}
+
+.settings-toggle{display:flex;align-items:center;justify-content:center;gap:.6rem;
+  font-size:1rem;color:var(--text);cursor:pointer;margin:.3rem 0 .6rem}
+.settings-toggle input[type=checkbox]{width:18px;height:18px;accent-color:var(--gold);cursor:pointer}
+
+.settings-timeout{display:flex;align-items:center;justify-content:center;gap:.6rem;
+  font-size:.95rem;color:var(--text);margin-top:.4rem}
+.settings-timeout.disabled{opacity:.45}
+.settings-timeout label{color:var(--muted);letter-spacing:.04em}
+.settings-timeout input[type=number]{width:70px;padding:.35rem .5rem;
+  border-radius:8px;border:1px solid var(--gold-dark);background:rgba(0,0,0,.35);
+  color:var(--gold-bright);font-family:'Crimson Pro',serif;font-size:1rem;text-align:center}
+.settings-timeout input[type=number]:disabled{cursor:not-allowed}
+.settings-timeout input[type=number]:focus{outline:none;border-color:var(--gold)}
+
+.settings-card-preview{display:flex;justify-content:center;align-items:center;gap:8px;
+  min-height:160px;margin-top:.8rem;padding:.6rem;
+  background:rgba(0,0,0,.25);border-radius:10px}
+
+.settings-actions{display:flex;align-items:center;justify-content:center;gap:1rem;
+  margin:1.2rem 0 .4rem}
+.settings-saved{color:var(--accent);font-size:.9rem;opacity:0;transition:opacity .2s}
+.settings-saved.show{opacity:1}

--- a/src/utils/explain.js
+++ b/src/utils/explain.js
@@ -1,0 +1,111 @@
+// Short GTO-flavored rationale for a preflop quiz answer.
+// Combines a hand-feature description with an action rationale that
+// contrasts the correct choice against the alternatives the quiz offered.
+
+const RV = { A: 14, K: 13, Q: 12, J: 11, T: 10, 9: 9, 8: 8, 7: 7, 6: 6, 5: 5, 4: 4, 3: 3, 2: 2 };
+
+export function handFeatures(hand) {
+  const isPair = hand.length === 2;
+  const isSuited = hand.endsWith('s');
+  const r1 = hand[0];
+  const r2 = hand[1];
+  const hi = Math.max(RV[r1], RV[r2]);
+  const lo = Math.min(RV[r1], RV[r2]);
+  const gap = isPair ? 0 : hi - lo - 1;
+  return {
+    isPair,
+    isSuited,
+    isOffsuit: !isPair && !isSuited,
+    hi,
+    lo,
+    gap,
+    isPremiumPair: isPair && lo >= 10,         // TT+
+    isMidPair:     isPair && lo >= 7 && lo <= 9, // 77–99
+    isSmallPair:   isPair && lo <= 6,            // 22–66
+    isBroadway:    !isPair && hi >= 10 && lo >= 10,
+    isAx:          !isPair && hi === 14,
+    isWheelAx:     !isPair && hi === 14 && lo <= 5,
+    isKx:          !isPair && hi === 13,
+    isConnector:   !isPair && gap === 0,
+    isOneGapper:   !isPair && gap === 1,
+  };
+}
+
+export function handDescriptor(hand) {
+  const f = handFeatures(hand);
+  if (f.isPremiumPair) return 'Premium pair dominates almost every opening range';
+  if (f.isMidPair)     return 'Mid pair flops a set ~12% with solid showdown value';
+  if (f.isSmallPair)   return 'Small pair flops a set ~12% but needs implied odds';
+  if (f.isAx && f.isSuited && f.lo >= 10) return 'Suited big ace — top-pair equity plus nut-flush outs (~6.5%)';
+  if (f.isWheelAx && f.isSuited)          return 'Suited wheel ace — ~6.5% flush plus wheel-straight outs and an ace blocker';
+  if (f.isAx && f.isSuited)               return 'Suited ace — ~6.5% flush potential and an ace blocker';
+  if (f.isAx && f.lo >= 10)               return 'Offsuit big ace — strong top-pair hand but no flush outs';
+  if (f.isAx)                             return 'Offsuit small ace — easily dominated post-flop';
+  if (f.isBroadway && f.isSuited)         return 'Suited Broadway — top-pair equity stacked with flush + straight draws';
+  if (f.isBroadway)                       return 'Offsuit Broadway — top-pair and straight equity but no flush outs';
+  if (f.isKx && f.isSuited)               return 'Suited king — ~6.5% flush plus second-nut potential';
+  if (f.isConnector && f.isSuited)        return 'Suited connector — ~6.5% flush plus open-ended straight coverage';
+  if (f.isOneGapper && f.isSuited)        return 'Suited one-gapper — flush outs plus inside-straight coverage';
+  if (f.isSuited)                         return 'Suited — ~6.5% flush probability with backdoor straight potential';
+  if (f.isConnector)                      return 'Offsuit connector — straight coverage only, no flush outs';
+  return 'Offsuit holding with limited flush and straight equity';
+}
+
+const EP  = new Set(['UTG', 'HJ']);
+const LP  = new Set(['CO', 'BTN']);
+
+function posBucket(pos) {
+  if (EP.has(pos)) return 'ep';
+  if (LP.has(pos)) return 'lp';
+  return 'blind';
+}
+
+function stackNote(stack) {
+  if (stack === '25BB') return ' at 25BB, where speculative hands can\'t realize equity';
+  if (stack === '33BB') return ' at 33BB, where implied odds shrink';
+  return '';
+}
+
+export function actionRationale(q) {
+  const { type, heroPos, villainPos, stackDepth, correctAction } = q;
+  const bucket = posBucket(heroPos);
+  const stack = stackNote(stackDepth);
+
+  if (type === 'rfi') {
+    if (correctAction === 'raise') {
+      if (bucket === 'ep')    return `strong enough to open from ${heroPos} with players left to act; folding passes up clear +EV`;
+      if (bucket === 'lp')    return `${heroPos} has position and fold equity on the blinds — raising prints, folding is too tight`;
+      return `from ${heroPos} you can steal or set mine wide — raising beats folding here`;
+    }
+    if (bucket === 'ep')   return `too thin to open from ${heroPos}${stack} — raising gets 3-bet or flatted by better`;
+    if (bucket === 'lp')   return `below ${heroPos}'s threshold${stack} — raising bleeds when blinds wake up`;
+    return `not strong enough to steal from ${heroPos}${stack} — folding preserves chips`;
+  }
+
+  if (type === 'limp') {
+    if (correctAction === 'raise') {
+      return `iso-raise to punish the ${villainPos} limp and deny equity; over-limping is passive and folding wastes a range edge`;
+    }
+    if (correctAction === 'call') {
+      return `over-limp for pot odds — iso-raising gets 3-bet or called by better, folding passes up cheap equity`;
+    }
+    return `too dominated to iso and too weak to call profitably vs ${villainPos}'s limping range — fold`;
+  }
+
+  if (type === 'vsRaise') {
+    if (correctAction === 'threebet') {
+      return `3-bet for value and fold equity vs ${villainPos}'s open; flatting lets them realize, folding spills a +EV spot`;
+    }
+    if (correctAction === 'call') {
+      return `flat to realize equity with pot odds; 3-betting folds out worse and gets called by better, folding is too tight`;
+    }
+    return `dominated by ${villainPos}'s opening range${stack} — calling bleeds postflop, 3-bet is pure bluff`;
+  }
+
+  return '';
+}
+
+export function explainQuestion(q) {
+  if (!q) return '';
+  return `${handDescriptor(q.hand)} — ${actionRationale(q)}.`;
+}

--- a/src/utils/explain.test.js
+++ b/src/utils/explain.test.js
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { handFeatures, handDescriptor, actionRationale, explainQuestion } from './explain.js';
+
+describe('handFeatures', () => {
+  it('flags premium pairs (TT+)', () => {
+    expect(handFeatures('AA').isPremiumPair).toBe(true);
+    expect(handFeatures('TT').isPremiumPair).toBe(true);
+    expect(handFeatures('99').isPremiumPair).toBe(false);
+  });
+
+  it('flags suited connectors with zero gap', () => {
+    const f = handFeatures('76s');
+    expect(f.isConnector).toBe(true);
+    expect(f.isSuited).toBe(true);
+    expect(f.gap).toBe(0);
+  });
+
+  it('flags suited wheel aces distinctly from suited big aces', () => {
+    expect(handFeatures('A5s').isWheelAx).toBe(true);
+    expect(handFeatures('AKs').isWheelAx).toBe(false);
+    expect(handFeatures('AKs').isAx).toBe(true);
+  });
+
+  it('flags suited Broadway hands', () => {
+    expect(handFeatures('KQs').isBroadway).toBe(true);
+    expect(handFeatures('KQs').isSuited).toBe(true);
+    expect(handFeatures('T9s').isBroadway).toBe(false); // 9 not broadway
+  });
+});
+
+describe('handDescriptor', () => {
+  it('mentions 6.5% flush probability for suited non-pair hands', () => {
+    // The example in the feature request: "Suited cards give 6.5% flush probability plus …"
+    expect(handDescriptor('76s')).toMatch(/6\.5%/);
+    expect(handDescriptor('A5s')).toMatch(/6\.5%/);
+    expect(handDescriptor('K8s')).toMatch(/6\.5%/);
+  });
+
+  it('does not credit offsuit hands with flush equity', () => {
+    // Offsuit descriptors may note the *absence* of flush outs, but must not
+    // claim the positive equity that suited hands get.
+    expect(handDescriptor('AKo')).not.toMatch(/6\.5%/);
+    expect(handDescriptor('AKo')).toMatch(/no flush outs/);
+    expect(handDescriptor('72o')).not.toMatch(/6\.5%/);
+  });
+
+  it('describes premium pairs as dominating', () => {
+    expect(handDescriptor('AA')).toMatch(/dominates/i);
+  });
+
+  it('mentions set-flop math for small pairs', () => {
+    expect(handDescriptor('22')).toMatch(/set/i);
+    expect(handDescriptor('22')).toMatch(/12%/);
+  });
+});
+
+describe('actionRationale', () => {
+  it('names the alternative action when correct is raise (RFI)', () => {
+    const r = actionRationale({ type: 'rfi', heroPos: 'BTN', stackDepth: '100BB', correctAction: 'raise' });
+    expect(r).toMatch(/fold/i);
+  });
+
+  it('names the alternative action when correct is fold (RFI)', () => {
+    const r = actionRationale({ type: 'rfi', heroPos: 'UTG', stackDepth: '100BB', correctAction: 'fold' });
+    expect(r).toMatch(/rais/i); // mentions why raising is wrong
+  });
+
+  it('mentions all three alternatives in vs-limp explanations', () => {
+    const rRaise = actionRationale({ type: 'limp', heroPos: 'BTN', villainPos: 'UTG', stackDepth: '100BB', correctAction: 'raise' });
+    expect(rRaise).toMatch(/limp/i);
+    expect(rRaise).toMatch(/fold/i);
+
+    const rCall = actionRationale({ type: 'limp', heroPos: 'BTN', villainPos: 'UTG', stackDepth: '100BB', correctAction: 'call' });
+    expect(rCall).toMatch(/iso|raise/i);
+    expect(rCall).toMatch(/fold/i);
+
+    const rFold = actionRationale({ type: 'limp', heroPos: 'BTN', villainPos: 'UTG', stackDepth: '100BB', correctAction: 'fold' });
+    expect(rFold).toMatch(/iso|call/i);
+  });
+
+  it('contrasts 3-bet vs call vs fold for vs-raise spots', () => {
+    const r3b = actionRationale({ type: 'vsRaise', heroPos: 'BTN', villainPos: 'CO', stackDepth: '100BB', correctAction: 'threebet' });
+    expect(r3b).toMatch(/flat|call/i);
+    expect(r3b).toMatch(/fold/i);
+
+    const rCall = actionRationale({ type: 'vsRaise', heroPos: 'BTN', villainPos: 'CO', stackDepth: '100BB', correctAction: 'call' });
+    expect(rCall).toMatch(/3-bet/i);
+    expect(rCall).toMatch(/fold/i);
+
+    const rFold = actionRationale({ type: 'vsRaise', heroPos: 'SB', villainPos: 'UTG', stackDepth: '100BB', correctAction: 'fold' });
+    expect(rFold).toMatch(/call|3-bet/i);
+  });
+
+  it('notes stack depth when short-stacked folds', () => {
+    const r = actionRationale({ type: 'rfi', heroPos: 'UTG', stackDepth: '25BB', correctAction: 'fold' });
+    expect(r).toMatch(/25BB/);
+  });
+});
+
+describe('explainQuestion', () => {
+  it('combines hand descriptor and rationale for a suited connector RFI raise', () => {
+    const txt = explainQuestion({
+      type: 'rfi', hand: '76s', heroPos: 'BTN', villainPos: null, stackDepth: '100BB', correctAction: 'raise',
+    });
+    // Descriptor references the 6.5% flush fact from the feature request example
+    expect(txt).toMatch(/6\.5%/);
+    // Rationale references the alternative action
+    expect(txt).toMatch(/fold/i);
+    expect(txt.endsWith('.')).toBe(true);
+  });
+
+  it('returns empty string on missing question', () => {
+    expect(explainQuestion(null)).toBe('');
+    expect(explainQuestion(undefined)).toBe('');
+  });
+});

--- a/src/utils/illustrations.jsx
+++ b/src/utils/illustrations.jsx
@@ -441,14 +441,16 @@ export function getIllus(t) {
 }
 
 
-export function handToCards(h, suit) {
+export function handToCards(h, suit, size) {
   const toRank = r => r==='T' ? '10' : r;
   const rank1 = toRank(h[0]), rank2 = toRank(h[1]);
+  const w  = size?.w  || 64;
+  const ch = size?.h  || 90;
   const type = h.length===2 ? 'pair' : h[2]==='s' ? 'suited' : 'offsuit';
-  if (type==='pair') return cardSvg(rank1,'♠',64,90)+cardSvg(rank2,'♥',64,90);
+  if (type==='pair') return cardSvg(rank1,'♠',w,ch)+cardSvg(rank2,'♥',w,ch);
   if (type==='suited') {
     const s = suit || ['♠','♥','♦','♣'][Math.floor(Math.random()*4)];
-    return cardSvg(rank1,s,64,90)+cardSvg(rank2,s,64,90);
+    return cardSvg(rank1,s,w,ch)+cardSvg(rank2,s,w,ch);
   }
-  return cardSvg(rank1,'♠',64,90)+cardSvg(rank2,'♥',64,90);
+  return cardSvg(rank1,'♠',w,ch)+cardSvg(rank2,'♥',w,ch);
 }

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -58,6 +58,46 @@ export function initAllModesQuizStats() {
   return { totalQuizzes:0, totalQuestions:0, totalCorrect:0, byMode:{ rfi:{total:0,correct:0}, limp:{total:0,correct:0}, vsRaise:{total:0,correct:0} }, recentScores:[] };
 }
 
+// App Settings
+export const CARD_SIZES = {
+  small:  { w: 52, h: 74,  label: 'Small'  },
+  medium: { w: 64, h: 90,  label: 'Medium' },
+  large:  { w: 80, h: 112, label: 'Large'  },
+  xlarge: { w: 100, h: 140, label: 'Extra Large' },
+};
+
+export const DEFAULT_SETTINGS = {
+  autoAdvance: false,       // off by default — users asked to read the explanation at their own pace
+  autoAdvanceSeconds: 10,   // only used when autoAdvance is true
+  cardSize: 'medium',
+};
+
+function normalizeSettings(raw) {
+  const s = { ...DEFAULT_SETTINGS, ...(raw || {}) };
+  s.autoAdvance = Boolean(s.autoAdvance);
+  const secs = Number(s.autoAdvanceSeconds);
+  s.autoAdvanceSeconds = Number.isFinite(secs) && secs >= 1 && secs <= 60
+    ? Math.round(secs)
+    : DEFAULT_SETTINGS.autoAdvanceSeconds;
+  if (!CARD_SIZES[s.cardSize]) s.cardSize = DEFAULT_SETTINGS.cardSize;
+  return s;
+}
+
+export function getSettings() {
+  try {
+    const d = localStorage.getItem('settings');
+    return normalizeSettings(d ? JSON.parse(d) : null);
+  } catch(e) { return normalizeSettings(null); }
+}
+
+export function saveSettings(s) {
+  try { localStorage.setItem('settings', JSON.stringify(normalizeSettings(s))); } catch(e) {}
+}
+
+export function resetSettings() {
+  try { localStorage.removeItem('settings'); } catch(e) {}
+}
+
 // Study Progress
 export function getStudyProgress() {
   try { const d = localStorage.getItem('study-progress'); return d ? JSON.parse(d) : null; }

--- a/src/utils/storage.test.js
+++ b/src/utils/storage.test.js
@@ -3,6 +3,7 @@ import {
   getLimpQuizStats, saveLimpQuizStats, initLimpQuizStats,
   getVsRaiseQuizStats, saveVsRaiseQuizStats, initVsRaiseQuizStats,
   getAllModesQuizStats, saveAllModesQuizStats, initAllModesQuizStats,
+  getSettings, saveSettings, resetSettings, DEFAULT_SETTINGS, CARD_SIZES,
 } from './storage.js';
 
 // Provide a minimal localStorage shim for the node test environment
@@ -60,6 +61,67 @@ describe('initVsRaiseQuizStats', () => {
     s.totalQuizzes = 2;
     saveVsRaiseQuizStats(s);
     expect(getVsRaiseQuizStats().totalQuizzes).toBe(2);
+  });
+});
+
+describe('Settings', () => {
+  it('returns defaults when nothing is stored (auto-advance off)', () => {
+    const s = getSettings();
+    expect(s).toEqual(DEFAULT_SETTINGS);
+    expect(s.autoAdvance).toBe(false);
+    expect(s.autoAdvanceSeconds).toBe(10);
+    expect(s.cardSize).toBe('medium');
+  });
+
+  it('persists and reloads user changes', () => {
+    saveSettings({ autoAdvance: true, autoAdvanceSeconds: 7, cardSize: 'large' });
+    const s = getSettings();
+    expect(s.autoAdvance).toBe(true);
+    expect(s.autoAdvanceSeconds).toBe(7);
+    expect(s.cardSize).toBe('large');
+  });
+
+  it('merges partial saves with defaults', () => {
+    saveSettings({ cardSize: 'xlarge' });
+    const s = getSettings();
+    expect(s.cardSize).toBe('xlarge');
+    expect(s.autoAdvance).toBe(DEFAULT_SETTINGS.autoAdvance);
+    expect(s.autoAdvanceSeconds).toBe(DEFAULT_SETTINGS.autoAdvanceSeconds);
+  });
+
+  it('clamps invalid autoAdvanceSeconds back to the default', () => {
+    saveSettings({ autoAdvanceSeconds: 0 });
+    expect(getSettings().autoAdvanceSeconds).toBe(DEFAULT_SETTINGS.autoAdvanceSeconds);
+
+    saveSettings({ autoAdvanceSeconds: 999 });
+    expect(getSettings().autoAdvanceSeconds).toBe(DEFAULT_SETTINGS.autoAdvanceSeconds);
+
+    saveSettings({ autoAdvanceSeconds: 'nope' });
+    expect(getSettings().autoAdvanceSeconds).toBe(DEFAULT_SETTINGS.autoAdvanceSeconds);
+  });
+
+  it('rejects unknown cardSize keys', () => {
+    saveSettings({ cardSize: 'giant' });
+    expect(getSettings().cardSize).toBe(DEFAULT_SETTINGS.cardSize);
+  });
+
+  it('resetSettings wipes the stored value', () => {
+    saveSettings({ autoAdvance: true, cardSize: 'large' });
+    resetSettings();
+    expect(getSettings()).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it('survives malformed JSON in storage', () => {
+    localStorage.setItem('settings', '{not valid json');
+    expect(getSettings()).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it('CARD_SIZES exposes labels for every available size', () => {
+    for (const key of Object.keys(CARD_SIZES)) {
+      expect(CARD_SIZES[key].label).toBeTruthy();
+      expect(CARD_SIZES[key].w).toBeGreaterThan(0);
+      expect(CARD_SIZES[key].h).toBeGreaterThan(0);
+    }
   });
 });
 


### PR DESCRIPTION
Each answered question now shows a one-line rationale combining the
hand's equity profile (e.g. suited-connector flush + straight coverage,
set-mining math for small pairs) with why the chosen action beats the
alternatives the quiz offered (raise vs fold, iso vs call vs fold,
3-bet vs flat vs fold). Short-stack depths surface in the rationale
when they change the decision.

https://claude.ai/code/session_0159Fj5rT8fvXY9VLRrreJ5C