### PR TITLE
Scope terminology quiz answer keys to qIdx to stop focus bleed

### DIFF
--- a/src/sections/terminology/Quiz.jsx
+++ b/src/sections/terminology/Quiz.jsx
@@ -298,9 +298,14 @@ export function Quiz({ path, query }) {
                   if (o.term === correctTerm) cls += ' correct';
                   else if (o.term === selectedAnswer) cls += ' wrong';
                 }
+                // Key is scoped to qIdx so a term appearing as a distractor in
+                // consecutive questions doesn't reuse the previous question's
+                // DOM node. Reuse was preserving :focus-visible on a randomly-
+                // positioned button in the next question's shuffled options,
+                // which looked like a "yellow highlight" on a random answer.
                 return (
                   <button
-                    key={o.term}
+                    key={qIdx + ':' + o.term}
                     class={cls}
                     disabled={answered}
                     onClick={() => answerQuiz(o.term)}

--- a/src/sections/terminology/Quiz.test.js
+++ b/src/sections/terminology/Quiz.test.js
@@ -139,6 +139,17 @@ describe('Quiz — playing screen', () => {
     expect(quizSource).toMatch(/qIdx\s*\/\s*quizDeck\.length\s*\*\s*100/);
   });
 
+  it('keys each answer button by qIdx + term so DOM nodes don\'t persist across questions — no random yellow highlight regression', () => {
+    // Regression for issue #46: when a term appeared as a distractor in two
+    // consecutive questions, Preact reused the previous question's DOM node
+    // (matched by key={o.term}). Focus and :focus-visible carried over, so a
+    // randomly-positioned answer in the next question showed the gold outline
+    // even though the user hadn't interacted with it yet. Scoping the key to
+    // qIdx forces a fresh DOM node per question.
+    expect(quizSource).toMatch(/key=\{qIdx\s*\+\s*['"]:['"][\s\S]{0,20}o\.term\}/);
+    expect(quizSource).not.toMatch(/key=\{o\.term\}/);
+  });
+
   it('renders a Question N / Total stat so users know where they are in the run', () => {
     // Regression: previously the playing screen hid the total count, so
     // users couldn't tell how many questions were left.

--- a/src/styles/quiz.css
+++ b/src/styles/quiz.css
@@ -20,7 +20,13 @@
   font-size:.95rem;cursor:pointer;transition:all .2s;text-align:left;line-height:1.35}
 .ans-btn:focus{outline:none}
 .ans-btn:focus-visible{outline:2px solid var(--gold-dark);outline-offset:2px}
-.ans-btn:hover:not(:disabled){background:rgba(201,168,76,.12);border-color:var(--gold)}
+/* Only apply hover on devices with a true hover-capable pointer. On iOS (and
+   other touch devices) :hover sticks to the last-tapped element until another
+   tap — that was painting a random answer gold on the *next* question because
+   the previous Next-button / answer tap left hover state behind. See #46. */
+@media (hover: hover) {
+  .ans-btn:hover:not(:disabled){background:rgba(201,168,76,.12);border-color:var(--gold)}
+}
 .ans-btn.correct{background:rgba(46,204,113,.18);border-color:#27ae60;color:#a8f0c6}
 .ans-btn.wrong{background:rgba(192,57,43,.18);border-color:#c0392b;color:#f0b8b0}
 .ans-btn:disabled{cursor:default}

--- a/src/styles/quiz.test.js
+++ b/src/styles/quiz.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(resolve(__dirname, 'quiz.css'), 'utf8');
+
+describe('quiz.css — answer button hover', () => {
+  it('gates .ans-btn:hover inside @media (hover: hover) — iOS hover-stickiness regression for #46', () => {
+    // Without the media gate, iOS keeps :hover on the last-tapped element
+    // until another tap. After tapping "Next Question" or an answer in the
+    // previous question, a randomly-positioned answer in the *next* question
+    // inherited the gold border/background — the user-reported "yellow
+    // highlight shows randomly" bug.
+    //
+    // Find the @media (hover: hover) block and assert that .ans-btn:hover
+    // lives inside it (not as a bare top-level rule).
+    const mediaBlockMatch = css.match(/@media\s*\(hover:\s*hover\)\s*\{([\s\S]*?)\n\}/);
+    expect(mediaBlockMatch, 'expected a @media (hover: hover) block in quiz.css').not.toBeNull();
+    expect(mediaBlockMatch[1]).toMatch(/\.ans-btn:hover/);
+
+    // There must be no bare .ans-btn:hover rule at the top level — otherwise
+    // the media-gated version would be redundant and iOS would still see it.
+    const withoutMedia = css.replace(/@media\s*\(hover:\s*hover\)\s*\{[\s\S]*?\n\}/g, '');
+    expect(withoutMedia).not.toMatch(/\.ans-btn:hover/);
+  });
+});


### PR DESCRIPTION
Fixes #46. When a term appeared as a distractor in two consecutive
questions, Preact reused the previous question's DOM node (matched by
key={o.term}), preserving :focus-visible on a button that ended up in
a random position in the next question's shuffled options — the
"yellow highlight on a random answer" symptom. Keying each button by
qIdx + term forces a fresh DOM node per question so focus/hover state
never carries over.

https://claude.ai/code/session_01DeSuA3jqjAwtatgPh6CQkk