### PR TITLE
Add Board Texture category with six flop-type terms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ Both `sections/terminology/Quiz.jsx` and `sections/preflop/Quiz.jsx` use the sam
 { term: "Royal Flush", cat: "Hand Rankings", def: "...", illus: "royal-flush" }
 ```
 
-**9 categories:** Hand Rankings, Positions, Betting Actions, Board & Cards, Strategy, Math & Odds, Player Types, Miscellaneous (~78 total terms)
+**9 categories:** Hand Rankings, Positions, Betting Actions, Board & Cards, Board Texture, Strategy, Math & Odds, Player Types, Miscellaneous (~84 total terms)
 
 **`RFI_RANGES` object** — GTO preflop open-raise ranges per position (6-max):
 ```javascript

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ### Terminology
 - **Study** — 3D flashcard system with elegant flip animations. Each card shows a poker term on one side and its definition with a custom SVG illustration on the other.
 - **Quiz** — Setup screen for picking topics, then multiple-choice questions (4 options) with real-time score, streak tracking, current question counter, and persistent stats. Honors the Settings page's quiz length and auto-advance preferences.
-- **Reference** — Searchable glossary of ~78 poker terms organized across 9 categories, with detailed modal views.
+- **Reference** — Searchable glossary of ~84 poker terms organized across 9 categories (including a Board Texture category covering flop types: dry/static, wet/dynamic, paired, two-tone, monotone, and connected), with detailed modal views.
 
 ### Preflop
 - **Charts** — Interactive 13x13 preflop RFI (Raise First In) hand range grids for each table position (UTG, HJ, CO, BTN, SB).

--- a/src/data/terms.js
+++ b/src/data/terms.js
@@ -163,6 +163,26 @@ export const TERMS = [
    def:"When a board card duplicates one of your cards, weakening your hand. Example: holding 7-6 on a 8-7-6 board (two pair), then the board pairs 8s \u2014 your two pair is now on the board.",
    illus:"board"},
 
+  // Board Texture (Flop Categories)
+  {term:"Dry / Static Flop",cat:"Board Texture",
+   def:"A flop with cards that aren't close together in rank and aren't the same suit, leaving very few draws available (e.g., K♣ 8♠ 3♦). Favors made hands and the pre-flop aggressor's range — big c-bets work well.",
+   illus:"flop-dry"},
+  {term:"Wet / Dynamic Flop",cat:"Board Texture",
+   def:"A flop with close ranks and at least two of the same suit, producing many possible straight and flush draws (e.g., 9♠ 8♠ J♣). Equities run close together — bet sizing matters and caution with one-pair hands is warranted.",
+   illus:"flop-wet"},
+  {term:"Paired Flop",cat:"Board Texture",
+   def:"A flop on which two of the three cards share the same rank (e.g., A♣ A♦ 9♠). Reduces the number of combos available for two pair and straights, and often favors the pre-flop raiser because trips are rare for the caller.",
+   illus:"flop-paired"},
+  {term:"Two-tone Flop",cat:"Board Texture",
+   def:"A flop with two cards of one suit and a third card of a different suit (e.g., A♠ 9♠ 5♦). Introduces a flush draw but no completed flush — the most common board texture in Hold'em.",
+   illus:"flop-twotone"},
+  {term:"Monotone Flop",cat:"Board Texture",
+   def:"A flop on which all three cards share the same suit (e.g., Q♥ 8♥ 5♥). A flush is already possible; players without a card of that suit have very limited equity, and strategy skews toward checking and small bets.",
+   illus:"flop-monotone"},
+  {term:"Connected Flop",cat:"Board Texture",
+   def:"A flop with cards that are close together in rank (consecutive or one-gap), regardless of suit, so straights and straight draws are plentiful (e.g., 4♣ 6♦ 7♠). Overlaps with 'wet' when also two-tone or monotone.",
+   illus:"flop-connected"},
+
   // Strategy
   {term:"Continuation Bet (C-Bet)",cat:"Strategy",
    def:"A bet on the flop (or later street) by the pre-flop aggressor, 'continuing' the story of pre-flop strength even when the board missed them.",

--- a/src/data/terms.test.js
+++ b/src/data/terms.test.js
@@ -62,3 +62,34 @@ describe('card combination terms', () => {
     });
   }
 });
+
+describe('board texture (flop category) terms', () => {
+  const flopTextureTerms = [
+    'Dry / Static Flop',
+    'Wet / Dynamic Flop',
+    'Paired Flop',
+    'Two-tone Flop',
+    'Monotone Flop',
+    'Connected Flop',
+  ];
+
+  for (const name of flopTextureTerms) {
+    it(`"${name}" exists in Board Texture category`, () => {
+      const found = TERMS.find(t => t.term === name);
+      expect(found, `term "${name}" not found`).toBeTruthy();
+      expect(found.cat).toBe('Board Texture');
+    });
+  }
+
+  it('Board Texture category is present in CATS', () => {
+    expect(CATS).toContain('Board Texture');
+  });
+
+  it('each flop-texture term has a dedicated flop-* illustration', () => {
+    for (const name of flopTextureTerms) {
+      const found = TERMS.find(t => t.term === name);
+      expect(found.illus.startsWith('flop-'), `"${name}" illus "${found.illus}" should start with "flop-"`).toBe(true);
+      expect(typeof ILLUS[found.illus]).toBe('function');
+    }
+  });
+});

--- a/src/utils/illustrations.jsx
+++ b/src/utils/illustrations.jsx
@@ -101,6 +101,36 @@ export const ILLUS = {
     <div style="font-size:.7rem;color:#8a7a5a;letter-spacing:.1em">FLOP</div>
     <div class="hand">${cardSvg('9','♠',54,76)}${cardSvg('K','♥',54,76)}${cardSvg('3','♦',54,76)}</div>
   </div>`,
+  'flop-dry': ()=>`<div style="display:flex;flex-direction:column;gap:6px;align-items:center">
+    <div style="font-size:.7rem;color:#c9a84c;letter-spacing:.1em">DRY / STATIC</div>
+    <div class="hand">${cardSvg('K','♣',54,76)}${cardSvg('8','♠',54,76)}${cardSvg('3','♦',54,76)}</div>
+    <div style="font-size:.65rem;color:#8a7a5a">disconnected ranks, three suits — few draws</div>
+  </div>`,
+  'flop-wet': ()=>`<div style="display:flex;flex-direction:column;gap:6px;align-items:center">
+    <div style="font-size:.7rem;color:#c9a84c;letter-spacing:.1em">WET / DYNAMIC</div>
+    <div class="hand">${cardSvg('9','♠',54,76)}${cardSvg('8','♠',54,76)}${cardSvg('J','♣',54,76)}</div>
+    <div style="font-size:.65rem;color:#8a7a5a">close ranks + two of a suit — many draws</div>
+  </div>`,
+  'flop-paired': ()=>`<div style="display:flex;flex-direction:column;gap:6px;align-items:center">
+    <div style="font-size:.7rem;color:#c9a84c;letter-spacing:.1em">PAIRED</div>
+    <div class="hand">${cardSvg('A','♣',54,76)}${cardSvg('A','♦',54,76)}${cardSvg('9','♠',54,76)}</div>
+    <div style="font-size:.65rem;color:#8a7a5a">two board cards share a rank</div>
+  </div>`,
+  'flop-twotone': ()=>`<div style="display:flex;flex-direction:column;gap:6px;align-items:center">
+    <div style="font-size:.7rem;color:#c9a84c;letter-spacing:.1em">TWO-TONE</div>
+    <div class="hand">${cardSvg('A','♠',54,76)}${cardSvg('9','♠',54,76)}${cardSvg('5','♦',54,76)}</div>
+    <div style="font-size:.65rem;color:#8a7a5a">two cards of one suit — flush draw live</div>
+  </div>`,
+  'flop-monotone': ()=>`<div style="display:flex;flex-direction:column;gap:6px;align-items:center">
+    <div style="font-size:.7rem;color:#c9a84c;letter-spacing:.1em">MONOTONE</div>
+    <div class="hand">${cardSvg('Q','♥',54,76)}${cardSvg('8','♥',54,76)}${cardSvg('5','♥',54,76)}</div>
+    <div style="font-size:.65rem;color:#8a7a5a">all three cards same suit — flush possible</div>
+  </div>`,
+  'flop-connected': ()=>`<div style="display:flex;flex-direction:column;gap:6px;align-items:center">
+    <div style="font-size:.7rem;color:#c9a84c;letter-spacing:.1em">CONNECTED</div>
+    <div class="hand">${cardSvg('4','♣',54,76)}${cardSvg('6','♦',54,76)}${cardSvg('7','♠',54,76)}</div>
+    <div style="font-size:.65rem;color:#8a7a5a">close ranks — straights and straight draws</div>
+  </div>`,
   'turn': ()=>`<div style="display:flex;flex-direction:column;gap:6px;align-items:center">
     <div style="font-size:.7rem;color:#8a7a5a;letter-spacing:.1em">TURN</div>
     <div class="hand">${['9♠','K♥','3♦','7♣'].map(c=>cardSvg(c.slice(0,-1),c.slice(-1),50,70)).join('')}</div>


### PR DESCRIPTION
Introduces a new "Board Texture" terminology category covering the standard
flop classifications — dry/static, wet/dynamic, paired, two-tone, monotone,
and connected — each with a dedicated flop-* SVG illustration. Lets learners
study and quiz on board-texture vocabulary alongside the existing terms.