### PR TITLE
Add regression tests for terminology quiz length setting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ poker-trainer/
 │       │   └── Welcome.jsx             # Landing page with hand rankings overview
 │       ├── terminology/
 │       │   ├── Study.jsx               # Flashcard study mode
-│       │   ├── Quiz.jsx                # Multiple-choice terminology quiz
+│       │   ├── Quiz.jsx                # Multiple-choice terminology quiz (setup → playing → complete, auto-advance)
 │       │   └── Reference.jsx           # Searchable glossary
 │       ├── preflop/
 │       │   ├── Charts.jsx              # RFI hand range grid with position tabs
@@ -107,7 +107,15 @@ Quiz routes accept query strings that encode a reproducible quiz:
 | `#/quizzes/terminology` | `?tq=<i,i,i,...>` | Comma-separated indexes into `TERMS`; defines the ordered question deck. |
 | `#/quizzes/preflop` | `?pq=<stackDepth>~<q1>~<q2>...` | Each `qN = <typeCode>.<hand>.<heroPos>.<villainOrDash>.<suitCode>` where typeCode ∈ `{r,l,v}` (rfi, limp, vsRaise) and suitCode ∈ `{s,h,d,c}`. Correct actions are re-derived from the GTO ranges; suits preserve the exact card rendering. The trailing suit field is optional — legacy 4-field links still decode. |
 
-A shared preflop quiz auto-starts in the playing phase; a shared terminology quiz replaces the randomly shuffled deck with the shared ordered list. "Play Again" replays the same deck; "New Random Quiz" exits shared mode. See `src/utils/share.js` and `src/components/ShareButton.jsx`.
+Both quiz types auto-start in the playing phase when loaded from a shared link, bypassing the setup screen so the recipient can't alter the shared deck. "Play Again" replays the same deck; "New Random Quiz" drops out of shared mode and returns the user to the setup screen (topic picker for terminology, mode/stack/positions for preflop). See `src/utils/share.js` and `src/components/ShareButton.jsx`.
+
+### Quiz flow (setup → playing → complete)
+
+Both `sections/terminology/Quiz.jsx` and `sections/preflop/Quiz.jsx` use the same three-phase flow:
+
+1. **Setup**: The user picks which terms/modes to practice and clicks *Start Quiz*. The terminology setup uses `FilterChips` for topic selection; the preflop setup uses mode/stack/position selectors.
+2. **Playing**: A progress bar, a `Question N / Total` stat, and the active question. If `settings.autoAdvance` is true, an interval counts down `settings.autoAdvanceSeconds` after each answer and jumps to the next question; the user can always click *Next Question* to skip the timer, or *Exit* to return to setup.
+3. **Complete**: Score summary with *Play Again* (same phase), *Back to Setup* (or *New Random Quiz* if shared), *Stats*, and share buttons.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ### Terminology
 - **Study** — 3D flashcard system with elegant flip animations. Each card shows a poker term on one side and its definition with a custom SVG illustration on the other.
-- **Quiz** — Multiple-choice questions (4 options) with real-time score, streak tracking, and persistent stats.
+- **Quiz** — Setup screen for picking topics, then multiple-choice questions (4 options) with real-time score, streak tracking, current question counter, and persistent stats. Honors the Settings page's quiz length and auto-advance preferences.
 - **Reference** — Searchable glossary of ~78 poker terms organized across 9 categories, with detailed modal views.
 
 ### Preflop

--- a/src/sections/stats/Dashboard.jsx
+++ b/src/sections/stats/Dashboard.jsx
@@ -64,100 +64,6 @@ export function Dashboard({ path }) {
 
       <Recommendation />
 
-      {/* Study Progress */}
-      <div class="stats-section">
-        <div class="stats-section-header">
-          <h3>Study Progress</h3>
-          <button class="stats-reset" onClick={resetStudy}>Reset</button>
-        </div>
-        <div class="stats-grid">
-          <div class="stats-card">
-            <div class="stats-val">{cardsSeen}</div>
-            <div class="stats-lbl">Cards Seen</div>
-          </div>
-          <div class="stats-card">
-            <div class="stats-val">{totalTerms}</div>
-            <div class="stats-lbl">Total Terms</div>
-          </div>
-          <div class="stats-card">
-            <div class="stats-val">{studyPct}%</div>
-            <div class="stats-lbl">Completion</div>
-          </div>
-          <div class="stats-card">
-            <div class="stats-val">{study.totalFlips}</div>
-            <div class="stats-lbl">Card Flips</div>
-          </div>
-        </div>
-        {Object.keys(study.byCategory).length > 0 && (
-          <div class="stats-bars">
-            <div class="stats-bars-title">Views by Category</div>
-            {CATS.map(cat => {
-              const count = study.byCategory[cat] || 0;
-              if (count === 0) return null;
-              const maxCount = Math.max(...Object.values(study.byCategory));
-              const barPct = maxCount > 0 ? Math.round(count / maxCount * 100) : 0;
-              return (
-                <div class="stats-cat-row" key={cat}>
-                  <div class="stats-cat-label">{cat}</div>
-                  <div class="stats-cat-bar">
-                    <div class="stats-cat-bar-fill" style={{ width: barPct + '%' }}></div>
-                    <div class="stats-cat-bar-text">{count}</div>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        )}
-      </div>
-
-      {/* Terminology Quiz */}
-      <div class="stats-section">
-        <div class="stats-section-header">
-          <h3>Terminology Quiz</h3>
-          <button class="stats-reset" onClick={resetTermQuiz}>Reset</button>
-        </div>
-        {termQuiz.totalQuizzes === 0 ? (
-          <p class="stats-empty">No quizzes taken yet. <a href="#/terminology/quiz">Take a quiz</a></p>
-        ) : (
-          <>
-            <div class="stats-grid">
-              <div class="stats-card">
-                <div class="stats-val">{termQuiz.totalQuizzes}</div>
-                <div class="stats-lbl">Quizzes</div>
-              </div>
-              <div class="stats-card">
-                <div class="stats-val">{termAccuracy}%</div>
-                <div class="stats-lbl">Accuracy</div>
-              </div>
-              <div class="stats-card">
-                <div class="stats-val">{termQuiz.totalCorrect}/{termQuiz.totalQuestions}</div>
-                <div class="stats-lbl">Correct</div>
-              </div>
-              <div class="stats-card">
-                <div class="stats-val">{termQuiz.bestStreak}</div>
-                <div class="stats-lbl">Best Streak</div>
-              </div>
-            </div>
-            {termQuiz.recentScores.length > 0 && (
-              <div class="stats-history">
-                <div class="stats-history-title">Recent Scores</div>
-                {termQuiz.recentScores.slice(-5).reverse().map((r, i) => {
-                  const p = Math.round(r.score / r.total * 100);
-                  return (
-                    <div class="stats-history-row" key={i}>
-                      <span>{r.date}</span>
-                      <span style={{ color: p >= 70 ? '#27ae60' : p >= 50 ? '#c9a84c' : '#c0392b' }}>
-                        {r.score}/{r.total} ({p}%)
-                      </span>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </>
-        )}
-      </div>
-
       {/* RFI Quiz */}
       <div class="stats-section">
         <div class="stats-section-header">
@@ -308,6 +214,120 @@ export function Dashboard({ path }) {
                 return (<div class="stats-cat-row" key={key}><div class="stats-cat-label">{lbl}</div><div class="stats-cat-bar"><div class="stats-cat-bar-fill" style={{width:pct+'%',background:clr}}></div><div class="stats-cat-bar-text">{pct}% ({ps.correct}/{ps.total})</div></div></div>);
               })}
             </div>
+          </>
+        )}
+      </div>
+
+      {/* Study Progress */}
+      <div class="stats-section">
+        <div class="stats-section-header">
+          <h3>Study Progress</h3>
+          <button class="stats-reset" onClick={resetStudy}>Reset</button>
+        </div>
+        <div class="stats-grid">
+          <div class="stats-card">
+            <div class="stats-val">{cardsSeen}</div>
+            <div class="stats-lbl">Cards Seen</div>
+          </div>
+          <div class="stats-card">
+            <div class="stats-val">{totalTerms}</div>
+            <div class="stats-lbl">Total Terms</div>
+          </div>
+          <div class="stats-card">
+            <div class="stats-val">{studyPct}%</div>
+            <div class="stats-lbl">Completion</div>
+          </div>
+          <div class="stats-card">
+            <div class="stats-val">{study.totalFlips}</div>
+            <div class="stats-lbl">Card Flips</div>
+          </div>
+        </div>
+        {Object.keys(study.byCategory).length > 0 && (
+          <div class="stats-bars">
+            <div class="stats-bars-title">Views by Category</div>
+            {CATS.map(cat => {
+              const count = study.byCategory[cat] || 0;
+              if (count === 0) return null;
+              const maxCount = Math.max(...Object.values(study.byCategory));
+              const barPct = maxCount > 0 ? Math.round(count / maxCount * 100) : 0;
+              return (
+                <div class="stats-cat-row" key={cat}>
+                  <div class="stats-cat-label">{cat}</div>
+                  <div class="stats-cat-bar">
+                    <div class="stats-cat-bar-fill" style={{ width: barPct + '%' }}></div>
+                    <div class="stats-cat-bar-text">{count}</div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Terminology Quiz */}
+      <div class="stats-section">
+        <div class="stats-section-header">
+          <h3>Terminology Quiz</h3>
+          <button class="stats-reset" onClick={resetTermQuiz}>Reset</button>
+        </div>
+        {termQuiz.totalQuizzes === 0 ? (
+          <p class="stats-empty">No quizzes taken yet. <a href="#/terminology/quiz">Take a quiz</a></p>
+        ) : (
+          <>
+            <div class="stats-grid">
+              <div class="stats-card">
+                <div class="stats-val">{termQuiz.totalQuizzes}</div>
+                <div class="stats-lbl">Quizzes</div>
+              </div>
+              <div class="stats-card">
+                <div class="stats-val">{termAccuracy}%</div>
+                <div class="stats-lbl">Accuracy</div>
+              </div>
+              <div class="stats-card">
+                <div class="stats-val">{termQuiz.totalCorrect}/{termQuiz.totalQuestions}</div>
+                <div class="stats-lbl">Correct</div>
+              </div>
+              <div class="stats-card">
+                <div class="stats-val">{termQuiz.bestStreak}</div>
+                <div class="stats-lbl">Best Streak</div>
+              </div>
+            </div>
+            {termQuiz.byCategory && Object.keys(termQuiz.byCategory).length > 0 && (
+              <div class="stats-bars">
+                <div class="stats-bars-title">Accuracy by Category</div>
+                {CATS.map(cat => {
+                  const ps = termQuiz.byCategory[cat];
+                  if (!ps || ps.total === 0) return null;
+                  const pct = Math.round(ps.correct / ps.total * 100);
+                  const clr = pct >= 80 ? '#27ae60' : pct >= 60 ? '#c9a84c' : '#c0392b';
+                  return (
+                    <div class="stats-cat-row" key={cat}>
+                      <div class="stats-cat-label">{cat}</div>
+                      <div class="stats-cat-bar">
+                        <div class="stats-cat-bar-fill" style={{ width: pct + '%', background: clr }}></div>
+                        <div class="stats-cat-bar-text">{pct}% ({ps.correct}/{ps.total})</div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+            {termQuiz.recentScores.length > 0 && (
+              <div class="stats-history">
+                <div class="stats-history-title">Recent Scores</div>
+                {termQuiz.recentScores.slice(-5).reverse().map((r, i) => {
+                  const p = Math.round(r.score / r.total * 100);
+                  return (
+                    <div class="stats-history-row" key={i}>
+                      <span>{r.date}</span>
+                      <span style={{ color: p >= 70 ? '#27ae60' : p >= 50 ? '#c9a84c' : '#c0392b' }}>
+                        {r.score}/{r.total} ({p}%)
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
           </>
         )}
       </div>

--- a/src/sections/stats/Dashboard.test.js
+++ b/src/sections/stats/Dashboard.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const dashboardSource = readFileSync(resolve(__dirname, 'Dashboard.jsx'), 'utf8');
+
+describe('Dashboard — section order', () => {
+  it('renders preflop quiz sections before Study Progress', () => {
+    // User-requested ordering: preflop stats (the primary trainer) live
+    // above study/terminology stats on the dashboard.
+    const rfiIdx     = dashboardSource.indexOf('Preflop RFI Quiz');
+    const limpIdx    = dashboardSource.indexOf('Preflop vs Limp Quiz');
+    const vsRaiseIdx = dashboardSource.indexOf('Preflop vs Raise Quiz');
+    const allIdx     = dashboardSource.indexOf('Preflop All-Modes Quiz');
+    const studyIdx   = dashboardSource.indexOf('<h3>Study Progress</h3>');
+    const termIdx    = dashboardSource.indexOf('<h3>Terminology Quiz</h3>');
+
+    expect(rfiIdx).toBeGreaterThan(-1);
+    expect(studyIdx).toBeGreaterThan(-1);
+    expect(termIdx).toBeGreaterThan(-1);
+
+    expect(rfiIdx).toBeLessThan(studyIdx);
+    expect(limpIdx).toBeLessThan(studyIdx);
+    expect(vsRaiseIdx).toBeLessThan(studyIdx);
+    expect(allIdx).toBeLessThan(studyIdx);
+    expect(studyIdx).toBeLessThan(termIdx);
+  });
+});
+
+describe('Dashboard — terminology quiz category breakdown', () => {
+  it('renders an "Accuracy by Category" bar chart from termQuiz.byCategory', () => {
+    // Mirrors the RFI "Accuracy by Position" chart — users need to see which
+    // term categories they struggle with, not just an overall accuracy number.
+    expect(dashboardSource).toMatch(/Accuracy by Category/);
+    expect(dashboardSource).toMatch(/termQuiz\.byCategory/);
+  });
+
+  it('iterates CATS when rendering per-category rows so order matches the rest of the app', () => {
+    expect(dashboardSource).toMatch(/CATS\.map\(cat\s*=>\s*\{[\s\S]*?termQuiz\.byCategory\[cat\]/);
+  });
+});

--- a/src/sections/terminology/Quiz.jsx
+++ b/src/sections/terminology/Quiz.jsx
@@ -24,7 +24,10 @@ export function buildDeck(cats, length = Infinity) {
 export function buildOptions(deck, idx) {
   if (idx >= deck.length) return [];
   const t = deck[idx];
-  const wrong = TERMS.filter(x => x.term !== t.term);
+  // Wrong answers come from the same topic pool as the deck — selecting
+  // "Hand Rankings" only shouldn't surface a "Positions" term as a distractor.
+  const deckCats = new Set(deck.map(x => x.cat));
+  const wrong = TERMS.filter(x => x.term !== t.term && deckCats.has(x.cat));
   const picked = shuffle(wrong).slice(0, 3);
   return shuffle([...picked, t]);
 }
@@ -44,6 +47,7 @@ export function Quiz({ path, query }) {
   const [selectedAnswer, setSelectedAnswer] = useState(null);
   const [options, setOptions] = useState(() => (shared?.deck ? buildOptions(shared.deck, 0) : []));
   const [countdown, setCountdown] = useState(settings.autoAdvanceSeconds);
+  const [perQuestionResults, setPerQuestionResults] = useState([]);
 
   // If the URL's ?tq= query changes (e.g. opening a shared link while already
   // on the quiz), rebuild the deck from the shared terms and jump straight
@@ -65,6 +69,7 @@ export function Quiz({ path, query }) {
     setAnswered(false);
     setSelectedAnswer(null);
     setOptions(buildOptions(next.deck, 0));
+    setPerQuestionResults([]);
   }, [query?.tq]);
 
   function startQuiz() {
@@ -82,6 +87,7 @@ export function Quiz({ path, query }) {
     setAnswered(false);
     setSelectedAnswer(null);
     setOptions(buildOptions(newDeck, 0));
+    setPerQuestionResults([]);
     setPhase('playing');
   }
 
@@ -99,6 +105,7 @@ export function Quiz({ path, query }) {
     setAnswered(false);
     setSelectedAnswer(null);
     setOptions(buildOptions(newDeck, 0));
+    setPerQuestionResults([]);
   }
 
   function exitQuiz() {
@@ -109,6 +116,7 @@ export function Quiz({ path, query }) {
     setTotal(0);
     setAnswered(false);
     setSelectedAnswer(null);
+    setPerQuestionResults([]);
   }
 
   function startFreshQuiz() {
@@ -122,6 +130,7 @@ export function Quiz({ path, query }) {
     setTotal(0);
     setAnswered(false);
     setSelectedAnswer(null);
+    setPerQuestionResults([]);
     setPhase('setup');
     if (window.location.hash.includes('?tq=')) {
       window.location.hash = '#/quizzes/terminology';
@@ -135,7 +144,8 @@ export function Quiz({ path, query }) {
     if (answered) return;
     setAnswered(true);
     setSelectedAnswer(chosen);
-    const correct = quizDeck[qIdx].term;
+    const current = quizDeck[qIdx];
+    const correct = current.term;
     const isCorrect = chosen === correct;
     if (isCorrect) {
       setScore(s => s + 1);
@@ -144,6 +154,7 @@ export function Quiz({ path, query }) {
       setStreak(0);
     }
     setTotal(t => t + 1);
+    setPerQuestionResults(r => [...r, { cat: current.cat, correct: isCorrect }]);
   }, [answered, quizDeck, qIdx]);
 
   function nextQuiz(e) {
@@ -211,6 +222,13 @@ export function Quiz({ path, query }) {
     stats.totalQuestions += total;
     stats.totalCorrect += score;
     if (streak > stats.bestStreak) stats.bestStreak = streak;
+    if (!stats.byCategory) stats.byCategory = {};
+    for (const r of perQuestionResults) {
+      const bucket = stats.byCategory[r.cat] || { total: 0, correct: 0 };
+      bucket.total += 1;
+      if (r.correct) bucket.correct += 1;
+      stats.byCategory[r.cat] = bucket;
+    }
     stats.recentScores.push({ date: new Date().toLocaleDateString(), score, total });
     if (stats.recentScores.length > 20) stats.recentScores = stats.recentScores.slice(-20);
     saveTermQuizStats(stats);

--- a/src/sections/terminology/Quiz.jsx
+++ b/src/sections/terminology/Quiz.jsx
@@ -33,21 +33,21 @@ export function Quiz({ path, query }) {
   const shared = decodeTermQuiz(query);
   const { activeCats, toggleCat } = useFilters();
   const [settings, setSettings] = useState(() => getSettings());
+  const [phase, setPhase] = useState(shared ? 'playing' : 'setup');
   const [sharedDeck, setSharedDeck] = useState(() => shared?.deck || null);
-  const [quizDeck, setQuizDeck] = useState(() => (
-    shared?.deck ? shared.deck : buildDeck(activeCats, settings.quizLength)
-  ));
+  const [quizDeck, setQuizDeck] = useState(() => shared?.deck || []);
   const [qIdx, setQIdx] = useState(0);
   const [score, setScore] = useState(0);
   const [streak, setStreak] = useState(0);
   const [total, setTotal] = useState(0);
   const [answered, setAnswered] = useState(false);
   const [selectedAnswer, setSelectedAnswer] = useState(null);
-  // quizDeck is already set above; use the same deck for initial options so q0 answer is always present
-  const [options, setOptions] = useState(() => buildOptions(quizDeck, 0));
+  const [options, setOptions] = useState(() => (shared?.deck ? buildOptions(shared.deck, 0) : []));
+  const [countdown, setCountdown] = useState(settings.autoAdvanceSeconds);
 
   // If the URL's ?tq= query changes (e.g. opening a shared link while already
-  // on the quiz), rebuild the deck from the shared terms.
+  // on the quiz), rebuild the deck from the shared terms and jump straight
+  // into playing — mirrors the preflop shared-link behavior.
   useEffect(() => {
     const next = decodeTermQuiz(query);
     if (!next) return;
@@ -57,6 +57,7 @@ export function Quiz({ path, query }) {
     if (sameDeck) return;
     setSharedDeck(next.deck);
     setQuizDeck(next.deck);
+    setPhase('playing');
     setQIdx(0);
     setScore(0);
     setStreak(0);
@@ -66,10 +67,27 @@ export function Quiz({ path, query }) {
     setOptions(buildOptions(next.deck, 0));
   }, [query?.tq]);
 
+  function startQuiz() {
+    // Entered from the setup screen's Start button. Reads fresh settings so
+    // quizLength/autoAdvance changes made on the Settings page take effect
+    // without requiring a reload.
+    const fresh = getSettings();
+    setSettings(fresh);
+    const newDeck = buildDeck(activeCats, fresh.quizLength);
+    setQuizDeck(newDeck);
+    setQIdx(0);
+    setScore(0);
+    setStreak(0);
+    setTotal(0);
+    setAnswered(false);
+    setSelectedAnswer(null);
+    setOptions(buildOptions(newDeck, 0));
+    setPhase('playing');
+  }
+
   function restart() {
-    // Re-read settings so a quizLength change on the Settings page takes
-    // effect on the next run without requiring a reload. Shared quizzes
-    // replay the same deck so the share link stays reproducible.
+    // "Play Again" from the complete screen — stays in playing phase.
+    // Shared quizzes replay the same deck so the share link stays reproducible.
     const fresh = getSettings();
     setSettings(fresh);
     const newDeck = sharedDeck ? sharedDeck : buildDeck(activeCats, fresh.quizLength);
@@ -83,30 +101,31 @@ export function Quiz({ path, query }) {
     setOptions(buildOptions(newDeck, 0));
   }
 
-  function startFreshQuiz() {
-    setSharedDeck(null);
-    const fresh = getSettings();
-    setSettings(fresh);
-    const newDeck = buildDeck(activeCats, fresh.quizLength);
-    setQuizDeck(newDeck);
+  function exitQuiz() {
+    setPhase('setup');
     setQIdx(0);
     setScore(0);
     setStreak(0);
     setTotal(0);
     setAnswered(false);
     setSelectedAnswer(null);
-    setOptions(buildOptions(newDeck, 0));
-    // Strip the share query from the URL so the user ends up on a clean quiz route.
+  }
+
+  function startFreshQuiz() {
+    // Dropping out of a shared deck returns the user to the setup screen so
+    // they can pick topics before the random quiz starts.
+    setSharedDeck(null);
+    setQuizDeck([]);
+    setQIdx(0);
+    setScore(0);
+    setStreak(0);
+    setTotal(0);
+    setAnswered(false);
+    setSelectedAnswer(null);
+    setPhase('setup');
     if (window.location.hash.includes('?tq=')) {
       window.location.hash = '#/quizzes/terminology';
     }
-  }
-
-  function handleFilterToggle(cat) {
-    if (sharedDeck) return; // filters are meaningless for a fixed shared deck
-    toggleCat(cat);
-    // Restart quiz with new filters on next render
-    setTimeout(restart, 0);
   }
 
   const shareQuery = encodeTermQuiz(quizDeck);
@@ -128,7 +147,7 @@ export function Quiz({ path, query }) {
   }, [answered, quizDeck, qIdx]);
 
   function nextQuiz(e) {
-    e.currentTarget.blur();
+    if (e?.currentTarget?.blur) e.currentTarget.blur();
     const nextIdx = qIdx + 1;
     setQIdx(nextIdx);
     setAnswered(false);
@@ -136,7 +155,49 @@ export function Quiz({ path, query }) {
     setOptions(buildOptions(quizDeck, nextIdx));
   }
 
-  // Quiz complete
+  // Auto-advance after answering — only runs when the user has enabled it in
+  // settings. Cleanup cancels the timer when the user clicks Next manually or
+  // exits the quiz.
+  useEffect(() => {
+    if (!answered || phase !== 'playing') return;
+    if (!settings.autoAdvance) return;
+    const start = settings.autoAdvanceSeconds;
+    setCountdown(start);
+    let secs = start;
+    const id = setInterval(() => {
+      secs -= 1;
+      setCountdown(secs);
+      if (secs <= 0) {
+        clearInterval(id);
+        const nextIdx = qIdx + 1;
+        setQIdx(nextIdx);
+        setAnswered(false);
+        setSelectedAnswer(null);
+        setOptions(buildOptions(quizDeck, nextIdx));
+      }
+    }, 1000);
+    return () => clearInterval(id);
+  }, [answered, phase, settings.autoAdvance, settings.autoAdvanceSeconds, qIdx, quizDeck]);
+
+  // ── Setup screen ──────────────────────────────────────────────────────────
+  if (phase === 'setup') {
+    return (
+      <div>
+        <SubNav tabs={TABS} currentPath="/quizzes/terminology" />
+        <div class="rq-panel">
+          <h2 class="rq-title">Terminology Quiz</h2>
+          <p class="rq-sub">Pick the topics you want to practice, then start the quiz.</p>
+          <div class="rq-setup-label">Topics</div>
+          <FilterChips activeCats={activeCats} onToggle={toggleCat} />
+          <div class="rq-start-row">
+            <button class="rq-start-btn" onClick={startQuiz}>Start Quiz</button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Complete screen ───────────────────────────────────────────────────────
   if (qIdx >= quizDeck.length && quizDeck.length > 0) {
     const pct = Math.round(score / total * 100);
     const msg = pct >= 90 ? 'Phenomenal \u2014 table captain!' :
@@ -157,17 +218,18 @@ export function Quiz({ path, query }) {
     return (
       <div>
         <SubNav tabs={TABS} currentPath="/quizzes/terminology" />
-        {!sharedDeck && <FilterChips activeCats={activeCats} onToggle={handleFilterToggle} />}
-        <div class="quiz-panel">
-          <div class="quiz-complete">
+        <div class="rq-panel">
+          <div class="rq-complete">
             <h2>{pct >= 70 ? '\uD83C\uDFC6' : '\uD83C\uDCCF'} Round Complete</h2>
-            <p style="font-size:1.5rem;color:var(--gold-bright);margin:.5rem 0">{score} / {total} &mdash; {pct}%</p>
+            <div class="score-big">{score} / {total} &mdash; {pct}%</div>
             <p>{msg}</p>
-            <button class="restart-btn" onClick={restart}>Play Again</button>
-            {sharedDeck && (
-              <button class="restart-btn" style="background:transparent;border:1px solid var(--gold-dark);margin-left:.5rem" onClick={startFreshQuiz}>New Random Quiz</button>
+            <button class="rq-restart" onClick={restart}>Play Again</button>
+            {sharedDeck ? (
+              <button class="rq-restart" style="background:transparent;border:1px solid var(--gold-dark)" onClick={startFreshQuiz}>New Random Quiz</button>
+            ) : (
+              <button class="rq-restart" style="background:transparent;border:1px solid var(--gold-dark)" onClick={exitQuiz}>Back to Setup</button>
             )}
-            <a class="restart-btn" href="#/stats" style="background:transparent;border:1px solid var(--gold-dark);text-decoration:none;display:inline-block;margin-left:.5rem">Stats</a>
+            <a class="rq-restart" href="#/stats" style="background:transparent;border:1px solid var(--gold-dark);text-decoration:none;display:inline-block;text-align:center">Stats</a>
             <div class="share-row">
               <ShareButton url={shareUrl} label="Share Link" copiedLabel="Link Copied!" />
               <ShareButton
@@ -183,27 +245,27 @@ export function Quiz({ path, query }) {
     );
   }
 
+  // ── Playing screen ────────────────────────────────────────────────────────
   const current = quizDeck[qIdx];
   const correctTerm = current?.term;
   const pctDisplay = total > 0 ? Math.round(score / total * 100) + '%' : '\u2014';
 
   return (
-    <div>
-      <SubNav tabs={TABS} currentPath="/quizzes/terminology" />
-      {!sharedDeck && <FilterChips activeCats={activeCats} onToggle={handleFilterToggle} />}
-      <div class="quiz-panel">
-        {sharedDeck && (
-          <div class="shared-quiz-banner">
-            <span>Shared quiz {'\u2014'} {quizDeck.length} questions</span>
-            <button type="button" class="shared-quiz-exit" onClick={startFreshQuiz}>Start Random Quiz</button>
-          </div>
-        )}
-        <div class="quiz-status">
-          <div class="q-stat"><div class="val">{score}</div><div class="lbl">Correct</div></div>
-          <div class="q-stat"><div class="val">{streak}</div><div class="lbl">Streak</div></div>
-          <div class="q-stat"><div class="val">{total}</div><div class="lbl">Answered</div></div>
-          <div class="q-stat"><div class="val">{pctDisplay}</div><div class="lbl">Accuracy</div></div>
+    <div class="rq-playing-wrapper">
+      <div class="rq-panel">
+        <div class="rq-playing-header">
+          <div class="rq-mode-badge">Terminology{sharedDeck ? ' \u00b7 Shared' : ''}</div>
+          <button class="rq-exit-btn" onClick={sharedDeck ? startFreshQuiz : exitQuiz}>Exit</button>
         </div>
+
+        <div class="rq-progress"><div class="rq-progress-fill" style={{ width: (qIdx / quizDeck.length * 100) + '%' }}></div></div>
+        <div class="rq-status">
+          <div class="rq-stat"><div class="val">{score}</div><div class="lbl">Correct</div></div>
+          <div class="rq-stat"><div class="val">{qIdx + 1} / {quizDeck.length}</div><div class="lbl">Question</div></div>
+          <div class="rq-stat"><div class="val">{streak}</div><div class="lbl">Streak</div></div>
+          <div class="rq-stat"><div class="val">{pctDisplay}</div><div class="lbl">Accuracy</div></div>
+        </div>
+
         {current && (
           <>
             <div class="quiz-q">
@@ -230,11 +292,16 @@ export function Quiz({ path, query }) {
                 );
               })}
             </div>
-            <div style="text-align:center">
+            <div class="rq-next-row">
               {answered && (
-                <button class="quiz-next" style="display:inline-block" onClick={nextQuiz}>
-                  Next Question {'\u2192'}
-                </button>
+                <>
+                  <button class="rq-next" style="display:inline-block" onClick={nextQuiz}>
+                    Next Question {'\u2192'}
+                  </button>
+                  {settings.autoAdvance && (
+                    <div class="rq-countdown">Auto-advancing in {countdown}s</div>
+                  )}
+                </>
               )}
             </div>
             <div class="share-row">

--- a/src/sections/terminology/Quiz.test.js
+++ b/src/sections/terminology/Quiz.test.js
@@ -47,6 +47,11 @@ describe('Quiz — complete screen', () => {
     expect(quizSource).toMatch(/import\s*\{\s*Recommendation\s*\}\s*from\s*['"][^'"]*Recommendation\.jsx['"]/);
     expect(quizSource).toMatch(/<Recommendation\s*\/>/);
   });
+
+  it('offers a Back to Setup button when the quiz is not from a shared link', () => {
+    // Mirrors preflop: "Back to Setup" returns the user to the topic picker.
+    expect(quizSource).toMatch(/onClick=\{exitQuiz\}[^>]*>Back to Setup/);
+  });
 });
 
 describe('Quiz — share link integration', () => {
@@ -73,6 +78,87 @@ describe('Quiz — share link integration', () => {
     expect(quizSource).toMatch(/decodeTermQuiz\(query\)/);
     expect(quizSource).toMatch(/shared\?\.deck/);
   });
+
+  it('shared links auto-start in the playing phase — skip the setup screen', () => {
+    // The recipient of a share should see the quiz immediately, not a
+    // setup screen that could let them alter the shared deck's topics.
+    expect(quizSource).toMatch(/useState\(shared\s*\?\s*['"]playing['"]\s*:\s*['"]setup['"]\)/);
+  });
+});
+
+describe('Quiz — setup phase', () => {
+  it('defines a setup phase separate from playing — mirrors the preflop quiz flow', () => {
+    // Regression: without a setup phase, the quiz would start immediately on
+    // mount and give the user no chance to pick topics before answering.
+    expect(quizSource).toMatch(/phase\s*===\s*['"]setup['"]/);
+    expect(quizSource).toMatch(/setPhase\(['"]playing['"]\)/);
+  });
+
+  it('renders a Start Quiz button on the setup screen — triggers startQuiz', () => {
+    expect(quizSource).toMatch(/<button\s+class="rq-start-btn"\s+onClick=\{startQuiz\}>\s*Start Quiz\s*<\/button>/);
+  });
+
+  it('renders the FilterChips topic selector on the setup screen', () => {
+    // Users pick which term categories to quiz on before starting.
+    expect(quizSource).toMatch(/import\s*\{\s*FilterChips\s*\}\s*from\s*['"][^'"]*\/FilterChips\.jsx['"]/);
+    expect(quizSource).toMatch(/<FilterChips\s+activeCats=\{activeCats\}\s+onToggle=\{toggleCat\}\s*\/>/);
+  });
+
+  it('startQuiz() re-reads settings and threads fresh.quizLength into buildDeck', () => {
+    // Entering the playing phase must pick up the latest Settings page values
+    // (quizLength, autoAdvance) — otherwise changes wouldn't take effect
+    // without a reload.
+    expect(quizSource).toMatch(/function\s+startQuiz[\s\S]*?getSettings\(\)[\s\S]*?buildDeck\(activeCats,\s*fresh\.quizLength\)[\s\S]*?setPhase\(['"]playing['"]\)/);
+  });
+
+  it('exitQuiz() returns to the setup phase — lets the user re-pick topics mid-quiz', () => {
+    expect(quizSource).toMatch(/function\s+exitQuiz[\s\S]*?setPhase\(['"]setup['"]\)/);
+  });
+});
+
+describe('Quiz — playing screen', () => {
+  it('renders a progress bar filled proportionally to qIdx / quizDeck.length', () => {
+    // Visual feedback that matches the preflop quiz's rq-progress pattern.
+    expect(quizSource).toMatch(/class="rq-progress"/);
+    expect(quizSource).toMatch(/qIdx\s*\/\s*quizDeck\.length\s*\*\s*100/);
+  });
+
+  it('renders a Question N / Total stat so users know where they are in the run', () => {
+    // Regression: previously the playing screen hid the total count, so
+    // users couldn't tell how many questions were left.
+    expect(quizSource).toMatch(/\{qIdx\s*\+\s*1\}\s*\/\s*\{quizDeck\.length\}/);
+    expect(quizSource).toMatch(/<div class="lbl">Question<\/div>/);
+  });
+
+  it('renders an Exit button on the playing screen — mirrors preflop', () => {
+    expect(quizSource).toMatch(/class="rq-exit-btn"/);
+  });
+});
+
+describe('Quiz — auto-advance', () => {
+  it('imports useEffect — required to drive the auto-advance countdown interval', () => {
+    expect(quizSource).toMatch(/import\s*\{[^}]*useEffect[^}]*\}\s*from\s*['"]preact\/hooks['"]/);
+  });
+
+  it('holds a countdown state seeded from settings.autoAdvanceSeconds', () => {
+    expect(quizSource).toMatch(/useState\(settings\.autoAdvanceSeconds\)/);
+  });
+
+  it('bails out of the countdown effect when autoAdvance is disabled in settings', () => {
+    // Users who want to read the question at their own pace must not be
+    // kicked forward by a background timer.
+    expect(quizSource).toMatch(/if\s*\(!settings\.autoAdvance\)\s*return/);
+  });
+
+  it('countdown effect depends on settings.autoAdvance and autoAdvanceSeconds — reflects live Settings changes', () => {
+    expect(quizSource).toMatch(/\[answered,\s*phase,\s*settings\.autoAdvance,\s*settings\.autoAdvanceSeconds[\s\S]*?\]/);
+  });
+
+  it('shows an "Auto-advancing in Ns" indicator while the timer is active', () => {
+    // Users need to see that a timer is running so they can choose to click
+    // Next manually or wait.
+    expect(quizSource).toMatch(/Auto-advancing in \{countdown\}s/);
+  });
 });
 
 describe('Quiz — configurable quiz length', () => {
@@ -80,10 +166,11 @@ describe('Quiz — configurable quiz length', () => {
     expect(quizSource).toMatch(/import\s*\{[^}]*getSettings[^}]*\}\s*from\s*['"][^'"]*\/utils\/storage\.js['"]/);
   });
 
-  it('component initial deck is built with settings.quizLength — respects Settings page choice on mount', () => {
-    // Regression: if buildDeck is called without the length arg here, the terminology
-    // quiz silently ignores the Settings page "Quiz length" choice on first visit.
-    expect(quizSource).toMatch(/buildDeck\(activeCats,\s*settings\.quizLength\)/);
+  it('startQuiz() reads settings.quizLength — the Start button respects the Settings page choice', () => {
+    // Regression: if startQuiz builds the deck without passing the length arg,
+    // the terminology quiz silently ignores the Settings page "Quiz length"
+    // choice and always uses the filtered pool's full size.
+    expect(quizSource).toMatch(/function\s+startQuiz[\s\S]*?buildDeck\(activeCats,\s*fresh\.quizLength\)/);
   });
 
   it('restart() re-reads settings and threads fresh.quizLength into buildDeck — Play Again reflects latest setting', () => {
@@ -91,13 +178,6 @@ describe('Quiz — configurable quiz length', () => {
     // calling getSettings(), changing quizLength in Settings wouldn't take
     // effect on "Play Again" without a full remount.
     expect(quizSource).toMatch(/function\s+restart[\s\S]*?getSettings\(\)[\s\S]*?buildDeck\(activeCats,\s*fresh\.quizLength\)/);
-  });
-
-  it('startFreshQuiz() re-reads settings and threads fresh.quizLength into buildDeck — escaping a shared link honors the Settings choice', () => {
-    // Regression: "New Random Quiz" from a shared deck must respect the
-    // user's current quizLength preference, not silently fall back to the
-    // default or the shared deck's length.
-    expect(quizSource).toMatch(/function\s+startFreshQuiz[\s\S]*?getSettings\(\)[\s\S]*?buildDeck\(activeCats,\s*fresh\.quizLength\)/);
   });
 });
 

--- a/src/sections/terminology/Quiz.test.js
+++ b/src/sections/terminology/Quiz.test.js
@@ -34,6 +34,22 @@ describe('buildOptions', () => {
     expect(buildOptions(deck, deck.length)).toEqual([]);
     expect(buildOptions([], 0)).toEqual([]);
   });
+
+  it('distractors share categories with the deck — no off-topic options', () => {
+    // Regression: with a single selected category, wrong answers pulled from
+    // the global TERMS pool surfaced unrelated terms (e.g. "UTG" as a
+    // distractor in a Hand Rankings quiz), making the quiz feel off-topic.
+    const cats = new Set(['Hand Rankings']);
+    const deck = buildDeck(cats);
+    for (let run = 0; run < 20; run++) {
+      for (let i = 0; i < deck.length; i++) {
+        const opts = buildOptions(deck, i);
+        for (const o of opts) {
+          expect(o.cat, `option ${o.term} had cat ${o.cat}`).toBe('Hand Rankings');
+        }
+      }
+    }
+  });
 });
 
 describe('Quiz — complete screen', () => {
@@ -158,6 +174,22 @@ describe('Quiz — auto-advance', () => {
     // Users need to see that a timer is running so they can choose to click
     // Next manually or wait.
     expect(quizSource).toMatch(/Auto-advancing in \{countdown\}s/);
+  });
+});
+
+describe('Quiz — per-category stats tracking', () => {
+  it('answerQuiz records the current term\'s category alongside correctness', () => {
+    // Per-category accuracy can't be derived after the fact from just
+    // totalCorrect/totalQuestions — we need to log each question's cat as it
+    // gets answered so the complete screen can roll it up by category.
+    expect(quizSource).toMatch(/setPerQuestionResults\(r\s*=>\s*\[\.\.\.r,\s*\{\s*cat:\s*current\.cat,\s*correct:\s*isCorrect\s*\}\s*\]\)/);
+  });
+
+  it('complete screen writes each question into stats.byCategory', () => {
+    // Rolls perQuestionResults up into { total, correct } buckets keyed by
+    // category so the Dashboard can render an "Accuracy by Category" bar chart.
+    expect(quizSource).toMatch(/stats\.byCategory/);
+    expect(quizSource).toMatch(/for\s*\(\s*const\s+r\s+of\s+perQuestionResults/);
   });
 });
 

--- a/src/sections/terminology/Quiz.test.js
+++ b/src/sections/terminology/Quiz.test.js
@@ -75,6 +75,32 @@ describe('Quiz — share link integration', () => {
   });
 });
 
+describe('Quiz — configurable quiz length', () => {
+  it('imports getSettings from storage — required to read the quizLength preference', () => {
+    expect(quizSource).toMatch(/import\s*\{[^}]*getSettings[^}]*\}\s*from\s*['"][^'"]*\/utils\/storage\.js['"]/);
+  });
+
+  it('component initial deck is built with settings.quizLength — respects Settings page choice on mount', () => {
+    // Regression: if buildDeck is called without the length arg here, the terminology
+    // quiz silently ignores the Settings page "Quiz length" choice on first visit.
+    expect(quizSource).toMatch(/buildDeck\(activeCats,\s*settings\.quizLength\)/);
+  });
+
+  it('restart() re-reads settings and threads fresh.quizLength into buildDeck — Play Again reflects latest setting', () => {
+    // Regression: if restart() captured the stale settings state instead of
+    // calling getSettings(), changing quizLength in Settings wouldn't take
+    // effect on "Play Again" without a full remount.
+    expect(quizSource).toMatch(/function\s+restart[\s\S]*?getSettings\(\)[\s\S]*?buildDeck\(activeCats,\s*fresh\.quizLength\)/);
+  });
+
+  it('startFreshQuiz() re-reads settings and threads fresh.quizLength into buildDeck — escaping a shared link honors the Settings choice', () => {
+    // Regression: "New Random Quiz" from a shared deck must respect the
+    // user's current quizLength preference, not silently fall back to the
+    // default or the shared deck's length.
+    expect(quizSource).toMatch(/function\s+startFreshQuiz[\s\S]*?getSettings\(\)[\s\S]*?buildDeck\(activeCats,\s*fresh\.quizLength\)/);
+  });
+});
+
 describe('buildDeck', () => {
   it('filters terms to only matching categories', () => {
     const cats = new Set(['Hand Rankings']);

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -19,7 +19,7 @@ export function saveTermQuizStats(s) {
   try { localStorage.setItem('term-quiz-stats', JSON.stringify(s)); } catch(e) {}
 }
 export function initTermQuizStats() {
-  return { totalQuizzes:0, totalQuestions:0, totalCorrect:0, bestStreak:0, recentScores:[] };
+  return { totalQuizzes:0, totalQuestions:0, totalCorrect:0, bestStreak:0, byCategory:{}, recentScores:[] };
 }
 
 // Limp Quiz Stats

--- a/src/utils/storage.test.js
+++ b/src/utils/storage.test.js
@@ -3,6 +3,7 @@ import {
   getLimpQuizStats, saveLimpQuizStats, initLimpQuizStats,
   getVsRaiseQuizStats, saveVsRaiseQuizStats, initVsRaiseQuizStats,
   getAllModesQuizStats, saveAllModesQuizStats, initAllModesQuizStats,
+  getTermQuizStats, saveTermQuizStats, initTermQuizStats,
   getSettings, saveSettings, resetSettings, DEFAULT_SETTINGS, CARD_SIZES,
   QUIZ_LENGTH_MIN, QUIZ_LENGTH_MAX,
 } from './storage.js';
@@ -168,6 +169,23 @@ describe('Settings', () => {
   it('quiz length range is at least 5..100', () => {
     expect(QUIZ_LENGTH_MIN).toBeLessThanOrEqual(5);
     expect(QUIZ_LENGTH_MAX).toBeGreaterThanOrEqual(100);
+  });
+});
+
+describe('initTermQuizStats', () => {
+  it('exposes an empty byCategory map for per-category accuracy tracking', () => {
+    const s = initTermQuizStats();
+    expect(s.byCategory).toEqual({});
+  });
+
+  it('save/get round-trips byCategory buckets', () => {
+    const s = initTermQuizStats();
+    s.byCategory['Hand Rankings'] = { total: 5, correct: 4 };
+    s.byCategory['Positions']    = { total: 3, correct: 1 };
+    saveTermQuizStats(s);
+    const loaded = getTermQuizStats();
+    expect(loaded.byCategory['Hand Rankings']).toEqual({ total: 5, correct: 4 });
+    expect(loaded.byCategory['Positions']).toEqual({ total: 3, correct: 1 });
   });
 });
 


### PR DESCRIPTION
The terminology Quiz component already reads settings.quizLength on
mount, restart, and startFreshQuiz — but no component-level tests
guarded that wiring. Mirrors the preflop quiz's source-level integration
tests so a future refactor that drops the length argument (or stops
re-reading settings on Play Again) will fail CI instead of silently
regressing the Settings page "Quiz length" preference for terminology
quizzes.