### PR TITLE
Add configurable quiz length setting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ Fonts: `'Playfair Display'` for headings, `'Crimson Pro'` for body text.
 | `rfi-quiz-stats` | `{ totalQuizzes, totalQuestions, totalCorrect, byPosition, recentScores }` |
 | `term-quiz-stats` | `{ totalQuizzes, totalQuestions, totalCorrect, bestStreak, recentScores }` |
 | `study-progress` | `{ cardsSeen: [], totalFlips, byCategory: {} }` |
-| `settings` | `{ autoAdvance, autoAdvanceSeconds, cardSize }` |
+| `settings` | `{ autoAdvance, autoAdvanceSeconds, cardSize, quizLength }` |
 
 ---
 

--- a/src/sections/preflop/Quiz.jsx
+++ b/src/sections/preflop/Quiz.jsx
@@ -122,15 +122,19 @@ function generateVsRaiseHand(stackDepth, heroOverride = null, villainOverride = 
   return { type: 'vsRaise', hand, heroPos, villainPos, stackDepth, suit: randomSuit(), correctAction };
 }
 
-function buildDeck(mode, stackDepth, heroPos = 'all', villainPos = 'all') {
+export function buildDeck(mode, stackDepth, heroPos = 'all', villainPos = 'all', length = RFI_QUIZ_LENGTH) {
   const heroOv    = heroPos    !== 'all' ? heroPos    : null;
   const villainOv = villainPos !== 'all' ? villainPos : null;
   const deck = [];
   const counts = {};
   let attempts = 0;
-  const maxPerAction = mode === 'rfi' ? 7 : 4;
+  // Cap per action scales with quiz length so the balance constraint doesn't
+  // stall deck-building for longer quizzes. Same ratios as the original 10-q
+  // defaults (7/10 for rfi, 4/10 for the other modes).
+  const maxPerAction = mode === 'rfi' ? Math.ceil(length * 0.7) : Math.ceil(length * 0.4);
+  const maxAttempts = Math.max(300, length * 30);
 
-  while (deck.length < RFI_QUIZ_LENGTH && attempts < 300) {
+  while (deck.length < length && attempts < maxAttempts) {
     attempts++;
     let q;
     if (mode === 'rfi') q = generateRfiHand(stackDepth, heroOv);
@@ -183,7 +187,7 @@ function promptText(q) {
 }
 
 // ---------- save stats helpers ----------
-function saveStats(results, mode, score, stackDepth) {
+function saveStats(results, mode, score, stackDepth, quizLength) {
   if (mode === 'rfi' || mode === 'all') {
     const rfi = getRfiQuizStats() || initRfiQuizStats();
     const rfiResults = results.filter(r => r.type === 'rfi');
@@ -197,7 +201,7 @@ function saveStats(results, mode, score, stackDepth) {
         if (r.correct) rfi.byPosition[r.heroPos].correct++;
       });
       if (mode === 'rfi') {
-        rfi.recentScores.push({ date: new Date().toLocaleDateString(), score, total: RFI_QUIZ_LENGTH });
+        rfi.recentScores.push({ date: new Date().toLocaleDateString(), score, total: quizLength });
         if (rfi.recentScores.length > 20) rfi.recentScores = rfi.recentScores.slice(-20);
       }
       saveRfiQuizStats(rfi);
@@ -222,7 +226,7 @@ function saveStats(results, mode, score, stackDepth) {
         }
       });
       if (mode === 'limp') {
-        limp.recentScores.push({ date: new Date().toLocaleDateString(), score, total: RFI_QUIZ_LENGTH });
+        limp.recentScores.push({ date: new Date().toLocaleDateString(), score, total: quizLength });
         if (limp.recentScores.length > 20) limp.recentScores = limp.recentScores.slice(-20);
       }
       saveLimpQuizStats(limp);
@@ -247,7 +251,7 @@ function saveStats(results, mode, score, stackDepth) {
         }
       });
       if (mode === 'vsRaise') {
-        vsr.recentScores.push({ date: new Date().toLocaleDateString(), score, total: RFI_QUIZ_LENGTH });
+        vsr.recentScores.push({ date: new Date().toLocaleDateString(), score, total: quizLength });
         if (vsr.recentScores.length > 20) vsr.recentScores = vsr.recentScores.slice(-20);
       }
       saveVsRaiseQuizStats(vsr);
@@ -257,7 +261,7 @@ function saveStats(results, mode, score, stackDepth) {
   if (mode === 'all') {
     const all = getAllModesQuizStats() || initAllModesQuizStats();
     all.totalQuizzes++;
-    all.totalQuestions += RFI_QUIZ_LENGTH;
+    all.totalQuestions += quizLength;
     all.totalCorrect += score;
     results.forEach(r => {
       const modeKey = r.type === 'vsRaise' ? 'vsRaise' : r.type;
@@ -265,7 +269,7 @@ function saveStats(results, mode, score, stackDepth) {
       all.byMode[modeKey].total++;
       if (r.correct) all.byMode[modeKey].correct++;
     });
-    all.recentScores.push({ date: new Date().toLocaleDateString(), score, total: RFI_QUIZ_LENGTH });
+    all.recentScores.push({ date: new Date().toLocaleDateString(), score, total: quizLength });
     if (all.recentScores.length > 20) all.recentScores = all.recentScores.slice(-20);
     saveAllModesQuizStats(all);
   }
@@ -279,17 +283,21 @@ export function PreflopQuiz({ query }) {
   const [stackDepth, setStackDepth] = useState('100BB');
   const [selectedPos, setSelectedPos] = useState('all');
   const [selectedVillainPos, setSelectedVillainPos] = useState('all');
-  const [deck, setDeck]             = useState(() => buildDeck(initialMode, '100BB', 'all', 'all'));
+  const [settings, setSettings]     = useState(() => getSettings());
+  const [deck, setDeck]             = useState(() => buildDeck(initialMode, '100BB', 'all', 'all', settings.quizLength));
   const [qIdx, setQIdx]             = useState(0);
   const [score, setScore]           = useState(0);
   const [answered, setAnswered]     = useState(false);
   const [choseAction, setChoseAction] = useState(null);
   const [results, setResults]       = useState([]);
-  const [settings]                  = useState(() => getSettings());
   const [countdown, setCountdown]   = useState(settings.autoAdvanceSeconds);
 
   function resetQuiz(mode, depth, pos, villainPos) {
-    setDeck(buildDeck(mode, depth, pos, villainPos));
+    // Re-read settings at quiz-start so a length change on the Settings page
+    // takes effect the next time the user starts a quiz without a reload.
+    const fresh = getSettings();
+    setSettings(fresh);
+    setDeck(buildDeck(mode, depth, pos, villainPos, fresh.quizLength));
     setQIdx(0); setScore(0); setAnswered(false); setChoseAction(null); setResults([]);
   }
 
@@ -433,13 +441,13 @@ export function PreflopQuiz({ query }) {
 
   // ── Complete screen ───────────────────────────────────────────────────────
   if (qIdx >= deck.length && deck.length > 0) {
-    const pct = Math.round(score / RFI_QUIZ_LENGTH * 100);
+    const pct = Math.round(score / deck.length * 100);
     const msg = pct >= 90 ? 'Phenomenal \u2014 you know your ranges!' :
                 pct >= 70 ? 'Well played \u2014 solid range knowledge.' :
                 pct >= 50 ? 'Good start \u2014 review the charts.' :
                 'Hit the charts and come back!';
 
-    saveStats(results, quizMode, score, stackDepth);
+    saveStats(results, quizMode, score, stackDepth, deck.length);
 
     return (
       <div>
@@ -447,7 +455,7 @@ export function PreflopQuiz({ query }) {
         <div class="rq-panel">
           <div class="rq-complete">
             <h2>{pct >= 70 ? '\uD83C\uDFC6' : '\uD83C\uDCCF'} Quiz Complete</h2>
-            <div class="score-big">{score} / {RFI_QUIZ_LENGTH} &mdash; {pct}%</div>
+            <div class="score-big">{score} / {deck.length} &mdash; {pct}%</div>
             <p>{msg}</p>
             <button class="rq-restart" onClick={startQuiz}>Play Again</button>
             <button class="rq-restart" style="background:transparent;border:1px solid var(--gold-dark)" onClick={exitQuiz}>Back to Setup</button>
@@ -477,10 +485,10 @@ export function PreflopQuiz({ query }) {
           <button class="rq-exit-btn" onClick={exitQuiz}>Exit</button>
         </div>
 
-        <div class="rq-progress"><div class="rq-progress-fill" style={{ width: (qIdx / RFI_QUIZ_LENGTH * 100) + '%' }}></div></div>
+        <div class="rq-progress"><div class="rq-progress-fill" style={{ width: (qIdx / deck.length * 100) + '%' }}></div></div>
         <div class="rq-status">
           <div class="rq-stat"><div class="val">{score}</div><div class="lbl">Correct</div></div>
-          <div class="rq-stat"><div class="val">{qIdx + 1} / {RFI_QUIZ_LENGTH}</div><div class="lbl">Question</div></div>
+          <div class="rq-stat"><div class="val">{qIdx + 1} / {deck.length}</div><div class="lbl">Question</div></div>
           <div class="rq-stat"><div class="val">{pctDisplay}</div><div class="lbl">Accuracy</div></div>
         </div>
 

--- a/src/sections/preflop/Quiz.test.js
+++ b/src/sections/preflop/Quiz.test.js
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 import { RANKS, RFI_RANGES, RFI_QUIZ_LENGTH, RFI_QUIZ_POSITIONS, STACK_DEPTHS } from '../../data/rfi-ranges.js';
 import { LIMP_HERO_POSITIONS, RAISE_HERO_POSITIONS } from '../../data/preflop-ranges.js';
-import { getPositionsForMode, getVillainsForSelection, getHeroesForVillain } from './Quiz.jsx';
+import { getPositionsForMode, getVillainsForSelection, getHeroesForVillain, buildDeck } from './Quiz.jsx';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const quizSource = readFileSync(resolve(__dirname, 'Quiz.jsx'), 'utf8');
@@ -194,7 +194,7 @@ describe('PreflopQuiz — default mode', () => {
   });
 
   it('initial deck is built with the resolved initialMode (so default-all hits all hand generators)', () => {
-    expect(quizSource).toMatch(/buildDeck\(initialMode,\s*'100BB',\s*'all',\s*'all'\)/);
+    expect(quizSource).toMatch(/buildDeck\(initialMode,\s*'100BB',\s*'all',\s*'all'(?:,\s*settings\.quizLength)?\)/);
   });
 });
 
@@ -217,6 +217,43 @@ describe('PreflopQuiz — complete screen', () => {
     // A useEffect watching query?.mode must reset phase + mode + deck so the
     // user lands on the setup screen for the requested mode.
     expect(quizSource).toMatch(/useEffect\(\(\)\s*=>\s*\{[\s\S]*?query\?\.mode[\s\S]*?setPhase\(['"]setup['"]\)[\s\S]*?\},\s*\[query\?\.mode\]\)/);
+  });
+});
+
+describe('PreflopQuiz — configurable quiz length', () => {
+  it('buildDeck honors the length parameter (rfi mode)', () => {
+    for (const len of [5, 10, 20, 30]) {
+      const deck = buildDeck('rfi', '100BB', 'all', 'all', len);
+      expect(deck.length).toBe(len);
+    }
+  });
+
+  it('buildDeck honors the length parameter (all mode)', () => {
+    for (const len of [5, 15, 25]) {
+      const deck = buildDeck('all', '100BB', 'all', 'all', len);
+      expect(deck.length).toBe(len);
+    }
+  });
+
+  it('buildDeck defaults to RFI_QUIZ_LENGTH when no length is passed', () => {
+    const deck = buildDeck('rfi', '100BB', 'all', 'all');
+    expect(deck.length).toBe(RFI_QUIZ_LENGTH);
+  });
+
+  it('component reads settings.quizLength and threads it through buildDeck', () => {
+    // Regression: if buildDeck is called without the length arg, the preflop
+    // quiz silently ignores the Settings page "Quiz length" choice.
+    expect(quizSource).toMatch(/buildDeck\([^)]*,\s*fresh\.quizLength\)/);
+    expect(quizSource).toMatch(/buildDeck\(initialMode,\s*'100BB',\s*'all',\s*'all',\s*settings\.quizLength\)/);
+  });
+
+  it('component renders deck.length in playing/complete UI (not a hardcoded constant)', () => {
+    // Progress bar, "Question X / N", and complete-screen score must scale
+    // with the user-chosen quiz length.
+    expect(quizSource).toMatch(/qIdx \/ deck\.length \* 100/);
+    expect(quizSource).toMatch(/\{qIdx \+ 1\} \/ \{deck\.length\}/);
+    expect(quizSource).toMatch(/score \/ deck\.length \* 100/);
+    expect(quizSource).toMatch(/\{score\} \/ \{deck\.length\}/);
   });
 });
 

--- a/src/sections/settings/Settings.jsx
+++ b/src/sections/settings/Settings.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'preact/hooks';
-import { getSettings, saveSettings, resetSettings, DEFAULT_SETTINGS, CARD_SIZES } from '../../utils/storage.js';
+import { getSettings, saveSettings, resetSettings, DEFAULT_SETTINGS, CARD_SIZES, QUIZ_LENGTH_MIN, QUIZ_LENGTH_MAX } from '../../utils/storage.js';
 import { handToCards } from '../../utils/illustrations.jsx';
 import '../../styles/settings.css';
 
@@ -53,6 +53,38 @@ export function Settings() {
             onInput={(e) => {
               const n = Number(e.currentTarget.value);
               if (Number.isFinite(n) && n >= 1 && n <= 60) update({ autoAdvanceSeconds: n });
+            }}
+          />
+        </div>
+      </section>
+
+      <section class="settings-section">
+        <div class="rq-setup-label">Quiz length</div>
+        <p class="settings-sub" style="margin:.2rem 0 .6rem">Number of questions per quiz run.</p>
+        <div class="rq-selector-group">
+          {[5, 10, 20, 30, 50].map(n => (
+            <button
+              key={n}
+              type="button"
+              class={`rq-selector-btn${settings.quizLength === n ? ' active' : ''}`}
+              onClick={() => update({ quizLength: n })}
+            >{n}</button>
+          ))}
+        </div>
+        <div class="settings-timeout">
+          <label for="settings-quiz-length-input">Custom</label>
+          <input
+            id="settings-quiz-length-input"
+            type="number"
+            min={QUIZ_LENGTH_MIN}
+            max={QUIZ_LENGTH_MAX}
+            step="1"
+            value={settings.quizLength}
+            onInput={(e) => {
+              const n = Number(e.currentTarget.value);
+              if (Number.isFinite(n) && n >= QUIZ_LENGTH_MIN && n <= QUIZ_LENGTH_MAX) {
+                update({ quizLength: Math.round(n) });
+              }
             }}
           />
         </div>

--- a/src/sections/terminology/Quiz.jsx
+++ b/src/sections/terminology/Quiz.jsx
@@ -6,7 +6,7 @@ import { useFilters } from '../../hooks/useFilters.js';
 import { TERMS } from '../../data/terms.js';
 import { shuffle } from '../../utils/shuffle.js';
 import { getIllus } from '../../utils/illustrations.jsx';
-import { getTermQuizStats, saveTermQuizStats, initTermQuizStats } from '../../utils/storage.js';
+import { getTermQuizStats, saveTermQuizStats, initTermQuizStats, getSettings } from '../../utils/storage.js';
 import '../../styles/quiz.css';
 
 const TABS = [
@@ -14,8 +14,9 @@ const TABS = [
   { path: '/quizzes/terminology', label: 'Terminology' },
 ];
 
-export function buildDeck(cats) {
-  return shuffle(TERMS.filter(t => cats.has(t.cat)));
+export function buildDeck(cats, length = Infinity) {
+  const deck = shuffle(TERMS.filter(t => cats.has(t.cat)));
+  return Number.isFinite(length) ? deck.slice(0, Math.max(0, length)) : deck;
 }
 
 export function buildOptions(deck, idx) {
@@ -28,7 +29,8 @@ export function buildOptions(deck, idx) {
 
 export function Quiz({ path }) {
   const { activeCats, toggleCat } = useFilters();
-  const [quizDeck, setQuizDeck] = useState(() => buildDeck(activeCats));
+  const [settings, setSettings] = useState(() => getSettings());
+  const [quizDeck, setQuizDeck] = useState(() => buildDeck(activeCats, settings.quizLength));
   const [qIdx, setQIdx] = useState(0);
   const [score, setScore] = useState(0);
   const [streak, setStreak] = useState(0);
@@ -39,7 +41,11 @@ export function Quiz({ path }) {
   const [options, setOptions] = useState(() => buildOptions(quizDeck, 0));
 
   function restart() {
-    const newDeck = buildDeck(activeCats);
+    // Re-read settings so a quizLength change on the Settings page takes
+    // effect on the next run without requiring a reload.
+    const fresh = getSettings();
+    setSettings(fresh);
+    const newDeck = buildDeck(activeCats, fresh.quizLength);
     setQuizDeck(newDeck);
     setQIdx(0);
     setScore(0);

--- a/src/sections/terminology/Quiz.test.js
+++ b/src/sections/terminology/Quiz.test.js
@@ -63,4 +63,21 @@ describe('buildDeck', () => {
     const deck = buildDeck(new Set());
     expect(deck).toHaveLength(0);
   });
+
+  it('respects the optional length parameter — quizLength setting controls question count', () => {
+    const deck = buildDeck(ALL_CATS, 5);
+    expect(deck).toHaveLength(5);
+  });
+
+  it('returns fewer than requested when the filtered pool is smaller', () => {
+    const cats = new Set(['Hand Rankings']);
+    const full = buildDeck(cats);
+    const limited = buildDeck(cats, full.length + 50);
+    expect(limited.length).toBe(full.length);
+  });
+
+  it('defaults to the full filtered deck when no length is passed', () => {
+    const full = buildDeck(ALL_CATS);
+    expect(full.length).toBe(TERMS.filter(t => ALL_CATS.has(t.cat)).length);
+  });
 });

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -67,10 +67,14 @@ export const CARD_SIZES = {
   xlarge: { w: 100, h: 140, label: 'Extra Large' },
 };
 
+export const QUIZ_LENGTH_MIN = 5;
+export const QUIZ_LENGTH_MAX = 100;
+
 export const DEFAULT_SETTINGS = {
   autoAdvance: false,       // off by default — users asked to read the explanation at their own pace
   autoAdvanceSeconds: 10,   // only used when autoAdvance is true
   cardSize: 'medium',
+  quizLength: 10,           // number of questions per quiz run
 };
 
 function normalizeSettings(raw) {
@@ -81,6 +85,10 @@ function normalizeSettings(raw) {
     ? Math.round(secs)
     : DEFAULT_SETTINGS.autoAdvanceSeconds;
   if (!CARD_SIZES[s.cardSize]) s.cardSize = DEFAULT_SETTINGS.cardSize;
+  const ql = Number(s.quizLength);
+  s.quizLength = Number.isFinite(ql) && ql >= QUIZ_LENGTH_MIN && ql <= QUIZ_LENGTH_MAX
+    ? Math.round(ql)
+    : DEFAULT_SETTINGS.quizLength;
   return s;
 }
 

--- a/src/utils/storage.test.js
+++ b/src/utils/storage.test.js
@@ -4,6 +4,7 @@ import {
   getVsRaiseQuizStats, saveVsRaiseQuizStats, initVsRaiseQuizStats,
   getAllModesQuizStats, saveAllModesQuizStats, initAllModesQuizStats,
   getSettings, saveSettings, resetSettings, DEFAULT_SETTINGS, CARD_SIZES,
+  QUIZ_LENGTH_MIN, QUIZ_LENGTH_MAX,
 } from './storage.js';
 
 // Provide a minimal localStorage shim for the node test environment
@@ -134,6 +135,39 @@ describe('Settings', () => {
   it('persists xsmall as a valid cardSize selection', () => {
     saveSettings({ cardSize: 'xsmall' });
     expect(getSettings().cardSize).toBe('xsmall');
+  });
+
+  it('exposes a default quizLength in DEFAULT_SETTINGS', () => {
+    expect(DEFAULT_SETTINGS.quizLength).toBe(10);
+    expect(getSettings().quizLength).toBe(10);
+  });
+
+  it('persists quizLength selections within range', () => {
+    saveSettings({ quizLength: 25 });
+    expect(getSettings().quizLength).toBe(25);
+    saveSettings({ quizLength: QUIZ_LENGTH_MAX });
+    expect(getSettings().quizLength).toBe(QUIZ_LENGTH_MAX);
+  });
+
+  it('clamps invalid quizLength back to the default', () => {
+    saveSettings({ quizLength: 0 });
+    expect(getSettings().quizLength).toBe(DEFAULT_SETTINGS.quizLength);
+
+    saveSettings({ quizLength: QUIZ_LENGTH_MAX + 1 });
+    expect(getSettings().quizLength).toBe(DEFAULT_SETTINGS.quizLength);
+
+    saveSettings({ quizLength: 'nope' });
+    expect(getSettings().quizLength).toBe(DEFAULT_SETTINGS.quizLength);
+  });
+
+  it('rounds non-integer quizLength values', () => {
+    saveSettings({ quizLength: 12.7 });
+    expect(getSettings().quizLength).toBe(13);
+  });
+
+  it('quiz length range is at least 5..100', () => {
+    expect(QUIZ_LENGTH_MIN).toBeLessThanOrEqual(5);
+    expect(QUIZ_LENGTH_MAX).toBeGreaterThanOrEqual(100);
   });
 });
 


### PR DESCRIPTION
Adds a "Quiz length" control to the Settings page so users can choose
how many hand combinations (or terminology questions) each quiz run
contains. Preset buttons (5/10/20/30/50) plus a custom numeric input
(clamped to 5..100) persist to localStorage and take effect on the next
quiz start. Preflop Quiz now scales its action-balance cap and
deck-build attempt budget with the chosen length; UI references to the
hardcoded 10-question total switch to deck.length.