### PR TITLE
Add Stats link to quiz end screens and drop terminology from recommendations

### DIFF
--- a/src/components/Recommendation.jsx
+++ b/src/components/Recommendation.jsx
@@ -1,0 +1,22 @@
+import { getRfiQuizStats, getLimpQuizStats, getVsRaiseQuizStats } from '../utils/storage.js';
+import { getRecommendation } from '../utils/recommendation.js';
+import '../styles/stats.css';
+
+export function Recommendation() {
+  const rec = getRecommendation({
+    rfi:     getRfiQuizStats(),
+    limp:    getLimpQuizStats(),
+    vsRaise: getVsRaiseQuizStats(),
+  });
+  if (!rec) return null;
+  return (
+    <div class="stats-recommendation" data-testid="stats-recommendation">
+      <div class="stats-rec-label">Recommended Next Quiz</div>
+      <div class="stats-rec-title">{rec.label}</div>
+      <div class="stats-rec-reason">{rec.reason}</div>
+      <a class="stats-rec-btn" href={rec.href}>
+        {rec.accuracy === null ? 'Start Quiz' : 'Practice Now'} &rarr;
+      </a>
+    </div>
+  );
+}

--- a/src/components/Recommendation.test.js
+++ b/src/components/Recommendation.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const store = {};
+const localStorageMock = {
+  getItem: (k) => (k in store ? store[k] : null),
+  setItem: (k, v) => { store[k] = String(v); },
+  removeItem: (k) => { delete store[k]; },
+  clear: () => { Object.keys(store).forEach(k => delete store[k]); },
+};
+vi.stubGlobal('localStorage', localStorageMock);
+
+beforeEach(() => { localStorageMock.clear(); });
+
+describe('Recommendation source — wired to preflop stats only', () => {
+  it('imports only preflop stats getters (not terminology) for its recommendation', async () => {
+    // Guardrail: terminology quiz stats must NOT influence the recommendation since
+    // terminology was removed from QUIZ_CATALOG.
+    const { readFileSync } = await import('fs');
+    const { fileURLToPath } = await import('url');
+    const { dirname, resolve } = await import('path');
+    const here = dirname(fileURLToPath(import.meta.url));
+    const src = readFileSync(resolve(here, 'Recommendation.jsx'), 'utf8');
+    expect(src).toMatch(/getRfiQuizStats/);
+    expect(src).toMatch(/getLimpQuizStats/);
+    expect(src).toMatch(/getVsRaiseQuizStats/);
+    expect(src).not.toMatch(/getTermQuizStats/);
+  });
+
+  it('reads current stats from storage via getRecommendation', async () => {
+    // Populate rfi as weakest; expect rfi to be the recommendation after save.
+    const { saveRfiQuizStats, saveLimpQuizStats, saveVsRaiseQuizStats } = await import('../utils/storage.js');
+    saveRfiQuizStats({     totalQuizzes: 1, totalQuestions: 10, totalCorrect:  2, byPosition: {},       recentScores: [] });
+    saveLimpQuizStats({    totalQuizzes: 1, totalQuestions: 10, totalCorrect:  9, byHeroPosition: {},   byVillainPosition: {}, recentScores: [] });
+    saveVsRaiseQuizStats({ totalQuizzes: 1, totalQuestions: 10, totalCorrect:  8, byHeroPosition: {},   byVillainPosition: {}, recentScores: [] });
+
+    const { getRfiQuizStats, getLimpQuizStats, getVsRaiseQuizStats } = await import('../utils/storage.js');
+    const { getRecommendation } = await import('../utils/recommendation.js');
+    const rec = getRecommendation({
+      rfi: getRfiQuizStats(),
+      limp: getLimpQuizStats(),
+      vsRaise: getVsRaiseQuizStats(),
+    });
+    expect(rec.key).toBe('rfi');
+    expect(rec.accuracy).toBe(20);
+  });
+});

--- a/src/sections/preflop/Quiz.jsx
+++ b/src/sections/preflop/Quiz.jsx
@@ -436,6 +436,7 @@ export function PreflopQuiz({ query }) {
             <button class="rq-restart" onClick={startQuiz}>Play Again</button>
             <button class="rq-restart" style="background:transparent;border:1px solid var(--gold-dark)" onClick={exitQuiz}>Back to Setup</button>
             <a class="rq-restart" href="#/preflop/charts" style="background:transparent;border:1px solid var(--gold-dark);text-decoration:none;display:inline-block;text-align:center">Review Charts</a>
+            <a class="rq-restart" href="#/stats" style="background:transparent;border:1px solid var(--gold-dark);text-decoration:none;display:inline-block;text-align:center">Stats</a>
           </div>
           <QuizStats mode={quizMode} />
         </div>

--- a/src/sections/preflop/Quiz.jsx
+++ b/src/sections/preflop/Quiz.jsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect } from 'preact/hooks';
 import { SubNav } from '../../components/SubNav.jsx';
 import { PositionTable } from '../../components/PositionTable.jsx';
+import { Recommendation } from '../../components/Recommendation.jsx';
 import { RANKS, RFI_RANGES, RFI_QUIZ_LENGTH, RFI_QUIZ_POSITIONS, STACK_DEPTHS } from '../../data/rfi-ranges.js';
 import { LIMP_RANGES, LIMP_HERO_POSITIONS, VALID_LIMP_VILLAINS, VS_RAISE_RANGES, RAISE_HERO_POSITIONS, VALID_RAISE_VILLAINS } from '../../data/preflop-ranges.js';
 
@@ -438,6 +439,7 @@ export function PreflopQuiz({ query }) {
             <a class="rq-restart" href="#/preflop/charts" style="background:transparent;border:1px solid var(--gold-dark);text-decoration:none;display:inline-block;text-align:center">Review Charts</a>
             <a class="rq-restart" href="#/stats" style="background:transparent;border:1px solid var(--gold-dark);text-decoration:none;display:inline-block;text-align:center">Stats</a>
           </div>
+          <Recommendation />
           <QuizStats mode={quizMode} />
         </div>
       </div>

--- a/src/sections/preflop/Quiz.jsx
+++ b/src/sections/preflop/Quiz.jsx
@@ -326,6 +326,21 @@ export function PreflopQuiz({ query }) {
     setQIdx(0); setScore(0); setAnswered(false); setChoseAction(null); setResults([]);
   }
 
+  // When the URL's ?mode= changes (e.g. via the Stats page's "Practice Now"
+  // link landing on the same /quizzes/preflop route), reset to the setup
+  // screen in the requested mode. Without this, the component stays mounted
+  // and the previous complete screen persists.
+  useEffect(() => {
+    const urlMode = query?.mode && MODES.some(m => m.id === query.mode) ? query.mode : null;
+    if (!urlMode) return;
+    if (urlMode === quizMode && phase === 'setup') return;
+    setQuizMode(urlMode);
+    setSelectedPos('all');
+    setSelectedVillainPos('all');
+    setPhase('setup');
+    resetQuiz(urlMode, stackDepth, 'all', 'all');
+  }, [query?.mode]);
+
   const answer = useCallback((action) => {
     if (answered) return;
     setAnswered(true);

--- a/src/sections/preflop/Quiz.test.js
+++ b/src/sections/preflop/Quiz.test.js
@@ -209,6 +209,15 @@ describe('PreflopQuiz — complete screen', () => {
     expect(quizSource).toMatch(/import\s*\{\s*Recommendation\s*\}\s*from\s*['"][^'"]*Recommendation\.jsx['"]/);
     expect(quizSource).toMatch(/<Recommendation\s*\/>/);
   });
+
+  it('resets to setup screen when query.mode changes — fixes stuck Practice Now navigation', () => {
+    // Regression: previously, clicking "Practice Now" from the complete screen
+    // only updated the URL hash; the component stayed mounted showing the old
+    // complete screen because useState initializers don't re-run on prop change.
+    // A useEffect watching query?.mode must reset phase + mode + deck so the
+    // user lands on the setup screen for the requested mode.
+    expect(quizSource).toMatch(/useEffect\(\(\)\s*=>\s*\{[\s\S]*?query\?\.mode[\s\S]*?setPhase\(['"]setup['"]\)[\s\S]*?\},\s*\[query\?\.mode\]\)/);
+  });
 });
 
 describe('PreflopQuiz — playing screen position table', () => {

--- a/src/sections/preflop/Quiz.test.js
+++ b/src/sections/preflop/Quiz.test.js
@@ -203,6 +203,12 @@ describe('PreflopQuiz — complete screen', () => {
     // Lets users jump straight to their overall stats after finishing a quiz.
     expect(quizSource).toMatch(/href="#\/stats"[^>]*>Stats<\/a>/);
   });
+
+  it('renders the Recommendation component on the complete screen', () => {
+    // Surfaces the "Recommended Next Quiz" block right after a quiz ends.
+    expect(quizSource).toMatch(/import\s*\{\s*Recommendation\s*\}\s*from\s*['"][^'"]*Recommendation\.jsx['"]/);
+    expect(quizSource).toMatch(/<Recommendation\s*\/>/);
+  });
 });
 
 describe('PreflopQuiz — playing screen position table', () => {

--- a/src/sections/preflop/Quiz.test.js
+++ b/src/sections/preflop/Quiz.test.js
@@ -198,6 +198,13 @@ describe('PreflopQuiz — default mode', () => {
   });
 });
 
+describe('PreflopQuiz — complete screen', () => {
+  it('renders a Stats link pointing to #/stats on the complete screen', () => {
+    // Lets users jump straight to their overall stats after finishing a quiz.
+    expect(quizSource).toMatch(/href="#\/stats"[^>]*>Stats<\/a>/);
+  });
+});
+
 describe('PreflopQuiz — playing screen position table', () => {
   it('renders the PositionTable inside the playing card — visual context for the question', () => {
     expect(quizSource).toMatch(/import\s*\{\s*PositionTable\s*\}/);

--- a/src/sections/stats/Dashboard.jsx
+++ b/src/sections/stats/Dashboard.jsx
@@ -3,7 +3,7 @@ import { TERMS, CATS } from '../../data/terms.js';
 import { RFI_QUIZ_POSITIONS } from '../../data/rfi-ranges.js';
 import { getStudyProgress, initStudyProgress, getTermQuizStats, initTermQuizStats, getRfiQuizStats, initRfiQuizStats, getLimpQuizStats, initLimpQuizStats, getVsRaiseQuizStats, initVsRaiseQuizStats, getAllModesQuizStats, initAllModesQuizStats } from '../../utils/storage.js';
 import { LIMP_HERO_POSITIONS, RAISE_HERO_POSITIONS } from '../../data/preflop-ranges.js';
-import { getRecommendation } from '../../utils/recommendation.js';
+import { Recommendation } from '../../components/Recommendation.jsx';
 import '../../styles/stats.css';
 
 export function Dashboard({ path }) {
@@ -26,13 +26,6 @@ export function Dashboard({ path }) {
 
   const rfiAccuracy = rfiQuiz.totalQuestions > 0
     ? Math.round(rfiQuiz.totalCorrect / rfiQuiz.totalQuestions * 100) : 0;
-
-  const recommendation = getRecommendation({
-    terminology: termQuiz,
-    rfi: rfiQuiz,
-    limp: limpQuiz,
-    vsRaise: vsRaiseQuiz,
-  });
 
   function resetStudy() {
     if (!confirm('Reset all study progress? This cannot be undone.')) return;
@@ -69,16 +62,7 @@ export function Dashboard({ path }) {
     <div class="stats-dashboard">
       <h2 class="stats-title">Your Stats</h2>
 
-      {recommendation && (
-        <div class="stats-recommendation" data-testid="stats-recommendation">
-          <div class="stats-rec-label">Recommended Next Quiz</div>
-          <div class="stats-rec-title">{recommendation.label}</div>
-          <div class="stats-rec-reason">{recommendation.reason}</div>
-          <a class="stats-rec-btn" href={recommendation.href}>
-            {recommendation.accuracy === null ? 'Start Quiz' : 'Practice Now'} &rarr;
-          </a>
-        </div>
-      )}
+      <Recommendation />
 
       {/* Study Progress */}
       <div class="stats-section">

--- a/src/sections/terminology/Quiz.jsx
+++ b/src/sections/terminology/Quiz.jsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'preact/hooks';
 import { SubNav } from '../../components/SubNav.jsx';
 import { FilterChips } from '../../components/FilterChips.jsx';
+import { Recommendation } from '../../components/Recommendation.jsx';
 import { useFilters } from '../../hooks/useFilters.js';
 import { TERMS } from '../../data/terms.js';
 import { shuffle } from '../../utils/shuffle.js';
@@ -109,6 +110,7 @@ export function Quiz({ path }) {
             <button class="restart-btn" onClick={restart}>Play Again</button>
             <a class="restart-btn" href="#/stats" style="background:transparent;border:1px solid var(--gold-dark);text-decoration:none;display:inline-block;margin-left:.5rem">Stats</a>
           </div>
+          <Recommendation />
         </div>
       </div>
     );

--- a/src/sections/terminology/Quiz.jsx
+++ b/src/sections/terminology/Quiz.jsx
@@ -107,6 +107,7 @@ export function Quiz({ path }) {
             <p style="font-size:1.5rem;color:var(--gold-bright);margin:.5rem 0">{score} / {total} &mdash; {pct}%</p>
             <p>{msg}</p>
             <button class="restart-btn" onClick={restart}>Play Again</button>
+            <a class="restart-btn" href="#/stats" style="background:transparent;border:1px solid var(--gold-dark);text-decoration:none;display:inline-block;margin-left:.5rem">Stats</a>
           </div>
         </div>
       </div>

--- a/src/sections/terminology/Quiz.test.js
+++ b/src/sections/terminology/Quiz.test.js
@@ -41,6 +41,12 @@ describe('Quiz — complete screen', () => {
     // Lets users jump straight to their overall stats after finishing a quiz.
     expect(quizSource).toMatch(/href="#\/stats"[^>]*>Stats<\/a>/);
   });
+
+  it('renders the Recommendation component on the complete screen', () => {
+    // Surfaces the "Recommended Next Quiz" block right after a quiz ends.
+    expect(quizSource).toMatch(/import\s*\{\s*Recommendation\s*\}\s*from\s*['"][^'"]*Recommendation\.jsx['"]/);
+    expect(quizSource).toMatch(/<Recommendation\s*\/>/);
+  });
 });
 
 describe('buildDeck', () => {

--- a/src/sections/terminology/Quiz.test.js
+++ b/src/sections/terminology/Quiz.test.js
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
 import { TERMS } from '../../data/terms.js';
 import { buildDeck, buildOptions } from './Quiz.jsx';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const quizSource = readFileSync(resolve(__dirname, 'Quiz.jsx'), 'utf8');
 
 const ALL_CATS = new Set(TERMS.map(t => t.cat));
 
@@ -27,6 +33,13 @@ describe('buildOptions', () => {
     const deck = buildDeck(ALL_CATS);
     expect(buildOptions(deck, deck.length)).toEqual([]);
     expect(buildOptions([], 0)).toEqual([]);
+  });
+});
+
+describe('Quiz — complete screen', () => {
+  it('renders a Stats link pointing to #/stats on the complete screen', () => {
+    // Lets users jump straight to their overall stats after finishing a quiz.
+    expect(quizSource).toMatch(/href="#\/stats"[^>]*>Stats<\/a>/);
   });
 });
 

--- a/src/utils/recommendation.js
+++ b/src/utils/recommendation.js
@@ -1,8 +1,9 @@
 // Pure logic for "next quiz to take" recommendation on the Stats dashboard.
 // Extracted from the UI so it can be unit-tested without DOM / localStorage.
 
+// Terminology quiz is intentionally excluded — recommendations focus on preflop ranges
+// since terminology knowledge is binary (learned or not) rather than a skill to grind.
 export const QUIZ_CATALOG = [
-  { key: 'terminology', label: 'Terminology Quiz',      href: '#/quizzes/terminology' },
   { key: 'rfi',         label: 'Preflop RFI Quiz',      href: '#/quizzes/preflop?mode=rfi' },
   { key: 'limp',        label: 'Preflop vs Limp Quiz',  href: '#/quizzes/preflop?mode=limp' },
   { key: 'vsRaise',     label: 'Preflop vs Raise Quiz', href: '#/quizzes/preflop?mode=vsRaise' },

--- a/src/utils/recommendation.test.js
+++ b/src/utils/recommendation.test.js
@@ -8,7 +8,6 @@ function stats(totalQuestions, totalCorrect) {
 describe('getRecommendation', () => {
   it('recommends an untaken quiz before ranking by accuracy', () => {
     const rec = getRecommendation({
-      terminology: stats(10, 5),
       rfi:         stats(10, 9),
       limp:        null, // untaken
       vsRaise:     stats(10, 4),
@@ -20,7 +19,6 @@ describe('getRecommendation', () => {
 
   it('recommends the lowest-accuracy quiz when all have data', () => {
     const rec = getRecommendation({
-      terminology: stats(20, 18), // 90%
       rfi:         stats(20, 14), // 70%
       limp:        stats(20,  8), // 40%  ← weakest
       vsRaise:     stats(20, 12), // 60%
@@ -32,24 +30,22 @@ describe('getRecommendation', () => {
 
   it('treats zero totalQuestions as untaken (not 0% accuracy)', () => {
     const rec = getRecommendation({
-      terminology: { totalQuestions: 0, totalCorrect: 0 },
-      rfi:         stats(10, 9),
+      rfi:         { totalQuestions: 0, totalCorrect: 0 },
       limp:        stats(10, 8),
       vsRaise:     stats(10, 7),
     });
-    expect(rec.key).toBe('terminology');
+    expect(rec.key).toBe('rfi');
     expect(rec.accuracy).toBeNull();
   });
 
   it('returns first catalog entry on a ties-at-lowest-accuracy case', () => {
     const rec = getRecommendation({
-      terminology: stats(10, 5),
       rfi:         stats(10, 5),
       limp:        stats(10, 5),
       vsRaise:     stats(10, 5),
     });
-    // All 50%; tie-break picks the first in catalog order (terminology).
-    expect(rec.key).toBe('terminology');
+    // All 50%; tie-break picks the first in catalog order (rfi).
+    expect(rec.key).toBe('rfi');
   });
 
   it('handles undefined statsMap entries the same as null', () => {
@@ -66,6 +62,21 @@ describe('getRecommendation', () => {
       const hash = q.href.replace(/^#/, '');
       const path = hash.split('?')[0];
       expect(validPaths.has(path), `${q.key} href ${q.href} points to unknown route ${path}`).toBe(true);
+    }
+  });
+
+  it('never recommends the terminology quiz — preflop-only recommendations', () => {
+    // Even when terminology stats are present in the map, it must not be recommended
+    // because it's not in QUIZ_CATALOG.
+    const rec = getRecommendation({
+      terminology: stats(10, 1), // 10% — would be weakest if considered
+      rfi:         stats(10, 9),
+      limp:        stats(10, 8),
+      vsRaise:     stats(10, 7),
+    });
+    expect(rec.key).not.toBe('terminology');
+    for (const q of QUIZ_CATALOG) {
+      expect(q.key).not.toBe('terminology');
     }
   });
 });


### PR DESCRIPTION
Both quiz complete screens now include a Stats link to #/stats so users
can jump straight to their progress after finishing a round. The Stats
dashboard's "Recommended Next Quiz" now considers only the preflop
quizzes — terminology knowledge is binary rather than a skill to grind,
so it shouldn't compete with preflop ranges for the recommendation slot.

https://claude.ai/code/session_01Q97sZfUM4xxZ5GGcZXmp66