### PR TITLE
Add Extra Small card size option to settings

### DIFF
--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -60,6 +60,7 @@ export function initAllModesQuizStats() {
 
 // App Settings
 export const CARD_SIZES = {
+  xsmall: { w: 40, h: 56,  label: 'Extra Small' },
   small:  { w: 52, h: 74,  label: 'Small'  },
   medium: { w: 64, h: 90,  label: 'Medium' },
   large:  { w: 80, h: 112, label: 'Large'  },

--- a/src/utils/storage.test.js
+++ b/src/utils/storage.test.js
@@ -123,6 +123,18 @@ describe('Settings', () => {
       expect(CARD_SIZES[key].h).toBeGreaterThan(0);
     }
   });
+
+  it('exposes an xsmall card size smaller than small', () => {
+    expect(CARD_SIZES.xsmall).toBeDefined();
+    expect(CARD_SIZES.xsmall.label).toBe('Extra Small');
+    expect(CARD_SIZES.xsmall.w).toBeLessThan(CARD_SIZES.small.w);
+    expect(CARD_SIZES.xsmall.h).toBeLessThan(CARD_SIZES.small.h);
+  });
+
+  it('persists xsmall as a valid cardSize selection', () => {
+    saveSettings({ cardSize: 'xsmall' });
+    expect(getSettings().cardSize).toBe('xsmall');
+  });
 });
 
 describe('initAllModesQuizStats', () => {


### PR DESCRIPTION
Adds `xsmall` (40x56) as the smallest option in the card image size
selector, giving users who prefer a more compact hand display a tighter
option below `small`. The key is placed first in `CARD_SIZES` so it
renders as the leftmost selector button.

https://claude.ai/code/session_01LB5Pgkhq4kaBceuxWQZpyW