### PR TITLE
Add shareable quiz links for terminology and preflop quizzes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,8 @@ poker-trainer/
 │   │   ├── illustrations.jsx           # cardSvg(), hand(), ILLUS, getIllus(), handToCards()
 │   │   ├── shuffle.js                  # Immutable Fisher-Yates shuffle
 │   │   ├── storage.js                  # localStorage helpers for all 3 stat stores
-│   │   └── explain.js                  # Quiz feedback rationale (hand features + action logic)
+│   │   ├── explain.js                  # Quiz feedback rationale (hand features + action logic)
+│   │   └── share.js                    # Encode/decode quiz config into share-link query strings
 │   ├── hooks/
 │   │   ├── useFilters.js               # activeCats state + toggle logic
 │   │   └── useDeck.js                  # deck, idx, flipped, nav, shuffle
@@ -57,6 +58,7 @@ poker-trainer/
 │   │   ├── SubNav.jsx                  # Sub-navigation tabs within a section
 │   │   ├── FilterChips.jsx             # Category filter chip bar
 │   │   ├── ProgressBar.jsx             # Study progress bar
+│   │   ├── ShareButton.jsx             # Copy-to-clipboard button for share links
 │   │   └── Modal.jsx                   # Term detail modal overlay
 │   └── sections/
 │       ├── welcome/
@@ -95,6 +97,17 @@ Hash-based routing (`#/path`) for GitHub Pages compatibility.
 | `#/settings` | Settings.jsx | User preferences (auto-advance, card image size) |
 
 Redirects: `/` → `/welcome`, `/terminology` → `/terminology/study`, `/preflop` → `/preflop/charts`
+
+### Shareable quiz links
+
+Quiz routes accept query strings that encode a reproducible quiz:
+
+| Route | Query | Meaning |
+|---|---|---|
+| `#/quizzes/terminology` | `?tq=<i,i,i,...>` | Comma-separated indexes into `TERMS`; defines the ordered question deck. |
+| `#/quizzes/preflop` | `?pq=<stackDepth>~<q1>~<q2>...` | Each `qN = <typeCode>.<hand>.<heroPos>.<villainOrDash>` where typeCode ∈ `{r,l,v}` (rfi, limp, vsRaise). Correct actions are re-derived from the GTO ranges. |
+
+A shared preflop quiz auto-starts in the playing phase; a shared terminology quiz replaces the randomly shuffled deck with the shared ordered list. "Play Again" replays the same deck; "New Random Quiz" exits shared mode. See `src/utils/share.js` and `src/components/ShareButton.jsx`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ Quiz routes accept query strings that encode a reproducible quiz:
 | Route | Query | Meaning |
 |---|---|---|
 | `#/quizzes/terminology` | `?tq=<i,i,i,...>` | Comma-separated indexes into `TERMS`; defines the ordered question deck. |
-| `#/quizzes/preflop` | `?pq=<stackDepth>~<q1>~<q2>...` | Each `qN = <typeCode>.<hand>.<heroPos>.<villainOrDash>` where typeCode ∈ `{r,l,v}` (rfi, limp, vsRaise). Correct actions are re-derived from the GTO ranges. |
+| `#/quizzes/preflop` | `?pq=<stackDepth>~<q1>~<q2>...` | Each `qN = <typeCode>.<hand>.<heroPos>.<villainOrDash>.<suitCode>` where typeCode ∈ `{r,l,v}` (rfi, limp, vsRaise) and suitCode ∈ `{s,h,d,c}`. Correct actions are re-derived from the GTO ranges; suits preserve the exact card rendering. The trailing suit field is optional — legacy 4-field links still decode. |
 
 A shared preflop quiz auto-starts in the playing phase; a shared terminology quiz replaces the randomly shuffled deck with the shared ordered list. "Play Again" replays the same deck; "New Random Quiz" exits shared mode. See `src/utils/share.js` and `src/components/ShareButton.jsx`.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@
 ### Stats
 - **Dashboard** — Full statistics view showing study progress, terminology quiz accuracy, and RFI quiz performance by position. Surfaces a "Recommended Next Quiz" card that points you at your weakest area (or an untaken quiz for a baseline) with a one-click button to start it.
 
+### Shareable Quiz Links
+Every quiz (terminology + preflop) has a **Share** button that copies a link encoding the exact quiz configuration — its length, stack depth, and the full ordered list of questions. Opening the link launches that identical quiz, so two players can attempt the same set of questions and compare scores.
+
 ## Technology
 
 | Concern | Implementation |

--- a/src/components/ShareButton.jsx
+++ b/src/components/ShareButton.jsx
@@ -1,0 +1,46 @@
+import { useState, useRef, useEffect } from 'preact/hooks';
+import { copyToClipboard } from '../utils/share.js';
+
+export function ShareButton({ url, label = 'Share Quiz', disabled = false }) {
+  const [status, setStatus] = useState('idle'); // 'idle' | 'copied' | 'error'
+  const timerRef = useRef(null);
+
+  useEffect(() => () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+  }, []);
+
+  async function onClick() {
+    if (disabled || !url) return;
+    const ok = await copyToClipboard(url);
+    setStatus(ok ? 'copied' : 'error');
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setStatus('idle'), 2200);
+  }
+
+  const text = status === 'copied' ? 'Link Copied!' :
+               status === 'error'  ? 'Copy Failed \u2014 Long-press URL:'
+                                   : label;
+
+  return (
+    <div class="share-wrap">
+      <button
+        type="button"
+        class={`share-btn${status === 'copied' ? ' copied' : ''}${status === 'error' ? ' error' : ''}`}
+        onClick={onClick}
+        disabled={disabled || !url}
+        aria-label={label}
+      >
+        {text}
+      </button>
+      {status === 'error' && (
+        <input
+          class="share-fallback"
+          type="text"
+          readOnly
+          value={url}
+          onFocus={(e) => e.currentTarget.select()}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/ShareButton.jsx
+++ b/src/components/ShareButton.jsx
@@ -1,7 +1,17 @@
 import { useState, useRef, useEffect } from 'preact/hooks';
 import { copyToClipboard } from '../utils/share.js';
 
-export function ShareButton({ url, label = 'Share Quiz', disabled = false }) {
+export function ShareButton({
+  url,
+  content,
+  label = 'Share Link',
+  copiedLabel = 'Link Copied!',
+  disabled = false,
+}) {
+  // `content` is the payload that gets copied. Defaults to `url` so the
+  // "Share Link" variant stays a one-prop call. The "Share Score" variant
+  // passes a full message that already embeds the URL.
+  const payload = content ?? url;
   const [status, setStatus] = useState('idle'); // 'idle' | 'copied' | 'error'
   const timerRef = useRef(null);
 
@@ -10,15 +20,15 @@ export function ShareButton({ url, label = 'Share Quiz', disabled = false }) {
   }, []);
 
   async function onClick() {
-    if (disabled || !url) return;
-    const ok = await copyToClipboard(url);
+    if (disabled || !payload) return;
+    const ok = await copyToClipboard(payload);
     setStatus(ok ? 'copied' : 'error');
     if (timerRef.current) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => setStatus('idle'), 2200);
   }
 
-  const text = status === 'copied' ? 'Link Copied!' :
-               status === 'error'  ? 'Copy Failed \u2014 Long-press URL:'
+  const text = status === 'copied' ? copiedLabel :
+               status === 'error'  ? 'Copy Failed \u2014 select text below:'
                                    : label;
 
   return (
@@ -27,17 +37,17 @@ export function ShareButton({ url, label = 'Share Quiz', disabled = false }) {
         type="button"
         class={`share-btn${status === 'copied' ? ' copied' : ''}${status === 'error' ? ' error' : ''}`}
         onClick={onClick}
-        disabled={disabled || !url}
+        disabled={disabled || !payload}
         aria-label={label}
       >
         {text}
       </button>
       {status === 'error' && (
-        <input
+        <textarea
           class="share-fallback"
-          type="text"
           readOnly
-          value={url}
+          rows={2}
+          value={payload}
           onFocus={(e) => e.currentTarget.select()}
         />
       )}

--- a/src/sections/preflop/Quiz.jsx
+++ b/src/sections/preflop/Quiz.jsx
@@ -278,7 +278,10 @@ function saveStats(results, mode, score, stackDepth, quizLength) {
 }
 
 function hydrateSharedDeck(deck) {
-  return deck.map(q => ({ ...q, suit: randomSuit() }));
+  // Preserve suits encoded in the share link (so suited hands render
+  // identically across replays). Legacy links without a suit get a
+  // freshly randomized one on each play.
+  return deck.map(q => ({ ...q, suit: q.suit || randomSuit() }));
 }
 
 function deriveModeFromDeck(deck) {

--- a/src/sections/preflop/Quiz.jsx
+++ b/src/sections/preflop/Quiz.jsx
@@ -43,7 +43,7 @@ import { getRfiQuizStats, saveRfiQuizStats, initRfiQuizStats, getLimpQuizStats, 
 import { handToCards } from '../../utils/illustrations.jsx';
 import { explainQuestion } from '../../utils/explain.js';
 import { ShareButton } from '../../components/ShareButton.jsx';
-import { encodePreflopQuiz, decodePreflopQuiz, buildShareUrl } from '../../utils/share.js';
+import { encodePreflopQuiz, decodePreflopQuiz, buildShareUrl, buildScoreMessage } from '../../utils/share.js';
 import '../../styles/quiz.css';
 
 const TABS = [
@@ -535,7 +535,12 @@ export function PreflopQuiz({ query }) {
             <a class="rq-restart" href="#/preflop/charts" style="background:transparent;border:1px solid var(--gold-dark);text-decoration:none;display:inline-block;text-align:center">Review Charts</a>
             <a class="rq-restart" href="#/stats" style="background:transparent;border:1px solid var(--gold-dark);text-decoration:none;display:inline-block;text-align:center">Stats</a>
             <div class="share-row">
-              <ShareButton url={completeShareUrl} label="Share This Quiz" />
+              <ShareButton url={completeShareUrl} label="Share Link" copiedLabel="Link Copied!" />
+              <ShareButton
+                content={completeShareUrl ? buildScoreMessage(score, deck.length, completeShareUrl) : null}
+                label="Share Score"
+                copiedLabel="Message Copied!"
+              />
             </div>
           </div>
           <Recommendation />
@@ -630,7 +635,7 @@ export function PreflopQuiz({ query }) {
               )}
             </div>
             <div class="share-row">
-              <ShareButton url={playingShareUrl} />
+              <ShareButton url={playingShareUrl} label="Share Link" copiedLabel="Link Copied!" />
             </div>
           </>
         )}

--- a/src/sections/preflop/Quiz.jsx
+++ b/src/sections/preflop/Quiz.jsx
@@ -42,6 +42,8 @@ export function getHeroesForVillain(mode, villainPos) {
 import { getRfiQuizStats, saveRfiQuizStats, initRfiQuizStats, getLimpQuizStats, saveLimpQuizStats, initLimpQuizStats, getVsRaiseQuizStats, saveVsRaiseQuizStats, initVsRaiseQuizStats, getAllModesQuizStats, saveAllModesQuizStats, initAllModesQuizStats, getSettings, CARD_SIZES } from '../../utils/storage.js';
 import { handToCards } from '../../utils/illustrations.jsx';
 import { explainQuestion } from '../../utils/explain.js';
+import { ShareButton } from '../../components/ShareButton.jsx';
+import { encodePreflopQuiz, decodePreflopQuiz, buildShareUrl } from '../../utils/share.js';
 import '../../styles/quiz.css';
 
 const TABS = [
@@ -275,16 +277,35 @@ function saveStats(results, mode, score, stackDepth, quizLength) {
   }
 }
 
+function hydrateSharedDeck(deck) {
+  return deck.map(q => ({ ...q, suit: randomSuit() }));
+}
+
+function deriveModeFromDeck(deck) {
+  if (!Array.isArray(deck) || deck.length === 0) return 'all';
+  const types = new Set(deck.map(q => q.type));
+  if (types.size === 1) return [...types][0];
+  return 'all';
+}
+
 // ---------- main component ----------
 export function PreflopQuiz({ query }) {
-  const initialMode = query?.mode && MODES.some(m => m.id === query.mode) ? query.mode : 'all';
-  const [phase, setPhase]           = useState('setup'); // 'setup' | 'playing'
+  const shared = decodePreflopQuiz(query);
+  const initialMode = shared
+    ? deriveModeFromDeck(shared.deck)
+    : (query?.mode && MODES.some(m => m.id === query.mode) ? query.mode : 'all');
+  const initialStack = shared ? shared.stackDepth : '100BB';
+  const initialPhase = shared ? 'playing' : 'setup';
+  const [phase, setPhase]           = useState(initialPhase);
   const [quizMode, setQuizMode]     = useState(initialMode);
-  const [stackDepth, setStackDepth] = useState('100BB');
+  const [stackDepth, setStackDepth] = useState(initialStack);
   const [selectedPos, setSelectedPos] = useState('all');
   const [selectedVillainPos, setSelectedVillainPos] = useState('all');
   const [settings, setSettings]     = useState(() => getSettings());
-  const [deck, setDeck]             = useState(() => buildDeck(initialMode, '100BB', 'all', 'all', settings.quizLength));
+  const [sharedDeck, setSharedDeck] = useState(() => (shared ? hydrateSharedDeck(shared.deck) : null));
+  const [deck, setDeck]             = useState(() => (
+    shared ? hydrateSharedDeck(shared.deck) : buildDeck(initialMode, '100BB', 'all', 'all', settings.quizLength)
+  ));
   const [qIdx, setQIdx]             = useState(0);
   const [score, setScore]           = useState(0);
   const [answered, setAnswered]     = useState(false);
@@ -299,6 +320,21 @@ export function PreflopQuiz({ query }) {
     setSettings(fresh);
     setDeck(buildDeck(mode, depth, pos, villainPos, fresh.quizLength));
     setQIdx(0); setScore(0); setAnswered(false); setChoseAction(null); setResults([]);
+  }
+
+  function replaySharedDeck() {
+    if (!sharedDeck) return;
+    setDeck(hydrateSharedDeck(sharedDeck));
+    setQIdx(0); setScore(0); setAnswered(false); setChoseAction(null); setResults([]);
+  }
+
+  function exitShared() {
+    setSharedDeck(null);
+    setPhase('setup');
+    setQIdx(0); setScore(0); setAnswered(false); setChoseAction(null); setResults([]);
+    if (window.location.hash.includes('?pq=')) {
+      window.location.hash = '#/quizzes/preflop';
+    }
   }
 
   function changeMode(m) {
@@ -339,6 +375,7 @@ export function PreflopQuiz({ query }) {
   // screen in the requested mode. Without this, the component stays mounted
   // and the previous complete screen persists.
   useEffect(() => {
+    if (query?.pq) return; // shared-link handler owns state transitions
     const urlMode = query?.mode && MODES.some(m => m.id === query.mode) ? query.mode : null;
     if (!urlMode) return;
     if (urlMode === quizMode && phase === 'setup') return;
@@ -348,6 +385,32 @@ export function PreflopQuiz({ query }) {
     setPhase('setup');
     resetQuiz(urlMode, stackDepth, 'all', 'all');
   }, [query?.mode]);
+
+  // Shared-link handler: when ?pq= appears (or changes), load the shared deck
+  // and auto-start the quiz so the recipient sees the exact same questions.
+  useEffect(() => {
+    const next = decodePreflopQuiz(query);
+    if (!next) return;
+    const sameDeck = sharedDeck
+      && sharedDeck.length === next.deck.length
+      && sharedDeck.every((q, i) => (
+        q.type === next.deck[i].type
+        && q.hand === next.deck[i].hand
+        && q.heroPos === next.deck[i].heroPos
+        && q.villainPos === next.deck[i].villainPos
+      ))
+      && stackDepth === next.stackDepth;
+    if (sameDeck) return;
+    const hydrated = hydrateSharedDeck(next.deck);
+    setSharedDeck(hydrated);
+    setDeck(hydrated);
+    setStackDepth(next.stackDepth);
+    setQuizMode(deriveModeFromDeck(next.deck));
+    setSelectedPos('all');
+    setSelectedVillainPos('all');
+    setPhase('playing');
+    setQIdx(0); setScore(0); setAnswered(false); setChoseAction(null); setResults([]);
+  }, [query?.pq]);
 
   const answer = useCallback((action) => {
     if (answered) return;
@@ -449,6 +512,9 @@ export function PreflopQuiz({ query }) {
 
     saveStats(results, quizMode, score, stackDepth, deck.length);
 
+    const completeShareQuery = encodePreflopQuiz(stackDepth, deck);
+    const completeShareUrl = completeShareQuery ? buildShareUrl('/quizzes/preflop', completeShareQuery) : null;
+
     return (
       <div>
         <SubNav tabs={TABS} currentPath="/quizzes/preflop" />
@@ -457,10 +523,17 @@ export function PreflopQuiz({ query }) {
             <h2>{pct >= 70 ? '\uD83C\uDFC6' : '\uD83C\uDCCF'} Quiz Complete</h2>
             <div class="score-big">{score} / {deck.length} &mdash; {pct}%</div>
             <p>{msg}</p>
-            <button class="rq-restart" onClick={startQuiz}>Play Again</button>
-            <button class="rq-restart" style="background:transparent;border:1px solid var(--gold-dark)" onClick={exitQuiz}>Back to Setup</button>
+            <button class="rq-restart" onClick={sharedDeck ? replaySharedDeck : startQuiz}>Play Again</button>
+            {sharedDeck ? (
+              <button class="rq-restart" style="background:transparent;border:1px solid var(--gold-dark)" onClick={exitShared}>New Random Quiz</button>
+            ) : (
+              <button class="rq-restart" style="background:transparent;border:1px solid var(--gold-dark)" onClick={exitQuiz}>Back to Setup</button>
+            )}
             <a class="rq-restart" href="#/preflop/charts" style="background:transparent;border:1px solid var(--gold-dark);text-decoration:none;display:inline-block;text-align:center">Review Charts</a>
             <a class="rq-restart" href="#/stats" style="background:transparent;border:1px solid var(--gold-dark);text-decoration:none;display:inline-block;text-align:center">Stats</a>
+            <div class="share-row">
+              <ShareButton url={completeShareUrl} label="Share This Quiz" />
+            </div>
           </div>
           <Recommendation />
           <QuizStats mode={quizMode} />
@@ -476,13 +549,15 @@ export function PreflopQuiz({ query }) {
   const buttons = current ? getButtons(current.type) : [];
   const modeLabel = MODES.find(m => m.id === quizMode)?.label ?? quizMode;
   const villainAction = current?.type === 'vsRaise' ? 'raise' : current?.type === 'limp' ? 'limp' : null;
+  const playingShareQuery = encodePreflopQuiz(stackDepth, deck);
+  const playingShareUrl = playingShareQuery ? buildShareUrl('/quizzes/preflop', playingShareQuery) : null;
 
   return (
     <div class="rq-playing-wrapper">
       <div class="rq-panel">
         <div class="rq-playing-header">
-          <div class="rq-mode-badge">{modeLabel} &middot; {stackDepth}</div>
-          <button class="rq-exit-btn" onClick={exitQuiz}>Exit</button>
+          <div class="rq-mode-badge">{modeLabel} &middot; {stackDepth}{sharedDeck ? ' \u00b7 Shared' : ''}</div>
+          <button class="rq-exit-btn" onClick={sharedDeck ? exitShared : exitQuiz}>Exit</button>
         </div>
 
         <div class="rq-progress"><div class="rq-progress-fill" style={{ width: (qIdx / deck.length * 100) + '%' }}></div></div>
@@ -550,6 +625,9 @@ export function PreflopQuiz({ query }) {
                   )}
                 </>
               )}
+            </div>
+            <div class="share-row">
+              <ShareButton url={playingShareUrl} />
             </div>
           </>
         )}

--- a/src/sections/preflop/Quiz.test.js
+++ b/src/sections/preflop/Quiz.test.js
@@ -268,6 +268,14 @@ describe('PreflopQuiz — share link integration', () => {
     expect(quizSource).toMatch(/<ShareButton\s/);
   });
 
+  it('splits the complete-screen share UI into Share Link + Share Score buttons', () => {
+    // "Share Link" copies just the URL; "Share Score" copies a score-brag
+    // message that already embeds the URL via buildScoreMessage.
+    expect(quizSource).toMatch(/label="Share Link"/);
+    expect(quizSource).toMatch(/label="Share Score"/);
+    expect(quizSource).toMatch(/buildScoreMessage\(score,\s*deck\.length,\s*completeShareUrl\)/);
+  });
+
   it('auto-starts in playing phase when a shared ?pq= deck is decoded', () => {
     // Share links should launch the quiz directly; if the recipient had to
     // click through the setup screen, they could rebuild a different deck.

--- a/src/sections/preflop/Quiz.test.js
+++ b/src/sections/preflop/Quiz.test.js
@@ -257,6 +257,29 @@ describe('PreflopQuiz — configurable quiz length', () => {
   });
 });
 
+describe('PreflopQuiz — share link integration', () => {
+  it('imports share utilities used to encode/decode quiz config into a URL', () => {
+    expect(quizSource).toMatch(/from\s+['"][^'"]*\/utils\/share\.js['"]/);
+    expect(quizSource).toMatch(/encodePreflopQuiz/);
+    expect(quizSource).toMatch(/decodePreflopQuiz/);
+  });
+
+  it('renders a ShareButton so users can copy a link to the current quiz', () => {
+    expect(quizSource).toMatch(/<ShareButton\s/);
+  });
+
+  it('auto-starts in playing phase when a shared ?pq= deck is decoded', () => {
+    // Share links should launch the quiz directly; if the recipient had to
+    // click through the setup screen, they could rebuild a different deck.
+    expect(quizSource).toMatch(/shared\s*\?\s*'playing'\s*:\s*'setup'/);
+  });
+
+  it('hydrates the deck from a shared ?pq= query and respects its stack depth', () => {
+    expect(quizSource).toMatch(/decodePreflopQuiz\(query\)/);
+    expect(quizSource).toMatch(/shared\.stackDepth/);
+  });
+});
+
 describe('PreflopQuiz — playing screen position table', () => {
   it('renders the PositionTable inside the playing card — visual context for the question', () => {
     expect(quizSource).toMatch(/import\s*\{\s*PositionTable\s*\}/);

--- a/src/sections/terminology/Quiz.jsx
+++ b/src/sections/terminology/Quiz.jsx
@@ -1,12 +1,14 @@
-import { useState, useCallback } from 'preact/hooks';
+import { useState, useCallback, useEffect } from 'preact/hooks';
 import { SubNav } from '../../components/SubNav.jsx';
 import { FilterChips } from '../../components/FilterChips.jsx';
 import { Recommendation } from '../../components/Recommendation.jsx';
+import { ShareButton } from '../../components/ShareButton.jsx';
 import { useFilters } from '../../hooks/useFilters.js';
 import { TERMS } from '../../data/terms.js';
 import { shuffle } from '../../utils/shuffle.js';
 import { getIllus } from '../../utils/illustrations.jsx';
 import { getTermQuizStats, saveTermQuizStats, initTermQuizStats, getSettings } from '../../utils/storage.js';
+import { encodeTermQuiz, decodeTermQuiz, buildShareUrl } from '../../utils/share.js';
 import '../../styles/quiz.css';
 
 const TABS = [
@@ -27,10 +29,14 @@ export function buildOptions(deck, idx) {
   return shuffle([...picked, t]);
 }
 
-export function Quiz({ path }) {
+export function Quiz({ path, query }) {
+  const shared = decodeTermQuiz(query);
   const { activeCats, toggleCat } = useFilters();
   const [settings, setSettings] = useState(() => getSettings());
-  const [quizDeck, setQuizDeck] = useState(() => buildDeck(activeCats, settings.quizLength));
+  const [sharedDeck, setSharedDeck] = useState(() => shared?.deck || null);
+  const [quizDeck, setQuizDeck] = useState(() => (
+    shared?.deck ? shared.deck : buildDeck(activeCats, settings.quizLength)
+  ));
   const [qIdx, setQIdx] = useState(0);
   const [score, setScore] = useState(0);
   const [streak, setStreak] = useState(0);
@@ -40,9 +46,45 @@ export function Quiz({ path }) {
   // quizDeck is already set above; use the same deck for initial options so q0 answer is always present
   const [options, setOptions] = useState(() => buildOptions(quizDeck, 0));
 
+  // If the URL's ?tq= query changes (e.g. opening a shared link while already
+  // on the quiz), rebuild the deck from the shared terms.
+  useEffect(() => {
+    const next = decodeTermQuiz(query);
+    if (!next) return;
+    const sameDeck = sharedDeck
+      && sharedDeck.length === next.deck.length
+      && sharedDeck.every((t, i) => t.term === next.deck[i].term);
+    if (sameDeck) return;
+    setSharedDeck(next.deck);
+    setQuizDeck(next.deck);
+    setQIdx(0);
+    setScore(0);
+    setStreak(0);
+    setTotal(0);
+    setAnswered(false);
+    setSelectedAnswer(null);
+    setOptions(buildOptions(next.deck, 0));
+  }, [query?.tq]);
+
   function restart() {
     // Re-read settings so a quizLength change on the Settings page takes
-    // effect on the next run without requiring a reload.
+    // effect on the next run without requiring a reload. Shared quizzes
+    // replay the same deck so the share link stays reproducible.
+    const fresh = getSettings();
+    setSettings(fresh);
+    const newDeck = sharedDeck ? sharedDeck : buildDeck(activeCats, fresh.quizLength);
+    setQuizDeck(newDeck);
+    setQIdx(0);
+    setScore(0);
+    setStreak(0);
+    setTotal(0);
+    setAnswered(false);
+    setSelectedAnswer(null);
+    setOptions(buildOptions(newDeck, 0));
+  }
+
+  function startFreshQuiz() {
+    setSharedDeck(null);
     const fresh = getSettings();
     setSettings(fresh);
     const newDeck = buildDeck(activeCats, fresh.quizLength);
@@ -54,13 +96,21 @@ export function Quiz({ path }) {
     setAnswered(false);
     setSelectedAnswer(null);
     setOptions(buildOptions(newDeck, 0));
+    // Strip the share query from the URL so the user ends up on a clean quiz route.
+    if (window.location.hash.includes('?tq=')) {
+      window.location.hash = '#/quizzes/terminology';
+    }
   }
 
   function handleFilterToggle(cat) {
+    if (sharedDeck) return; // filters are meaningless for a fixed shared deck
     toggleCat(cat);
     // Restart quiz with new filters on next render
     setTimeout(restart, 0);
   }
+
+  const shareQuery = encodeTermQuiz(quizDeck);
+  const shareUrl = shareQuery ? buildShareUrl('/quizzes/terminology', shareQuery) : null;
 
   const answerQuiz = useCallback((chosen) => {
     if (answered) return;
@@ -107,14 +157,20 @@ export function Quiz({ path }) {
     return (
       <div>
         <SubNav tabs={TABS} currentPath="/quizzes/terminology" />
-        <FilterChips activeCats={activeCats} onToggle={handleFilterToggle} />
+        {!sharedDeck && <FilterChips activeCats={activeCats} onToggle={handleFilterToggle} />}
         <div class="quiz-panel">
           <div class="quiz-complete">
             <h2>{pct >= 70 ? '\uD83C\uDFC6' : '\uD83C\uDCCF'} Round Complete</h2>
             <p style="font-size:1.5rem;color:var(--gold-bright);margin:.5rem 0">{score} / {total} &mdash; {pct}%</p>
             <p>{msg}</p>
             <button class="restart-btn" onClick={restart}>Play Again</button>
+            {sharedDeck && (
+              <button class="restart-btn" style="background:transparent;border:1px solid var(--gold-dark);margin-left:.5rem" onClick={startFreshQuiz}>New Random Quiz</button>
+            )}
             <a class="restart-btn" href="#/stats" style="background:transparent;border:1px solid var(--gold-dark);text-decoration:none;display:inline-block;margin-left:.5rem">Stats</a>
+            <div class="share-row">
+              <ShareButton url={shareUrl} label="Share This Quiz" />
+            </div>
           </div>
           <Recommendation />
         </div>
@@ -129,8 +185,14 @@ export function Quiz({ path }) {
   return (
     <div>
       <SubNav tabs={TABS} currentPath="/quizzes/terminology" />
-      <FilterChips activeCats={activeCats} onToggle={handleFilterToggle} />
+      {!sharedDeck && <FilterChips activeCats={activeCats} onToggle={handleFilterToggle} />}
       <div class="quiz-panel">
+        {sharedDeck && (
+          <div class="shared-quiz-banner">
+            <span>Shared quiz {'\u2014'} {quizDeck.length} questions</span>
+            <button type="button" class="shared-quiz-exit" onClick={startFreshQuiz}>Start Random Quiz</button>
+          </div>
+        )}
         <div class="quiz-status">
           <div class="q-stat"><div class="val">{score}</div><div class="lbl">Correct</div></div>
           <div class="q-stat"><div class="val">{streak}</div><div class="lbl">Streak</div></div>
@@ -169,6 +231,9 @@ export function Quiz({ path }) {
                   Next Question {'\u2192'}
                 </button>
               )}
+            </div>
+            <div class="share-row">
+              <ShareButton url={shareUrl} />
             </div>
           </>
         )}

--- a/src/sections/terminology/Quiz.jsx
+++ b/src/sections/terminology/Quiz.jsx
@@ -8,7 +8,7 @@ import { TERMS } from '../../data/terms.js';
 import { shuffle } from '../../utils/shuffle.js';
 import { getIllus } from '../../utils/illustrations.jsx';
 import { getTermQuizStats, saveTermQuizStats, initTermQuizStats, getSettings } from '../../utils/storage.js';
-import { encodeTermQuiz, decodeTermQuiz, buildShareUrl } from '../../utils/share.js';
+import { encodeTermQuiz, decodeTermQuiz, buildShareUrl, buildScoreMessage } from '../../utils/share.js';
 import '../../styles/quiz.css';
 
 const TABS = [
@@ -169,7 +169,12 @@ export function Quiz({ path, query }) {
             )}
             <a class="restart-btn" href="#/stats" style="background:transparent;border:1px solid var(--gold-dark);text-decoration:none;display:inline-block;margin-left:.5rem">Stats</a>
             <div class="share-row">
-              <ShareButton url={shareUrl} label="Share This Quiz" />
+              <ShareButton url={shareUrl} label="Share Link" copiedLabel="Link Copied!" />
+              <ShareButton
+                content={shareUrl ? buildScoreMessage(score, total, shareUrl) : null}
+                label="Share Score"
+                copiedLabel="Message Copied!"
+              />
             </div>
           </div>
           <Recommendation />
@@ -233,7 +238,7 @@ export function Quiz({ path, query }) {
               )}
             </div>
             <div class="share-row">
-              <ShareButton url={shareUrl} />
+              <ShareButton url={shareUrl} label="Share Link" copiedLabel="Link Copied!" />
             </div>
           </>
         )}

--- a/src/sections/terminology/Quiz.test.js
+++ b/src/sections/terminology/Quiz.test.js
@@ -60,6 +60,14 @@ describe('Quiz — share link integration', () => {
     expect(quizSource).toMatch(/<ShareButton\s/);
   });
 
+  it('splits the complete-screen share UI into Share Link + Share Score buttons', () => {
+    // "Share Link" copies just the URL; "Share Score" copies a score-brag
+    // message that already embeds the URL via buildScoreMessage.
+    expect(quizSource).toMatch(/label="Share Link"/);
+    expect(quizSource).toMatch(/label="Share Score"/);
+    expect(quizSource).toMatch(/buildScoreMessage\(score,\s*total,\s*shareUrl\)/);
+  });
+
   it('hydrates the deck from a shared ?tq= query on initial render', () => {
     // Without this branch a shared link would still show a random quiz.
     expect(quizSource).toMatch(/decodeTermQuiz\(query\)/);

--- a/src/sections/terminology/Quiz.test.js
+++ b/src/sections/terminology/Quiz.test.js
@@ -49,6 +49,24 @@ describe('Quiz — complete screen', () => {
   });
 });
 
+describe('Quiz — share link integration', () => {
+  it('imports share utilities used to encode/decode quiz config into a URL', () => {
+    expect(quizSource).toMatch(/from\s+['"][^'"]*\/utils\/share\.js['"]/);
+    expect(quizSource).toMatch(/encodeTermQuiz/);
+    expect(quizSource).toMatch(/decodeTermQuiz/);
+  });
+
+  it('renders a ShareButton so users can copy a link to the current quiz', () => {
+    expect(quizSource).toMatch(/<ShareButton\s/);
+  });
+
+  it('hydrates the deck from a shared ?tq= query on initial render', () => {
+    // Without this branch a shared link would still show a random quiz.
+    expect(quizSource).toMatch(/decodeTermQuiz\(query\)/);
+    expect(quizSource).toMatch(/shared\?\.deck/);
+  });
+});
+
 describe('buildDeck', () => {
   it('filters terms to only matching categories', () => {
     const cats = new Set(['Hand Rankings']);

--- a/src/styles/quiz.css
+++ b/src/styles/quiz.css
@@ -183,3 +183,24 @@
 .rq-history{margin-top:.5rem}
 .rq-history-title{font-size:.8rem;color:var(--muted);letter-spacing:.08em;text-transform:uppercase;margin-bottom:.4rem}
 .rq-history-row{display:flex;justify-content:space-between;font-size:.85rem;color:var(--muted);padding:.2rem 0;border-bottom:1px solid rgba(255,255,255,.05)}
+
+/* Share link */
+.share-row{display:flex;justify-content:center;margin:.8rem 0 .2rem}
+.share-wrap{display:flex;flex-direction:column;align-items:center;gap:.4rem;width:100%;max-width:420px}
+.share-btn{padding:.45rem 1.1rem;background:transparent;border:1px solid var(--gold-dark);
+  color:var(--gold);border-radius:20px;font-family:'Crimson Pro',serif;font-size:.85rem;
+  cursor:pointer;letter-spacing:.04em;transition:all .2s}
+.share-btn:hover:not(:disabled){background:rgba(201,168,76,.12);border-color:var(--gold);color:var(--gold-bright)}
+.share-btn:disabled{cursor:default;opacity:.5}
+.share-btn.copied{background:rgba(46,204,113,.18);border-color:#27ae60;color:#a8f0c6}
+.share-btn.error{background:rgba(192,57,43,.15);border-color:#c0392b;color:#f0b8b0}
+.share-fallback{width:100%;padding:.4rem .6rem;background:rgba(0,0,0,.35);
+  border:1px solid var(--gold-dark);border-radius:6px;color:var(--text);
+  font-family:monospace;font-size:.8rem}
+.shared-quiz-banner{display:flex;justify-content:space-between;align-items:center;gap:.5rem;
+  padding:.5rem .8rem;margin-bottom:.8rem;border:1px solid var(--gold-dark);
+  border-radius:10px;background:rgba(201,168,76,.08);color:var(--gold-bright);
+  font-size:.85rem;letter-spacing:.04em}
+.shared-quiz-exit{background:transparent;border:1px solid var(--gold-dark);color:var(--muted);
+  border-radius:16px;padding:.25rem .75rem;font-family:'Crimson Pro',serif;font-size:.8rem;cursor:pointer}
+.shared-quiz-exit:hover{border-color:var(--gold);color:var(--text)}

--- a/src/styles/quiz.css
+++ b/src/styles/quiz.css
@@ -185,8 +185,8 @@
 .rq-history-row{display:flex;justify-content:space-between;font-size:.85rem;color:var(--muted);padding:.2rem 0;border-bottom:1px solid rgba(255,255,255,.05)}
 
 /* Share link */
-.share-row{display:flex;justify-content:center;margin:.8rem 0 .2rem}
-.share-wrap{display:flex;flex-direction:column;align-items:center;gap:.4rem;width:100%;max-width:420px}
+.share-row{display:flex;justify-content:center;gap:.6rem;flex-wrap:wrap;margin:.8rem 0 .2rem}
+.share-wrap{display:flex;flex-direction:column;align-items:center;gap:.4rem;flex:0 1 auto;max-width:420px}
 .share-btn{padding:.45rem 1.1rem;background:transparent;border:1px solid var(--gold-dark);
   color:var(--gold);border-radius:20px;font-family:'Crimson Pro',serif;font-size:.85rem;
   cursor:pointer;letter-spacing:.04em;transition:all .2s}

--- a/src/utils/share.js
+++ b/src/utils/share.js
@@ -8,13 +8,16 @@
 //     indexes defines the exact question order.
 //
 //   Preflop:     #/quizzes/preflop?pq=<stackDepth>~<q1>~<q2>...
-//     Each qN = <typeCode>.<hand>.<heroPos>.<villainOrDash>
+//     Each qN = <typeCode>.<hand>.<heroPos>.<villainOrDash>.<suitCode>
 //     typeCode: r = rfi, l = limp, v = vsRaise
 //     villainOrDash: either a position string or "-" (RFI has no villain)
+//     suitCode: s / h / d / c (spades / hearts / diamonds / clubs).
+//       Older 4-field links without a suit field still decode — the recipient
+//       just gets a freshly-randomized suit for those questions.
 //
 // The decoded deck is sufficient to reproduce the identical quiz: correct
-// actions are looked up from the deterministic GTO ranges, and suits are
-// cosmetic (re-randomized on each play).
+// actions are looked up from the deterministic GTO ranges, and preserving
+// the suit keeps suited-hand renderings identical across shares.
 
 import { TERMS } from '../data/terms.js';
 import { RFI_RANGES, STACK_DEPTHS } from '../data/rfi-ranges.js';
@@ -22,6 +25,9 @@ import { LIMP_RANGES, VS_RAISE_RANGES } from '../data/preflop-ranges.js';
 
 const TYPE_ENCODE = { rfi: 'r', limp: 'l', vsRaise: 'v' };
 const TYPE_DECODE = { r: 'rfi', l: 'limp', v: 'vsRaise' };
+
+const SUIT_ENCODE = { '\u2660': 's', '\u2665': 'h', '\u2666': 'd', '\u2663': 'c' };
+const SUIT_DECODE = { s: '\u2660', h: '\u2665', d: '\u2666', c: '\u2663' };
 
 const TERM_INDEX = new Map(TERMS.map((t, i) => [t.term, i]));
 
@@ -76,7 +82,9 @@ export function encodePreflopQuiz(stackDepth, deck) {
   for (const q of deck) {
     const code = TYPE_ENCODE[q.type];
     if (!code || !q.hand || !q.heroPos) return null;
-    parts.push(`${code}.${q.hand}.${q.heroPos}.${q.villainPos || '-'}`);
+    const suitCode = SUIT_ENCODE[q.suit] || '';
+    const suffix = suitCode ? `.${suitCode}` : '';
+    parts.push(`${code}.${q.hand}.${q.heroPos}.${q.villainPos || '-'}${suffix}`);
   }
   return `pq=${stackDepth}~${parts.join('~')}`;
 }
@@ -91,14 +99,21 @@ export function decodePreflopQuiz(query) {
   const deck = [];
   for (const s of qs) {
     const fields = s.split('.');
-    if (fields.length !== 4) return null;
-    const [code, hand, heroPos, villainRaw] = fields;
+    // 4-field (legacy) or 5-field (with suit) encodings.
+    if (fields.length !== 4 && fields.length !== 5) return null;
+    const [code, hand, heroPos, villainRaw, suitRaw] = fields;
     const type = TYPE_DECODE[code];
     if (!type) return null;
     const villainPos = villainRaw === '-' ? null : villainRaw;
     const correctAction = lookupCorrectAction(type, stackDepth, hand, heroPos, villainPos);
     if (!correctAction) return null;
-    deck.push({ type, hand, heroPos, villainPos, stackDepth, correctAction });
+    const question = { type, hand, heroPos, villainPos, stackDepth, correctAction };
+    if (suitRaw) {
+      const suit = SUIT_DECODE[suitRaw];
+      if (!suit) return null;
+      question.suit = suit;
+    }
+    deck.push(question);
   }
   if (deck.length === 0) return null;
   return { stackDepth, deck };

--- a/src/utils/share.js
+++ b/src/utils/share.js
@@ -1,0 +1,130 @@
+// Share-link encoding for quiz configurations.
+//
+// Two quiz types have distinct encodings, both as query-string fragments
+// appended to the existing quiz hash routes:
+//
+//   Terminology: #/quizzes/terminology?tq=<i1>,<i2>,...
+//     Each iN is a zero-based index into the TERMS array. The order of
+//     indexes defines the exact question order.
+//
+//   Preflop:     #/quizzes/preflop?pq=<stackDepth>~<q1>~<q2>...
+//     Each qN = <typeCode>.<hand>.<heroPos>.<villainOrDash>
+//     typeCode: r = rfi, l = limp, v = vsRaise
+//     villainOrDash: either a position string or "-" (RFI has no villain)
+//
+// The decoded deck is sufficient to reproduce the identical quiz: correct
+// actions are looked up from the deterministic GTO ranges, and suits are
+// cosmetic (re-randomized on each play).
+
+import { TERMS } from '../data/terms.js';
+import { RFI_RANGES, STACK_DEPTHS } from '../data/rfi-ranges.js';
+import { LIMP_RANGES, VS_RAISE_RANGES } from '../data/preflop-ranges.js';
+
+const TYPE_ENCODE = { rfi: 'r', limp: 'l', vsRaise: 'v' };
+const TYPE_DECODE = { r: 'rfi', l: 'limp', v: 'vsRaise' };
+
+const TERM_INDEX = new Map(TERMS.map((t, i) => [t.term, i]));
+
+export function encodeTermQuiz(deck) {
+  if (!Array.isArray(deck) || deck.length === 0) return null;
+  const idxs = [];
+  for (const t of deck) {
+    const i = TERM_INDEX.get(t.term);
+    if (i == null) return null;
+    idxs.push(i);
+  }
+  return `tq=${idxs.join(',')}`;
+}
+
+export function decodeTermQuiz(query) {
+  const raw = query?.tq;
+  if (!raw) return null;
+  const parts = raw.split(',');
+  const deck = [];
+  for (const p of parts) {
+    const n = Number(p);
+    if (!Number.isInteger(n) || n < 0 || n >= TERMS.length) return null;
+    deck.push(TERMS[n]);
+  }
+  if (deck.length === 0) return null;
+  return { deck };
+}
+
+function lookupCorrectAction(type, stackDepth, hand, heroPos, villainPos) {
+  if (type === 'rfi') {
+    const set = RFI_RANGES[stackDepth]?.[heroPos];
+    if (!set) return null;
+    return set.has(hand) ? 'raise' : 'fold';
+  }
+  if (type === 'limp') {
+    const range = LIMP_RANGES[stackDepth]?.[heroPos]?.[villainPos];
+    if (!range) return null;
+    return range.raise.has(hand) ? 'raise' : range.call.has(hand) ? 'call' : 'fold';
+  }
+  if (type === 'vsRaise') {
+    const range = VS_RAISE_RANGES[stackDepth]?.[heroPos]?.[villainPos];
+    if (!range) return null;
+    return range.threebet.has(hand) ? 'threebet' : range.call.has(hand) ? 'call' : 'fold';
+  }
+  return null;
+}
+
+export function encodePreflopQuiz(stackDepth, deck) {
+  if (!STACK_DEPTHS.includes(stackDepth)) return null;
+  if (!Array.isArray(deck) || deck.length === 0) return null;
+  const parts = [];
+  for (const q of deck) {
+    const code = TYPE_ENCODE[q.type];
+    if (!code || !q.hand || !q.heroPos) return null;
+    parts.push(`${code}.${q.hand}.${q.heroPos}.${q.villainPos || '-'}`);
+  }
+  return `pq=${stackDepth}~${parts.join('~')}`;
+}
+
+export function decodePreflopQuiz(query) {
+  const raw = query?.pq;
+  if (!raw) return null;
+  const segments = raw.split('~');
+  if (segments.length < 2) return null;
+  const [stackDepth, ...qs] = segments;
+  if (!STACK_DEPTHS.includes(stackDepth)) return null;
+  const deck = [];
+  for (const s of qs) {
+    const fields = s.split('.');
+    if (fields.length !== 4) return null;
+    const [code, hand, heroPos, villainRaw] = fields;
+    const type = TYPE_DECODE[code];
+    if (!type) return null;
+    const villainPos = villainRaw === '-' ? null : villainRaw;
+    const correctAction = lookupCorrectAction(type, stackDepth, hand, heroPos, villainPos);
+    if (!correctAction) return null;
+    deck.push({ type, hand, heroPos, villainPos, stackDepth, correctAction });
+  }
+  if (deck.length === 0) return null;
+  return { stackDepth, deck };
+}
+
+// Build an absolute share URL for the given hash path + encoded query.
+export function buildShareUrl(path, encodedQuery) {
+  const { origin, pathname } = window.location;
+  return `${origin}${pathname}#${path}?${encodedQuery}`;
+}
+
+export async function copyToClipboard(text) {
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try { await navigator.clipboard.writeText(text); return true; }
+    catch (_) { /* fall through */ }
+  }
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.setAttribute('readonly', '');
+    ta.style.position = 'fixed';
+    ta.style.left = '-9999px';
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(ta);
+    return ok;
+  } catch (_) { return false; }
+}

--- a/src/utils/share.js
+++ b/src/utils/share.js
@@ -143,3 +143,11 @@ export async function copyToClipboard(text) {
     return ok;
   } catch (_) { return false; }
 }
+
+// "I've got 60% correct (3/5). Can you beat my score? <url>"
+export function buildScoreMessage(score, total, url) {
+  const safeTotal = Math.max(0, total | 0);
+  const safeScore = Math.max(0, score | 0);
+  const pct = safeTotal > 0 ? Math.round(safeScore / safeTotal * 100) : 0;
+  return `I've got ${pct}% correct (${safeScore}/${safeTotal}). Can you beat my score? ${url}`;
+}

--- a/src/utils/share.test.js
+++ b/src/utils/share.test.js
@@ -46,8 +46,8 @@ describe('encodePreflopQuiz / decodePreflopQuiz', () => {
   it('round-trips an RFI deck and fills in correctAction from ranges', () => {
     const sampleHand = [...RFI_RANGES['100BB'].UTG][0];
     const deck = [
-      { type: 'rfi', hand: sampleHand, heroPos: 'UTG', villainPos: null, stackDepth: '100BB', correctAction: 'raise' },
-      { type: 'rfi', hand: '72o',       heroPos: 'UTG', villainPos: null, stackDepth: '100BB', correctAction: 'fold'  },
+      { type: 'rfi', hand: sampleHand, heroPos: 'UTG', villainPos: null, stackDepth: '100BB', suit: '\u2660', correctAction: 'raise' },
+      { type: 'rfi', hand: '72o',       heroPos: 'UTG', villainPos: null, stackDepth: '100BB', suit: '\u2665', correctAction: 'fold'  },
     ];
     const encoded = encodePreflopQuiz('100BB', deck);
     expect(encoded).toMatch(/^pq=100BB~r\./);
@@ -60,6 +60,31 @@ describe('encodePreflopQuiz / decodePreflopQuiz', () => {
     expect(decoded[0].villainPos).toBeNull();
     expect(decoded[0].correctAction).toBe('raise');
     expect(decoded[1].correctAction).toBe('fold');
+  });
+
+  it('preserves per-question suits through the round-trip', () => {
+    const deck = [
+      { type: 'rfi', hand: 'AKs', heroPos: 'UTG', villainPos: null, stackDepth: '100BB', suit: '\u2660' },
+      { type: 'rfi', hand: 'QJs', heroPos: 'HJ',  villainPos: null, stackDepth: '100BB', suit: '\u2665' },
+      { type: 'rfi', hand: 'T9s', heroPos: 'CO',  villainPos: null, stackDepth: '100BB', suit: '\u2666' },
+      { type: 'rfi', hand: '98s', heroPos: 'BTN', villainPos: null, stackDepth: '100BB', suit: '\u2663' },
+    ];
+    const encoded = encodePreflopQuiz('100BB', deck);
+    const { deck: decoded } = decodePreflopQuiz({ pq: encoded.slice(3) });
+    expect(decoded.map(q => q.suit)).toEqual(['\u2660', '\u2665', '\u2666', '\u2663']);
+  });
+
+  it('decodes legacy 4-field links (no suit) without failing', () => {
+    // Links shared before suit encoding existed must still open — the
+    // recipient just gets freshly-randomized suits at render time.
+    const { deck } = decodePreflopQuiz({ pq: '100BB~r.AA.UTG.-~r.72o.HJ.-' });
+    expect(deck).toHaveLength(2);
+    expect(deck[0].suit).toBeUndefined();
+    expect(deck[1].suit).toBeUndefined();
+  });
+
+  it('returns null for an unknown suit code', () => {
+    expect(decodePreflopQuiz({ pq: '100BB~r.AA.UTG.-.x' })).toBeNull();
   });
 
   it('round-trips a mixed limp + vsRaise deck', () => {

--- a/src/utils/share.test.js
+++ b/src/utils/share.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { TERMS } from '../data/terms.js';
+import { RFI_RANGES } from '../data/rfi-ranges.js';
+import { LIMP_RANGES, VS_RAISE_RANGES } from '../data/preflop-ranges.js';
+import {
+  encodeTermQuiz, decodeTermQuiz,
+  encodePreflopQuiz, decodePreflopQuiz,
+  buildShareUrl,
+} from './share.js';
+
+describe('encodeTermQuiz / decodeTermQuiz', () => {
+  it('round-trips an ordered deck of terms', () => {
+    const deck = [TERMS[0], TERMS[5], TERMS[12], TERMS[3]];
+    const encoded = encodeTermQuiz(deck);
+    expect(encoded).toBe('tq=0,5,12,3');
+    const decoded = decodeTermQuiz({ tq: '0,5,12,3' });
+    expect(decoded.deck.map(t => t.term)).toEqual(deck.map(t => t.term));
+  });
+
+  it('preserves question order — share link must reproduce identical quiz', () => {
+    const deck = [TERMS[7], TERMS[2], TERMS[9]];
+    const encoded = encodeTermQuiz(deck);
+    const { deck: decoded } = decodeTermQuiz(Object.fromEntries(new URLSearchParams(encoded)));
+    expect(decoded).toEqual(deck);
+  });
+
+  it('returns null for empty / missing query', () => {
+    expect(decodeTermQuiz({})).toBeNull();
+    expect(decodeTermQuiz({ tq: '' })).toBeNull();
+    expect(decodeTermQuiz(null)).toBeNull();
+  });
+
+  it('returns null for out-of-range indexes — guards against stale links', () => {
+    expect(decodeTermQuiz({ tq: '9999' })).toBeNull();
+    expect(decodeTermQuiz({ tq: '-1' })).toBeNull();
+    expect(decodeTermQuiz({ tq: '1,abc,3' })).toBeNull();
+  });
+
+  it('returns null when encoding an empty deck', () => {
+    expect(encodeTermQuiz([])).toBeNull();
+    expect(encodeTermQuiz(null)).toBeNull();
+  });
+});
+
+describe('encodePreflopQuiz / decodePreflopQuiz', () => {
+  it('round-trips an RFI deck and fills in correctAction from ranges', () => {
+    const sampleHand = [...RFI_RANGES['100BB'].UTG][0];
+    const deck = [
+      { type: 'rfi', hand: sampleHand, heroPos: 'UTG', villainPos: null, stackDepth: '100BB', correctAction: 'raise' },
+      { type: 'rfi', hand: '72o',       heroPos: 'UTG', villainPos: null, stackDepth: '100BB', correctAction: 'fold'  },
+    ];
+    const encoded = encodePreflopQuiz('100BB', deck);
+    expect(encoded).toMatch(/^pq=100BB~r\./);
+    const { stackDepth, deck: decoded } = decodePreflopQuiz({ pq: encoded.slice(3) });
+    expect(stackDepth).toBe('100BB');
+    expect(decoded).toHaveLength(2);
+    expect(decoded[0].type).toBe('rfi');
+    expect(decoded[0].hand).toBe(sampleHand);
+    expect(decoded[0].heroPos).toBe('UTG');
+    expect(decoded[0].villainPos).toBeNull();
+    expect(decoded[0].correctAction).toBe('raise');
+    expect(decoded[1].correctAction).toBe('fold');
+  });
+
+  it('round-trips a mixed limp + vsRaise deck', () => {
+    const limpHand = [...LIMP_RANGES['100BB'].HJ.UTG.raise][0];
+    const vsrHand  = [...VS_RAISE_RANGES['100BB'].HJ.UTG.threebet][0];
+    const deck = [
+      { type: 'limp',    hand: limpHand, heroPos: 'HJ', villainPos: 'UTG', stackDepth: '100BB', correctAction: 'raise'    },
+      { type: 'vsRaise', hand: vsrHand,  heroPos: 'HJ', villainPos: 'UTG', stackDepth: '100BB', correctAction: 'threebet' },
+    ];
+    const encoded = encodePreflopQuiz('100BB', deck);
+    const { deck: decoded } = decodePreflopQuiz({ pq: encoded.slice(3) });
+    expect(decoded).toHaveLength(2);
+    expect(decoded[0].type).toBe('limp');
+    expect(decoded[0].villainPos).toBe('UTG');
+    expect(decoded[0].correctAction).toBe('raise');
+    expect(decoded[1].type).toBe('vsRaise');
+    expect(decoded[1].correctAction).toBe('threebet');
+  });
+
+  it('returns null for unknown stack depth', () => {
+    expect(decodePreflopQuiz({ pq: '9999BB~r.AA.UTG.-' })).toBeNull();
+    expect(encodePreflopQuiz('9999BB', [{ type: 'rfi', hand: 'AA', heroPos: 'UTG', villainPos: null }])).toBeNull();
+  });
+
+  it('returns null for unknown type code', () => {
+    expect(decodePreflopQuiz({ pq: '100BB~x.AA.UTG.-' })).toBeNull();
+  });
+
+  it('returns null for empty / missing query', () => {
+    expect(decodePreflopQuiz({})).toBeNull();
+    expect(decodePreflopQuiz({ pq: '' })).toBeNull();
+    expect(decodePreflopQuiz(null)).toBeNull();
+  });
+
+  it('returns null when encoding an empty deck', () => {
+    expect(encodePreflopQuiz('100BB', [])).toBeNull();
+    expect(encodePreflopQuiz('100BB', null)).toBeNull();
+  });
+
+  it('preserves deck order exactly — share link reproduces identical quiz', () => {
+    const deck = [
+      { type: 'rfi', hand: 'AA', heroPos: 'UTG', villainPos: null, stackDepth: '100BB', correctAction: 'raise' },
+      { type: 'rfi', hand: '72o', heroPos: 'HJ', villainPos: null, stackDepth: '100BB', correctAction: 'fold' },
+      { type: 'rfi', hand: 'KK', heroPos: 'CO', villainPos: null, stackDepth: '100BB', correctAction: 'raise' },
+    ];
+    const encoded = encodePreflopQuiz('100BB', deck);
+    const { deck: decoded } = decodePreflopQuiz({ pq: encoded.slice(3) });
+    expect(decoded.map(q => `${q.type}.${q.hand}.${q.heroPos}`)).toEqual([
+      'rfi.AA.UTG', 'rfi.72o.HJ', 'rfi.KK.CO',
+    ]);
+  });
+});
+
+describe('buildShareUrl', () => {
+  it('composes an absolute hash URL from the current location + path + query', () => {
+    const prevOrigin = globalThis.window;
+    globalThis.window = { location: { origin: 'https://example.com', pathname: '/poker-trainer/' } };
+    try {
+      const url = buildShareUrl('/quizzes/terminology', 'tq=1,2,3');
+      expect(url).toBe('https://example.com/poker-trainer/#/quizzes/terminology?tq=1,2,3');
+    } finally {
+      if (prevOrigin === undefined) delete globalThis.window;
+      else globalThis.window = prevOrigin;
+    }
+  });
+});

--- a/src/utils/share.test.js
+++ b/src/utils/share.test.js
@@ -5,7 +5,7 @@ import { LIMP_RANGES, VS_RAISE_RANGES } from '../data/preflop-ranges.js';
 import {
   encodeTermQuiz, decodeTermQuiz,
   encodePreflopQuiz, decodePreflopQuiz,
-  buildShareUrl,
+  buildShareUrl, buildScoreMessage,
 } from './share.js';
 
 describe('encodeTermQuiz / decodeTermQuiz', () => {
@@ -135,6 +135,19 @@ describe('encodePreflopQuiz / decodePreflopQuiz', () => {
     expect(decoded.map(q => `${q.type}.${q.hand}.${q.heroPos}`)).toEqual([
       'rfi.AA.UTG', 'rfi.72o.HJ', 'rfi.KK.CO',
     ]);
+  });
+});
+
+describe('buildScoreMessage', () => {
+  it('produces the brag-message wording with percent, raw score, and link', () => {
+    const url = 'https://example.com/#/quizzes/terminology?tq=1,2,3';
+    const msg = buildScoreMessage(3, 5, url);
+    expect(msg).toBe(`I've got 60% correct (3/5). Can you beat my score? ${url}`);
+  });
+
+  it('rounds percent and handles a total of zero without NaN', () => {
+    expect(buildScoreMessage(0, 0, 'https://x/')).toContain('0% correct (0/0)');
+    expect(buildScoreMessage(1, 3, 'https://x/')).toContain('33% correct (1/3)');
   });
 });
 


### PR DESCRIPTION
Encodes the exact quiz configuration (length, ordered questions,
stack depth for preflop) into a URL query string so two players can
attempt the identical set of questions. Terminology encodes term
indexes; preflop encodes each question as type.hand.heroPos.villain
and re-derives correct actions from the GTO ranges.

https://claude.ai/code/session_01DeSuA3jqjAwtatgPh6CQkk