### PR TITLE
Add Flop Texture classification quiz

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,8 @@ poker-trainer/
 │       ├── preflop/
 │       │   ├── Charts.jsx              # RFI hand range grid with position tabs
 │       │   └── Quiz.jsx                # Raise/fold RFI quiz
+│       ├── flop/
+│       │   └── Quiz.jsx                # Board-texture classification quiz (3 cards → texture)
 │       ├── stats/
 │       │   └── Dashboard.jsx           # Full stats dashboard
 │       └── settings/
@@ -93,10 +95,13 @@ Hash-based routing (`#/path`) for GitHub Pages compatibility.
 | `#/terminology/reference` | Reference.jsx | Searchable glossary |
 | `#/preflop/charts` | Charts.jsx | RFI hand range grids |
 | `#/preflop/quiz` | Quiz.jsx | Raise/fold RFI quiz |
+| `#/quizzes/terminology` | Terminology Quiz.jsx | Multiple-choice terminology quiz |
+| `#/quizzes/preflop` | Preflop Quiz.jsx | Raise/fold/3-bet preflop quiz (RFI / vs-Limp / vs-Raise / All) |
+| `#/quizzes/flop` | Flop Quiz.jsx | Board-texture classification quiz (3 flop cards → one of 6 textures) |
 | `#/stats` | Dashboard.jsx | Full stats dashboard |
 | `#/settings` | Settings.jsx | User preferences (auto-advance, card image size) |
 
-Redirects: `/` → `/welcome`, `/terminology` → `/terminology/study`, `/preflop` → `/preflop/charts`
+Redirects: `/` → `/welcome`, `/terminology` → `/terminology/study`, `/preflop` → `/preflop/charts`, `/quizzes` → `/quizzes/preflop`
 
 ### Shareable quiz links
 
@@ -106,6 +111,7 @@ Quiz routes accept query strings that encode a reproducible quiz:
 |---|---|---|
 | `#/quizzes/terminology` | `?tq=<i,i,i,...>` | Comma-separated indexes into `TERMS`; defines the ordered question deck. |
 | `#/quizzes/preflop` | `?pq=<stackDepth>~<q1>~<q2>...` | Each `qN = <typeCode>.<hand>.<heroPos>.<villainOrDash>.<suitCode>` where typeCode ∈ `{r,l,v}` (rfi, limp, vsRaise) and suitCode ∈ `{s,h,d,c}`. Correct actions are re-derived from the GTO ranges; suits preserve the exact card rendering. The trailing suit field is optional — legacy 4-field links still decode. |
+| `#/quizzes/flop` | `?fq=<q1>,<q2>,...` | Each `qN = <r1><s1><r2><s2><r3><s3>` — three cards with `rN ∈ {2..9,T,J,Q,K,A}` (T for 10) and `sN ∈ {s,h,d,c}`. The correct texture is re-derived by `classifyFlop` at load time, so only the cards need to travel in the URL. |
 
 Both quiz types auto-start in the playing phase when loaded from a shared link, bypassing the setup screen so the recipient can't alter the shared deck. "Play Again" replays the same deck; "New Random Quiz" drops out of shared mode and returns the user to the setup screen (topic picker for terminology, mode/stack/positions for preflop). See `src/utils/share.js` and `src/components/ShareButton.jsx`.
 
@@ -165,7 +171,8 @@ Fonts: `'Playfair Display'` for headings, `'Crimson Pro'` for body text.
 | Key | Content |
 |---|---|
 | `rfi-quiz-stats` | `{ totalQuizzes, totalQuestions, totalCorrect, byPosition, recentScores }` |
-| `term-quiz-stats` | `{ totalQuizzes, totalQuestions, totalCorrect, bestStreak, recentScores }` |
+| `term-quiz-stats` | `{ totalQuizzes, totalQuestions, totalCorrect, bestStreak, byCategory, recentScores }` |
+| `flop-quiz-stats` | `{ totalQuizzes, totalQuestions, totalCorrect, bestStreak, byTexture, recentScores }` |
 | `study-progress` | `{ cardsSeen: [], totalFlips, byCategory: {} }` |
 | `settings` | `{ autoAdvance, autoAdvanceSeconds, cardSize, quizLength }` |
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@
 - **Charts** — Interactive 13x13 preflop RFI (Raise First In) hand range grids for each table position (UTG, HJ, CO, BTN, SB).
 - **RFI Quiz** — Practice raise/fold decisions against GTO-optimal preflop ranges with persistent progress tracking. Each question shows the 6-max table with hero highlighted gold and (in vs Limp / vs Raise modes) the villain highlighted red, with a chip next to the villain seat indicating their action (↑ for raise, ✓ for limp).
 
+### Quizzes
+- **Preflop Quiz** — The RFI / vs-Limp / vs-Raise preflop quizzes (above).
+- **Terminology Quiz** — Multiple-choice questions on poker terms across all 9 categories.
+- **Flop Texture Quiz** — Classify a randomly dealt three-card flop as one of the six Board Texture categories (Paired, Monotone, Wet / Dynamic, Two-tone, Connected, Dry / Static). Four multiple-choice options are drawn from the same pool so the user has to read the flop's ranks, suits, and connectedness to pick the right one.
+
 ### Stats
 - **Dashboard** — Full statistics view showing study progress, terminology quiz accuracy, and RFI quiz performance by position. Surfaces a "Recommended Next Quiz" card that points you at your weakest area (or an untaken quiz for a baseline) with a one-click button to start it.
 
@@ -83,6 +88,7 @@ All routes use hash-based URLs for GitHub Pages compatibility:
 | `#/terminology/reference` | Searchable glossary |
 | `#/preflop/charts` | RFI hand range grids |
 | `#/preflop/quiz` | Raise/fold RFI quiz |
+| `#/quizzes/flop` | Flop Texture (Board Texture) quiz |
 | `#/stats` | Stats dashboard |
 
 ## Deployment

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -7,6 +7,7 @@ import { Charts } from './sections/preflop/Charts.jsx';
 import { LimpCharts } from './sections/preflop/LimpCharts.jsx';
 import { RaiseCharts } from './sections/preflop/RaiseCharts.jsx';
 import { PreflopQuiz } from './sections/preflop/Quiz.jsx';
+import { FlopQuiz } from './sections/flop/Quiz.jsx';
 import { Dashboard } from './sections/stats/Dashboard.jsx';
 import { Welcome } from './sections/welcome/Welcome.jsx';
 import { Settings } from './sections/settings/Settings.jsx';
@@ -47,6 +48,7 @@ const ROUTES = {
   '/preflop/vs-raise': RaiseCharts,
   '/quizzes/terminology': TermQuiz,
   '/quizzes/preflop': PreflopQuiz,
+  '/quizzes/flop': FlopQuiz,
   '/stats': Dashboard,
   '/settings': Settings,
 };

--- a/src/routing.js
+++ b/src/routing.js
@@ -8,6 +8,7 @@ export const ROUTES_LIST = [
   '/preflop/vs-raise',
   '/quizzes/terminology',
   '/quizzes/preflop',
+  '/quizzes/flop',
   '/stats',
   '/settings',
 ];

--- a/src/routing.test.js
+++ b/src/routing.test.js
@@ -61,6 +61,11 @@ describe('routing', () => {
     expect(ROUTES_LIST).toContain('/quizzes/preflop');
   });
 
+  it('/quizzes/flop exists in routes list — flop texture quiz is reachable', () => {
+    expect(ROUTES_LIST).toContain('/quizzes/flop');
+    expect(resolveRoute('/quizzes/flop')).toBe('/quizzes/flop');
+  });
+
   it('resolves /quizzes shorthand to preflop quiz — preflop is default quiz mode', () => {
     expect(resolveRoute('/quizzes')).toBe('/quizzes/preflop');
   });

--- a/src/sections/flop/Quiz.jsx
+++ b/src/sections/flop/Quiz.jsx
@@ -1,14 +1,22 @@
 import { useState, useCallback, useEffect } from 'preact/hooks';
 import { SubNav } from '../../components/SubNav.jsx';
-import { FilterChips } from '../../components/FilterChips.jsx';
-import { Recommendation } from '../../components/Recommendation.jsx';
 import { ShareButton } from '../../components/ShareButton.jsx';
-import { useFilters } from '../../hooks/useFilters.js';
 import { TERMS } from '../../data/terms.js';
 import { shuffle } from '../../utils/shuffle.js';
-import { getIllus } from '../../utils/illustrations.jsx';
-import { getTermQuizStats, saveTermQuizStats, initTermQuizStats, getSettings } from '../../utils/storage.js';
-import { encodeTermQuiz, decodeTermQuiz, buildShareUrl, buildScoreMessage } from '../../utils/share.js';
+import { cardSvg } from '../../utils/illustrations.jsx';
+import { BOARD_TEXTURES, buildFlopDeck } from '../../utils/flop.js';
+import {
+  getFlopQuizStats,
+  saveFlopQuizStats,
+  initFlopQuizStats,
+  getSettings,
+} from '../../utils/storage.js';
+import {
+  encodeFlopQuiz,
+  decodeFlopQuiz,
+  buildShareUrl,
+  buildScoreMessage,
+} from '../../utils/share.js';
 import '../../styles/quiz.css';
 
 const TABS = [
@@ -17,96 +25,101 @@ const TABS = [
   { path: '/quizzes/flop', label: 'Flop' },
 ];
 
-export function buildDeck(cats, length = Infinity) {
-  const deck = shuffle(TERMS.filter(t => cats.has(t.cat)));
-  return Number.isFinite(length) ? deck.slice(0, Math.max(0, length)) : deck;
+// The six Board Texture terms power both the quiz answers and the per-option
+// definitions shown to the user (pulled by name from terms.js).
+const TEXTURE_TERMS = BOARD_TEXTURES
+  .map(name => TERMS.find(t => t.term === name))
+  .filter(Boolean);
+
+const TEXTURE_BY_NAME = Object.fromEntries(TEXTURE_TERMS.map(t => [t.term, t]));
+
+function renderFlop(cards) {
+  const parts = cards.map(c => cardSvg(c.rank, c.suit, 60, 84)).join('');
+  return `<div class="hand">${parts}</div>`;
 }
 
-export function buildOptions(deck, idx) {
-  if (idx >= deck.length) return [];
-  const t = deck[idx];
-  // Wrong answers come from the same topic pool as the deck — selecting
-  // "Hand Rankings" only shouldn't surface a "Positions" term as a distractor.
-  const deckCats = new Set(deck.map(x => x.cat));
-  const wrong = TERMS.filter(x => x.term !== t.term && deckCats.has(x.cat));
-  const picked = shuffle(wrong).slice(0, 3);
-  return shuffle([...picked, t]);
+function buildOptions(correctTexture) {
+  const wrong = TEXTURE_TERMS.filter(t => t.term !== correctTexture);
+  const picks = shuffle(wrong).slice(0, 3);
+  const correct = TEXTURE_BY_NAME[correctTexture];
+  return shuffle([...picks, correct]);
 }
 
-export function Quiz({ path, query }) {
-  const shared = decodeTermQuiz(query);
-  const { activeCats, toggleCat } = useFilters();
+export function FlopQuiz({ query }) {
+  const shared = decodeFlopQuiz(query);
   const [settings, setSettings] = useState(() => getSettings());
   const [phase, setPhase] = useState(shared ? 'playing' : 'setup');
   const [sharedDeck, setSharedDeck] = useState(() => shared?.deck || null);
-  const [quizDeck, setQuizDeck] = useState(() => shared?.deck || []);
+  const [deck, setDeck] = useState(() => shared?.deck || []);
   const [qIdx, setQIdx] = useState(0);
   const [score, setScore] = useState(0);
   const [streak, setStreak] = useState(0);
   const [total, setTotal] = useState(0);
   const [answered, setAnswered] = useState(false);
-  const [selectedAnswer, setSelectedAnswer] = useState(null);
-  const [options, setOptions] = useState(() => (shared?.deck ? buildOptions(shared.deck, 0) : []));
+  const [selected, setSelected] = useState(null);
+  const [options, setOptions] = useState(() => (
+    shared?.deck?.length ? buildOptions(shared.deck[0].texture) : []
+  ));
   const [countdown, setCountdown] = useState(settings.autoAdvanceSeconds);
-  const [perQuestionResults, setPerQuestionResults] = useState([]);
+  const [results, setResults] = useState([]);
 
-  // If the URL's ?tq= query changes (e.g. opening a shared link while already
-  // on the quiz), rebuild the deck from the shared terms and jump straight
-  // into playing — mirrors the preflop shared-link behavior.
+  // Shared-link handler: when ?fq= appears or changes, rebuild from the
+  // encoded cards and auto-start the quiz.
   useEffect(() => {
-    const next = decodeTermQuiz(query);
+    const next = decodeFlopQuiz(query);
     if (!next) return;
     const sameDeck = sharedDeck
       && sharedDeck.length === next.deck.length
-      && sharedDeck.every((t, i) => t.term === next.deck[i].term);
+      && sharedDeck.every((q, i) => (
+        q.cards.length === next.deck[i].cards.length
+        && q.cards.every((c, j) => (
+          c.rank === next.deck[i].cards[j].rank
+          && c.suit === next.deck[i].cards[j].suit
+        ))
+      ));
     if (sameDeck) return;
     setSharedDeck(next.deck);
-    setQuizDeck(next.deck);
+    setDeck(next.deck);
     setPhase('playing');
     setQIdx(0);
     setScore(0);
     setStreak(0);
     setTotal(0);
     setAnswered(false);
-    setSelectedAnswer(null);
-    setOptions(buildOptions(next.deck, 0));
-    setPerQuestionResults([]);
-  }, [query?.tq]);
+    setSelected(null);
+    setOptions(buildOptions(next.deck[0].texture));
+    setResults([]);
+  }, [query?.fq]);
 
   function startQuiz() {
-    // Entered from the setup screen's Start button. Reads fresh settings so
-    // quizLength/autoAdvance changes made on the Settings page take effect
-    // without requiring a reload.
     const fresh = getSettings();
     setSettings(fresh);
-    const newDeck = buildDeck(activeCats, fresh.quizLength);
-    setQuizDeck(newDeck);
+    const newDeck = buildFlopDeck(fresh.quizLength);
+    setDeck(newDeck);
     setQIdx(0);
     setScore(0);
     setStreak(0);
     setTotal(0);
     setAnswered(false);
-    setSelectedAnswer(null);
-    setOptions(buildOptions(newDeck, 0));
-    setPerQuestionResults([]);
+    setSelected(null);
+    setOptions(buildOptions(newDeck[0].texture));
+    setResults([]);
     setPhase('playing');
   }
 
   function restart() {
-    // "Play Again" from the complete screen — stays in playing phase.
-    // Shared quizzes replay the same deck so the share link stays reproducible.
     const fresh = getSettings();
     setSettings(fresh);
-    const newDeck = sharedDeck ? sharedDeck : buildDeck(activeCats, fresh.quizLength);
-    setQuizDeck(newDeck);
+    const newDeck = sharedDeck ? sharedDeck : buildFlopDeck(fresh.quizLength);
+    setDeck(newDeck);
     setQIdx(0);
     setScore(0);
     setStreak(0);
     setTotal(0);
     setAnswered(false);
-    setSelectedAnswer(null);
-    setOptions(buildOptions(newDeck, 0));
-    setPerQuestionResults([]);
+    setSelected(null);
+    setOptions(buildOptions(newDeck[0].texture));
+    setResults([]);
   }
 
   function exitQuiz() {
@@ -116,38 +129,36 @@ export function Quiz({ path, query }) {
     setStreak(0);
     setTotal(0);
     setAnswered(false);
-    setSelectedAnswer(null);
-    setPerQuestionResults([]);
+    setSelected(null);
+    setResults([]);
   }
 
   function startFreshQuiz() {
-    // Dropping out of a shared deck returns the user to the setup screen so
-    // they can pick topics before the random quiz starts.
     setSharedDeck(null);
-    setQuizDeck([]);
+    setDeck([]);
     setQIdx(0);
     setScore(0);
     setStreak(0);
     setTotal(0);
     setAnswered(false);
-    setSelectedAnswer(null);
-    setPerQuestionResults([]);
+    setSelected(null);
+    setResults([]);
     setPhase('setup');
-    if (window.location.hash.includes('?tq=')) {
-      window.location.hash = '#/quizzes/terminology';
+    if (window.location.hash.includes('?fq=')) {
+      window.location.hash = '#/quizzes/flop';
     }
   }
 
-  const shareQuery = encodeTermQuiz(quizDeck);
-  const shareUrl = shareQuery ? buildShareUrl('/quizzes/terminology', shareQuery) : null;
+  const shareQuery = encodeFlopQuiz(deck);
+  const shareUrl = shareQuery ? buildShareUrl('/quizzes/flop', shareQuery) : null;
 
-  const answerQuiz = useCallback((chosen) => {
+  const answer = useCallback((chosenTerm) => {
     if (answered) return;
     setAnswered(true);
-    setSelectedAnswer(chosen);
-    const current = quizDeck[qIdx];
-    const correct = current.term;
-    const isCorrect = chosen === correct;
+    setSelected(chosenTerm);
+    const current = deck[qIdx];
+    const correct = current.texture;
+    const isCorrect = chosenTerm === correct;
     if (isCorrect) {
       setScore(s => s + 1);
       setStreak(s => s + 1);
@@ -155,21 +166,20 @@ export function Quiz({ path, query }) {
       setStreak(0);
     }
     setTotal(t => t + 1);
-    setPerQuestionResults(r => [...r, { cat: current.cat, correct: isCorrect }]);
-  }, [answered, quizDeck, qIdx]);
+    setResults(r => [...r, { texture: correct, correct: isCorrect }]);
+  }, [answered, deck, qIdx]);
 
-  function nextQuiz(e) {
+  function nextQuestion(e) {
     if (e?.currentTarget?.blur) e.currentTarget.blur();
     const nextIdx = qIdx + 1;
     setQIdx(nextIdx);
     setAnswered(false);
-    setSelectedAnswer(null);
-    setOptions(buildOptions(quizDeck, nextIdx));
+    setSelected(null);
+    if (nextIdx < deck.length) {
+      setOptions(buildOptions(deck[nextIdx].texture));
+    }
   }
 
-  // Auto-advance after answering — only runs when the user has enabled it in
-  // settings. Cleanup cancels the timer when the user clicks Next manually or
-  // exits the quiz.
   useEffect(() => {
     if (!answered || phase !== 'playing') return;
     if (!settings.autoAdvance) return;
@@ -184,23 +194,31 @@ export function Quiz({ path, query }) {
         const nextIdx = qIdx + 1;
         setQIdx(nextIdx);
         setAnswered(false);
-        setSelectedAnswer(null);
-        setOptions(buildOptions(quizDeck, nextIdx));
+        setSelected(null);
+        if (nextIdx < deck.length) {
+          setOptions(buildOptions(deck[nextIdx].texture));
+        }
       }
     }, 1000);
     return () => clearInterval(id);
-  }, [answered, phase, settings.autoAdvance, settings.autoAdvanceSeconds, qIdx, quizDeck]);
+  }, [answered, phase, settings.autoAdvance, settings.autoAdvanceSeconds, qIdx, deck]);
 
   // ── Setup screen ──────────────────────────────────────────────────────────
   if (phase === 'setup') {
     return (
       <div>
-        <SubNav tabs={TABS} currentPath="/quizzes/terminology" />
+        <SubNav tabs={TABS} currentPath="/quizzes/flop" />
         <div class="rq-panel">
-          <h2 class="rq-title">Terminology Quiz</h2>
-          <p class="rq-sub">Pick the topics you want to practice, then start the quiz.</p>
-          <div class="rq-setup-label">Topics</div>
-          <FilterChips activeCats={activeCats} onToggle={toggleCat} />
+          <h2 class="rq-title">Flop Texture Quiz</h2>
+          <p class="rq-sub">
+            You'll see three flop cards. Pick the board texture that best describes them.
+          </p>
+          <div class="rq-setup-label">Textures you'll see</div>
+          <ul class="rq-texture-list">
+            {TEXTURE_TERMS.map(t => (
+              <li key={t.term}><strong>{t.term}</strong> &mdash; {t.def}</li>
+            ))}
+          </ul>
           <div class="rq-start-row">
             <button class="rq-start-btn" onClick={startQuiz}>Start Quiz</button>
           </div>
@@ -210,36 +228,35 @@ export function Quiz({ path, query }) {
   }
 
   // ── Complete screen ───────────────────────────────────────────────────────
-  if (qIdx >= quizDeck.length && quizDeck.length > 0) {
+  if (qIdx >= deck.length && deck.length > 0) {
     const pct = Math.round(score / total * 100);
-    const msg = pct >= 90 ? 'Phenomenal \u2014 table captain!' :
-                pct >= 70 ? 'Well played \u2014 solid fundamentals.' :
-                pct >= 50 ? 'Good start \u2014 keep grinding.' :
+    const msg = pct >= 90 ? 'Phenomenal — you read boards like a pro!' :
+                pct >= 70 ? 'Well played — solid texture reads.' :
+                pct >= 50 ? 'Good start — revisit the Board Texture cards.' :
                 'Hit the study cards and come back!';
 
-    // Save stats
-    const stats = getTermQuizStats() || initTermQuizStats();
+    const stats = getFlopQuizStats() || initFlopQuizStats();
     stats.totalQuizzes++;
     stats.totalQuestions += total;
     stats.totalCorrect += score;
     if (streak > stats.bestStreak) stats.bestStreak = streak;
-    if (!stats.byCategory) stats.byCategory = {};
-    for (const r of perQuestionResults) {
-      const bucket = stats.byCategory[r.cat] || { total: 0, correct: 0 };
+    if (!stats.byTexture) stats.byTexture = {};
+    for (const r of results) {
+      const bucket = stats.byTexture[r.texture] || { total: 0, correct: 0 };
       bucket.total += 1;
       if (r.correct) bucket.correct += 1;
-      stats.byCategory[r.cat] = bucket;
+      stats.byTexture[r.texture] = bucket;
     }
     stats.recentScores.push({ date: new Date().toLocaleDateString(), score, total });
     if (stats.recentScores.length > 20) stats.recentScores = stats.recentScores.slice(-20);
-    saveTermQuizStats(stats);
+    saveFlopQuizStats(stats);
 
     return (
       <div>
-        <SubNav tabs={TABS} currentPath="/quizzes/terminology" />
+        <SubNav tabs={TABS} currentPath="/quizzes/flop" />
         <div class="rq-panel">
           <div class="rq-complete">
-            <h2>{pct >= 70 ? '\uD83C\uDFC6' : '\uD83C\uDCCF'} Round Complete</h2>
+            <h2>{pct >= 70 ? '🏆' : '🃏'} Round Complete</h2>
             <div class="score-big">{score} / {total} &mdash; {pct}%</div>
             <p>{msg}</p>
             <button class="rq-restart" onClick={restart}>Play Again</button>
@@ -258,29 +275,27 @@ export function Quiz({ path, query }) {
               />
             </div>
           </div>
-          <Recommendation />
         </div>
       </div>
     );
   }
 
   // ── Playing screen ────────────────────────────────────────────────────────
-  const current = quizDeck[qIdx];
-  const correctTerm = current?.term;
-  const pctDisplay = total > 0 ? Math.round(score / total * 100) + '%' : '\u2014';
+  const current = deck[qIdx];
+  const pctDisplay = total > 0 ? Math.round(score / total * 100) + '%' : '—';
 
   return (
     <div class="rq-playing-wrapper">
       <div class="rq-panel">
         <div class="rq-playing-header">
-          <div class="rq-mode-badge">Terminology{sharedDeck ? ' \u00b7 Shared' : ''}</div>
+          <div class="rq-mode-badge">Flop Texture{sharedDeck ? ' · Shared' : ''}</div>
           <button class="rq-exit-btn" onClick={sharedDeck ? startFreshQuiz : exitQuiz}>Exit</button>
         </div>
 
-        <div class="rq-progress"><div class="rq-progress-fill" style={{ width: (qIdx / quizDeck.length * 100) + '%' }}></div></div>
+        <div class="rq-progress"><div class="rq-progress-fill" style={{ width: (qIdx / deck.length * 100) + '%' }}></div></div>
         <div class="rq-status">
           <div class="rq-stat"><div class="val">{score}</div><div class="lbl">Correct</div></div>
-          <div class="rq-stat"><div class="val">{qIdx + 1} / {quizDeck.length}</div><div class="lbl">Question</div></div>
+          <div class="rq-stat"><div class="val">{qIdx + 1} / {deck.length}</div><div class="lbl">Question</div></div>
           <div class="rq-stat"><div class="val">{streak}</div><div class="lbl">Streak</div></div>
           <div class="rq-stat"><div class="val">{pctDisplay}</div><div class="lbl">Accuracy</div></div>
         </div>
@@ -288,29 +303,25 @@ export function Quiz({ path, query }) {
         {current && (
           <>
             <div class="quiz-q">
-              <div class="q-cat">{current.cat}</div>
-              <div class="q-term">{current.term}</div>
-              <div class="q-illus" dangerouslySetInnerHTML={{ __html: getIllus(current) }} />
+              <div class="q-cat">Board Texture</div>
+              <div class="q-term">Which texture best describes this flop?</div>
+              <div class="q-illus" dangerouslySetInnerHTML={{ __html: renderFlop(current.cards) }} />
             </div>
             <div class="answers">
               {options.map(o => {
                 let cls = 'ans-btn';
                 if (answered) {
-                  if (o.term === correctTerm) cls += ' correct';
-                  else if (o.term === selectedAnswer) cls += ' wrong';
+                  if (o.term === current.texture) cls += ' correct';
+                  else if (o.term === selected) cls += ' wrong';
                 }
-                // Key is scoped to qIdx so a term appearing as a distractor in
-                // consecutive questions doesn't reuse the previous question's
-                // DOM node. Reuse was preserving :focus-visible on a randomly-
-                // positioned button in the next question's shuffled options,
-                // which looked like a "yellow highlight" on a random answer.
                 return (
                   <button
                     key={qIdx + ':' + o.term}
                     class={cls}
                     disabled={answered}
-                    onClick={() => answerQuiz(o.term)}
+                    onClick={() => answer(o.term)}
                   >
+                    <span class="ans-term">{o.term}</span>
                     <span class="ans-def">{o.def}</span>
                   </button>
                 );
@@ -319,8 +330,8 @@ export function Quiz({ path, query }) {
             <div class="rq-next-row">
               {answered && (
                 <>
-                  <button class="rq-next" style="display:inline-block" onClick={nextQuiz}>
-                    Next Question {'\u2192'}
+                  <button class="rq-next" style="display:inline-block" onClick={nextQuestion}>
+                    Next Question {'→'}
                   </button>
                   {settings.autoAdvance && (
                     <div class="rq-countdown">Auto-advancing in {countdown}s</div>

--- a/src/sections/flop/Quiz.jsx
+++ b/src/sections/flop/Quiz.jsx
@@ -21,8 +21,8 @@ import '../../styles/quiz.css';
 
 const TABS = [
   { path: '/quizzes/preflop', label: 'Preflop' },
-  { path: '/quizzes/terminology', label: 'Terminology' },
   { path: '/quizzes/flop', label: 'Flop' },
+  { path: '/quizzes/terminology', label: 'Terminology' },
 ];
 
 // The six Board Texture terms power both the quiz answers and the per-option
@@ -322,7 +322,6 @@ export function FlopQuiz({ query }) {
                     onClick={() => answer(o.term)}
                   >
                     <span class="ans-term">{o.term}</span>
-                    <span class="ans-def">{o.def}</span>
                   </button>
                 );
               })}

--- a/src/sections/preflop/Quiz.jsx
+++ b/src/sections/preflop/Quiz.jsx
@@ -49,6 +49,7 @@ import '../../styles/quiz.css';
 const TABS = [
   { path: '/quizzes/preflop', label: 'Preflop' },
   { path: '/quizzes/terminology', label: 'Terminology' },
+  { path: '/quizzes/flop', label: 'Flop' },
 ];
 
 const MODES = [

--- a/src/sections/preflop/Quiz.jsx
+++ b/src/sections/preflop/Quiz.jsx
@@ -48,8 +48,8 @@ import '../../styles/quiz.css';
 
 const TABS = [
   { path: '/quizzes/preflop', label: 'Preflop' },
-  { path: '/quizzes/terminology', label: 'Terminology' },
   { path: '/quizzes/flop', label: 'Flop' },
+  { path: '/quizzes/terminology', label: 'Terminology' },
 ];
 
 const MODES = [

--- a/src/sections/stats/Dashboard.jsx
+++ b/src/sections/stats/Dashboard.jsx
@@ -1,7 +1,8 @@
 import { useState } from 'preact/hooks';
 import { TERMS, CATS } from '../../data/terms.js';
 import { RFI_QUIZ_POSITIONS } from '../../data/rfi-ranges.js';
-import { getStudyProgress, initStudyProgress, getTermQuizStats, initTermQuizStats, getRfiQuizStats, initRfiQuizStats, getLimpQuizStats, initLimpQuizStats, getVsRaiseQuizStats, initVsRaiseQuizStats, getAllModesQuizStats, initAllModesQuizStats } from '../../utils/storage.js';
+import { getStudyProgress, initStudyProgress, getTermQuizStats, initTermQuizStats, getRfiQuizStats, initRfiQuizStats, getLimpQuizStats, initLimpQuizStats, getVsRaiseQuizStats, initVsRaiseQuizStats, getAllModesQuizStats, initAllModesQuizStats, getFlopQuizStats, initFlopQuizStats } from '../../utils/storage.js';
+import { BOARD_TEXTURES } from '../../utils/flop.js';
 import { LIMP_HERO_POSITIONS, RAISE_HERO_POSITIONS } from '../../data/preflop-ranges.js';
 import { Recommendation } from '../../components/Recommendation.jsx';
 import '../../styles/stats.css';
@@ -16,6 +17,7 @@ export function Dashboard({ path }) {
   const limpQuiz   = getLimpQuizStats()    || initLimpQuizStats();
   const vsRaiseQuiz = getVsRaiseQuizStats() || initVsRaiseQuizStats();
   const allModes   = getAllModesQuizStats() || initAllModesQuizStats();
+  const flopQuiz   = getFlopQuizStats()    || initFlopQuizStats();
 
   const totalTerms = TERMS.length;
   const cardsSeen = study.cardsSeen.length;
@@ -57,6 +59,14 @@ export function Dashboard({ path }) {
     localStorage.removeItem('all-modes-quiz-stats');
     refresh();
   }
+  function resetFlopQuiz() {
+    if (!confirm('Reset all Flop quiz stats? This cannot be undone.')) return;
+    localStorage.removeItem('flop-quiz-stats');
+    refresh();
+  }
+
+  const flopAccuracy = flopQuiz.totalQuestions > 0
+    ? Math.round(flopQuiz.totalCorrect / flopQuiz.totalQuestions * 100) : 0;
 
   return (
     <div class="stats-dashboard">
@@ -316,6 +326,74 @@ export function Dashboard({ path }) {
               <div class="stats-history">
                 <div class="stats-history-title">Recent Scores</div>
                 {termQuiz.recentScores.slice(-5).reverse().map((r, i) => {
+                  const p = Math.round(r.score / r.total * 100);
+                  return (
+                    <div class="stats-history-row" key={i}>
+                      <span>{r.date}</span>
+                      <span style={{ color: p >= 70 ? '#27ae60' : p >= 50 ? '#c9a84c' : '#c0392b' }}>
+                        {r.score}/{r.total} ({p}%)
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Flop Texture Quiz */}
+      <div class="stats-section">
+        <div class="stats-section-header">
+          <h3>Flop Texture Quiz</h3>
+          <button class="stats-reset" onClick={resetFlopQuiz}>Reset</button>
+        </div>
+        {flopQuiz.totalQuizzes === 0 ? (
+          <p class="stats-empty">No quizzes taken yet. <a href="#/quizzes/flop">Take a quiz</a></p>
+        ) : (
+          <>
+            <div class="stats-grid">
+              <div class="stats-card">
+                <div class="stats-val">{flopQuiz.totalQuizzes}</div>
+                <div class="stats-lbl">Quizzes</div>
+              </div>
+              <div class="stats-card">
+                <div class="stats-val">{flopAccuracy}%</div>
+                <div class="stats-lbl">Accuracy</div>
+              </div>
+              <div class="stats-card">
+                <div class="stats-val">{flopQuiz.totalCorrect}/{flopQuiz.totalQuestions}</div>
+                <div class="stats-lbl">Correct</div>
+              </div>
+              <div class="stats-card">
+                <div class="stats-val">{flopQuiz.bestStreak}</div>
+                <div class="stats-lbl">Best Streak</div>
+              </div>
+            </div>
+            {flopQuiz.byTexture && Object.keys(flopQuiz.byTexture).length > 0 && (
+              <div class="stats-bars">
+                <div class="stats-bars-title">Accuracy by Texture</div>
+                {BOARD_TEXTURES.map(texture => {
+                  const ps = flopQuiz.byTexture[texture];
+                  if (!ps || ps.total === 0) return null;
+                  const pct = Math.round(ps.correct / ps.total * 100);
+                  const clr = pct >= 80 ? '#27ae60' : pct >= 60 ? '#c9a84c' : '#c0392b';
+                  return (
+                    <div class="stats-cat-row" key={texture}>
+                      <div class="stats-cat-label">{texture}</div>
+                      <div class="stats-cat-bar">
+                        <div class="stats-cat-bar-fill" style={{ width: pct + '%', background: clr }}></div>
+                        <div class="stats-cat-bar-text">{pct}% ({ps.correct}/{ps.total})</div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+            {flopQuiz.recentScores.length > 0 && (
+              <div class="stats-history">
+                <div class="stats-history-title">Recent Scores</div>
+                {flopQuiz.recentScores.slice(-5).reverse().map((r, i) => {
                   const p = Math.round(r.score / r.total * 100);
                   return (
                     <div class="stats-history-row" key={i}>

--- a/src/sections/stats/Dashboard.jsx
+++ b/src/sections/stats/Dashboard.jsx
@@ -228,6 +228,74 @@ export function Dashboard({ path }) {
         )}
       </div>
 
+      {/* Flop Texture Quiz */}
+      <div class="stats-section">
+        <div class="stats-section-header">
+          <h3>Flop Texture Quiz</h3>
+          <button class="stats-reset" onClick={resetFlopQuiz}>Reset</button>
+        </div>
+        {flopQuiz.totalQuizzes === 0 ? (
+          <p class="stats-empty">No quizzes taken yet. <a href="#/quizzes/flop">Take a quiz</a></p>
+        ) : (
+          <>
+            <div class="stats-grid">
+              <div class="stats-card">
+                <div class="stats-val">{flopQuiz.totalQuizzes}</div>
+                <div class="stats-lbl">Quizzes</div>
+              </div>
+              <div class="stats-card">
+                <div class="stats-val">{flopAccuracy}%</div>
+                <div class="stats-lbl">Accuracy</div>
+              </div>
+              <div class="stats-card">
+                <div class="stats-val">{flopQuiz.totalCorrect}/{flopQuiz.totalQuestions}</div>
+                <div class="stats-lbl">Correct</div>
+              </div>
+              <div class="stats-card">
+                <div class="stats-val">{flopQuiz.bestStreak}</div>
+                <div class="stats-lbl">Best Streak</div>
+              </div>
+            </div>
+            {flopQuiz.byTexture && Object.keys(flopQuiz.byTexture).length > 0 && (
+              <div class="stats-bars">
+                <div class="stats-bars-title">Accuracy by Texture</div>
+                {BOARD_TEXTURES.map(texture => {
+                  const ps = flopQuiz.byTexture[texture];
+                  if (!ps || ps.total === 0) return null;
+                  const pct = Math.round(ps.correct / ps.total * 100);
+                  const clr = pct >= 80 ? '#27ae60' : pct >= 60 ? '#c9a84c' : '#c0392b';
+                  return (
+                    <div class="stats-cat-row" key={texture}>
+                      <div class="stats-cat-label">{texture}</div>
+                      <div class="stats-cat-bar">
+                        <div class="stats-cat-bar-fill" style={{ width: pct + '%', background: clr }}></div>
+                        <div class="stats-cat-bar-text">{pct}% ({ps.correct}/{ps.total})</div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+            {flopQuiz.recentScores.length > 0 && (
+              <div class="stats-history">
+                <div class="stats-history-title">Recent Scores</div>
+                {flopQuiz.recentScores.slice(-5).reverse().map((r, i) => {
+                  const p = Math.round(r.score / r.total * 100);
+                  return (
+                    <div class="stats-history-row" key={i}>
+                      <span>{r.date}</span>
+                      <span style={{ color: p >= 70 ? '#27ae60' : p >= 50 ? '#c9a84c' : '#c0392b' }}>
+                        {r.score}/{r.total} ({p}%)
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
       {/* Study Progress */}
       <div class="stats-section">
         <div class="stats-section-header">
@@ -342,73 +410,6 @@ export function Dashboard({ path }) {
         )}
       </div>
 
-      {/* Flop Texture Quiz */}
-      <div class="stats-section">
-        <div class="stats-section-header">
-          <h3>Flop Texture Quiz</h3>
-          <button class="stats-reset" onClick={resetFlopQuiz}>Reset</button>
-        </div>
-        {flopQuiz.totalQuizzes === 0 ? (
-          <p class="stats-empty">No quizzes taken yet. <a href="#/quizzes/flop">Take a quiz</a></p>
-        ) : (
-          <>
-            <div class="stats-grid">
-              <div class="stats-card">
-                <div class="stats-val">{flopQuiz.totalQuizzes}</div>
-                <div class="stats-lbl">Quizzes</div>
-              </div>
-              <div class="stats-card">
-                <div class="stats-val">{flopAccuracy}%</div>
-                <div class="stats-lbl">Accuracy</div>
-              </div>
-              <div class="stats-card">
-                <div class="stats-val">{flopQuiz.totalCorrect}/{flopQuiz.totalQuestions}</div>
-                <div class="stats-lbl">Correct</div>
-              </div>
-              <div class="stats-card">
-                <div class="stats-val">{flopQuiz.bestStreak}</div>
-                <div class="stats-lbl">Best Streak</div>
-              </div>
-            </div>
-            {flopQuiz.byTexture && Object.keys(flopQuiz.byTexture).length > 0 && (
-              <div class="stats-bars">
-                <div class="stats-bars-title">Accuracy by Texture</div>
-                {BOARD_TEXTURES.map(texture => {
-                  const ps = flopQuiz.byTexture[texture];
-                  if (!ps || ps.total === 0) return null;
-                  const pct = Math.round(ps.correct / ps.total * 100);
-                  const clr = pct >= 80 ? '#27ae60' : pct >= 60 ? '#c9a84c' : '#c0392b';
-                  return (
-                    <div class="stats-cat-row" key={texture}>
-                      <div class="stats-cat-label">{texture}</div>
-                      <div class="stats-cat-bar">
-                        <div class="stats-cat-bar-fill" style={{ width: pct + '%', background: clr }}></div>
-                        <div class="stats-cat-bar-text">{pct}% ({ps.correct}/{ps.total})</div>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-            {flopQuiz.recentScores.length > 0 && (
-              <div class="stats-history">
-                <div class="stats-history-title">Recent Scores</div>
-                {flopQuiz.recentScores.slice(-5).reverse().map((r, i) => {
-                  const p = Math.round(r.score / r.total * 100);
-                  return (
-                    <div class="stats-history-row" key={i}>
-                      <span>{r.date}</span>
-                      <span style={{ color: p >= 70 ? '#27ae60' : p >= 50 ? '#c9a84c' : '#c0392b' }}>
-                        {r.score}/{r.total} ({p}%)
-                      </span>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </>
-        )}
-      </div>
     </div>
   );
 }

--- a/src/sections/terminology/Quiz.jsx
+++ b/src/sections/terminology/Quiz.jsx
@@ -13,8 +13,8 @@ import '../../styles/quiz.css';
 
 const TABS = [
   { path: '/quizzes/preflop', label: 'Preflop' },
-  { path: '/quizzes/terminology', label: 'Terminology' },
   { path: '/quizzes/flop', label: 'Flop' },
+  { path: '/quizzes/terminology', label: 'Terminology' },
 ];
 
 export function buildDeck(cats, length = Infinity) {

--- a/src/styles/quiz.css
+++ b/src/styles/quiz.css
@@ -32,6 +32,16 @@
 .ans-btn:disabled{cursor:default}
 .ans-def{font-size:.82rem;color:#a09070}
 .ans-btn.correct .ans-def,.ans-btn.wrong .ans-def{color:inherit}
+.ans-term{display:block;font-weight:600;color:var(--gold-bright);margin-bottom:.2rem}
+.ans-btn.correct .ans-term,.ans-btn.wrong .ans-term{color:inherit}
+
+/* Flop Quiz — setup texture list */
+.rq-texture-list{list-style:none;padding:0;margin:0 0 1rem;display:grid;gap:.55rem;
+  text-align:left;max-width:600px;margin-left:auto;margin-right:auto}
+.rq-texture-list li{font-size:.88rem;color:var(--text);padding:.55rem .75rem;
+  background:rgba(255,255,255,.03);border:1px solid rgba(201,168,76,.2);border-radius:8px;
+  line-height:1.35}
+.rq-texture-list strong{color:var(--gold-bright);font-weight:600}
 .quiz-next{display:none;margin:0 auto;padding:.65rem 2rem;
   background:var(--gold-dark);color:var(--gold-bright);border:none;border-radius:30px;
   font-family:'Crimson Pro',serif;font-size:1rem;cursor:pointer;

--- a/src/utils/flop.js
+++ b/src/utils/flop.js
@@ -1,0 +1,189 @@
+// Flop generation and classification for the Board Texture quiz.
+//
+// Each flop falls into exactly one of six canonical textures, matching the
+// Board Texture terms in src/data/terms.js:
+//
+//   Paired Flop          — two of the three cards share a rank.
+//   Monotone Flop        — all three cards share a suit.
+//   Wet / Dynamic Flop   — unpaired, two cards of one suit, close ranks.
+//   Two-tone Flop        — unpaired, two cards of one suit, disconnected ranks.
+//   Connected Flop       — unpaired, three different suits, close ranks.
+//   Dry / Static Flop    — unpaired, three different suits, disconnected ranks.
+//
+// "Close ranks" means the three ranks span at most 4 (covers consecutive and
+// one/two-gap flops that still have straight potential), with Ace-low wheel
+// handling so A-2-3 counts as connected.
+
+export const FLOP_RANKS = ['2','3','4','5','6','7','8','9','10','J','Q','K','A'];
+export const FLOP_SUITS = ['♠','♥','♦','♣']; // ♠ ♥ ♦ ♣
+
+export const BOARD_TEXTURES = [
+  'Paired Flop',
+  'Monotone Flop',
+  'Wet / Dynamic Flop',
+  'Two-tone Flop',
+  'Connected Flop',
+  'Dry / Static Flop',
+];
+
+function rankIdx(r) { return FLOP_RANKS.indexOf(r); }
+
+function isConnected(cards) {
+  const idxs = cards.map(c => rankIdx(c.rank)).sort((a, b) => a - b);
+  if (idxs[2] - idxs[0] <= 4) return true;
+  // Ace-low wheel: treat A as rank -1 when combined with small cards.
+  if (idxs[2] === 12) {
+    const low = [-1, idxs[0], idxs[1]].sort((a, b) => a - b);
+    if (low[2] - low[0] <= 4) return true;
+  }
+  return false;
+}
+
+export function classifyFlop(cards) {
+  if (!Array.isArray(cards) || cards.length !== 3) return null;
+  for (const c of cards) {
+    if (!c || !FLOP_RANKS.includes(c.rank) || !FLOP_SUITS.includes(c.suit)) return null;
+  }
+  const ranks = cards.map(c => c.rank);
+  if (new Set(ranks).size < 3) return 'Paired Flop';
+  const suits = new Set(cards.map(c => c.suit));
+  if (suits.size === 1) return 'Monotone Flop';
+  const connected = isConnected(cards);
+  if (suits.size === 2) return connected ? 'Wet / Dynamic Flop' : 'Two-tone Flop';
+  return connected ? 'Connected Flop' : 'Dry / Static Flop';
+}
+
+function randInt(n) { return Math.floor(Math.random() * n); }
+function pick(arr) { return arr[randInt(arr.length)]; }
+
+function sortByRank(cards) {
+  return [...cards].sort((a, b) => rankIdx(a.rank) - rankIdx(b.rank));
+}
+
+function dedupeCards(cards) {
+  const keys = new Set();
+  for (const c of cards) {
+    const k = c.rank + c.suit;
+    if (keys.has(k)) return false;
+    keys.add(k);
+  }
+  return true;
+}
+
+function make(rank, suit) { return { rank, suit }; }
+
+function rollPairedFlop() {
+  // Paired + rainbow + disconnected — keeps the pairing unambiguous.
+  const pairRank = pick(FLOP_RANKS);
+  const [s1, s2] = shufflePick(FLOP_SUITS, 2);
+  let kickerRank;
+  do {
+    kickerRank = pick(FLOP_RANKS);
+  } while (kickerRank === pairRank || Math.abs(rankIdx(kickerRank) - rankIdx(pairRank)) < 3);
+  const remainingSuits = FLOP_SUITS.filter(s => s !== s1 && s !== s2);
+  const kickerSuit = pick(remainingSuits);
+  return [make(pairRank, s1), make(pairRank, s2), make(kickerRank, kickerSuit)];
+}
+
+function rollMonotoneFlop() {
+  // All three same suit, distinct ranks, not connected (so classifier lands on monotone).
+  const suit = pick(FLOP_SUITS);
+  for (let i = 0; i < 40; i++) {
+    const [a, b, c] = shufflePick(FLOP_RANKS, 3).map(r => make(r, suit));
+    if (!isConnected([a, b, c])) return [a, b, c];
+  }
+  const [a, b, c] = shufflePick(FLOP_RANKS, 3).map(r => make(r, suit));
+  return [a, b, c];
+}
+
+function rollWetFlop() {
+  // Unpaired, two of one suit, connected ranks.
+  for (let i = 0; i < 60; i++) {
+    const [r1, r2, r3] = shufflePick(FLOP_RANKS, 3);
+    const cards = [make(r1, '♠'), make(r2, '♠'), make(r3, '♥')];
+    if (!isConnected(cards)) continue;
+    if (classifyFlop(cards) === 'Wet / Dynamic Flop') return cards;
+  }
+  return [make('9', '♠'), make('8', '♠'), make('J', '♣')];
+}
+
+function rollTwoToneFlop() {
+  // Unpaired, two of one suit, disconnected ranks.
+  for (let i = 0; i < 60; i++) {
+    const [r1, r2, r3] = shufflePick(FLOP_RANKS, 3);
+    const cards = [make(r1, '♠'), make(r2, '♠'), make(r3, '♦')];
+    if (classifyFlop(cards) === 'Two-tone Flop') return cards;
+  }
+  return [make('A', '♠'), make('9', '♠'), make('5', '♦')];
+}
+
+function rollConnectedFlop() {
+  // Unpaired, three different suits, connected ranks.
+  for (let i = 0; i < 80; i++) {
+    const [r1, r2, r3] = shufflePick(FLOP_RANKS, 3);
+    const suits = shufflePick(FLOP_SUITS, 3);
+    const cards = [make(r1, suits[0]), make(r2, suits[1]), make(r3, suits[2])];
+    if (classifyFlop(cards) === 'Connected Flop') return cards;
+  }
+  return [make('4', '♣'), make('6', '♦'), make('7', '♠')];
+}
+
+function rollDryFlop() {
+  for (let i = 0; i < 80; i++) {
+    const [r1, r2, r3] = shufflePick(FLOP_RANKS, 3);
+    const suits = shufflePick(FLOP_SUITS, 3);
+    const cards = [make(r1, suits[0]), make(r2, suits[1]), make(r3, suits[2])];
+    if (classifyFlop(cards) === 'Dry / Static Flop') return cards;
+  }
+  return [make('K', '♣'), make('8', '♠'), make('3', '♦')];
+}
+
+function shufflePick(arr, n) {
+  const copy = [...arr];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = randInt(i + 1);
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy.slice(0, n);
+}
+
+const ROLLERS = {
+  'Paired Flop': rollPairedFlop,
+  'Monotone Flop': rollMonotoneFlop,
+  'Wet / Dynamic Flop': rollWetFlop,
+  'Two-tone Flop': rollTwoToneFlop,
+  'Connected Flop': rollConnectedFlop,
+  'Dry / Static Flop': rollDryFlop,
+};
+
+export function generateFlopForTexture(texture) {
+  const roll = ROLLERS[texture];
+  if (!roll) return null;
+  for (let i = 0; i < 5; i++) {
+    const cards = sortByRank(roll());
+    if (!dedupeCards(cards)) continue;
+    if (classifyFlop(cards) === texture) return cards;
+  }
+  // Fallback: the canonical example in the terms.js definitions.
+  return sortByRank(roll());
+}
+
+// Build a full quiz deck: one question per texture (randomized order),
+// repeating cyclically if length exceeds BOARD_TEXTURES.length.
+export function buildFlopDeck(length) {
+  const order = shufflePick(BOARD_TEXTURES, BOARD_TEXTURES.length);
+  const deck = [];
+  let i = 0;
+  while (deck.length < length) {
+    const texture = order[i % order.length];
+    const cards = generateFlopForTexture(texture);
+    deck.push({ cards, texture });
+    i++;
+    if (i % order.length === 0) {
+      // Reshuffle each cycle so repeats don't line up in the same order.
+      const next = shufflePick(BOARD_TEXTURES, BOARD_TEXTURES.length);
+      for (let j = 0; j < order.length; j++) order[j] = next[j];
+    }
+  }
+  return deck;
+}

--- a/src/utils/flop.test.js
+++ b/src/utils/flop.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BOARD_TEXTURES,
+  FLOP_RANKS,
+  FLOP_SUITS,
+  classifyFlop,
+  generateFlopForTexture,
+  buildFlopDeck,
+} from './flop.js';
+
+const c = (rank, suit) => ({ rank, suit });
+
+describe('classifyFlop', () => {
+  it('identifies a paired flop regardless of suits', () => {
+    expect(classifyFlop([c('A','♣'), c('A','♦'), c('9','♠')])).toBe('Paired Flop');
+    expect(classifyFlop([c('7','♠'), c('7','♥'), c('7','♦')])).toBe('Paired Flop');
+  });
+
+  it('identifies a monotone flop when all three cards share a suit', () => {
+    expect(classifyFlop([c('Q','♥'), c('8','♥'), c('5','♥')])).toBe('Monotone Flop');
+  });
+
+  it('identifies a wet flop (two-tone + close ranks)', () => {
+    expect(classifyFlop([c('9','♠'), c('8','♠'), c('J','♣')])).toBe('Wet / Dynamic Flop');
+  });
+
+  it('identifies a two-tone flop (two of a suit, disconnected ranks)', () => {
+    expect(classifyFlop([c('A','♠'), c('9','♠'), c('5','♦')])).toBe('Two-tone Flop');
+  });
+
+  it('identifies a connected flop (rainbow + close ranks)', () => {
+    expect(classifyFlop([c('4','♣'), c('6','♦'), c('7','♠')])).toBe('Connected Flop');
+  });
+
+  it('identifies a dry flop (rainbow + disconnected ranks)', () => {
+    expect(classifyFlop([c('K','♣'), c('8','♠'), c('3','♦')])).toBe('Dry / Static Flop');
+  });
+
+  it('treats A-2-3 as connected via the Ace-low wheel', () => {
+    // Rainbow + Ace-low connected should still classify as Connected, not Dry.
+    expect(classifyFlop([c('A','♠'), c('2','♥'), c('3','♦')])).toBe('Connected Flop');
+  });
+
+  it('returns null for malformed input', () => {
+    expect(classifyFlop(null)).toBeNull();
+    expect(classifyFlop([c('A','♠'), c('K','♥')])).toBeNull();
+    expect(classifyFlop([c('A','♠'), c('K','♥'), { rank: 'X', suit: '♦' }])).toBeNull();
+  });
+});
+
+describe('generateFlopForTexture', () => {
+  it('produces a flop whose classification matches the requested texture', () => {
+    for (const texture of BOARD_TEXTURES) {
+      for (let i = 0; i < 10; i++) {
+        const cards = generateFlopForTexture(texture);
+        expect(cards).toHaveLength(3);
+        // Every card must use canonical ranks/suits so share-link encoding works.
+        for (const card of cards) {
+          expect(FLOP_RANKS).toContain(card.rank);
+          expect(FLOP_SUITS).toContain(card.suit);
+        }
+        // The canonical-example fallback for wet/connected may not survive the
+        // classifyFlop re-check in edge cases, but randomized generation does.
+        expect(classifyFlop(cards)).toBe(texture);
+      }
+    }
+  });
+
+  it('returns null for an unknown texture', () => {
+    expect(generateFlopForTexture('Nonsense Flop')).toBeNull();
+  });
+});
+
+describe('buildFlopDeck', () => {
+  it('produces the requested number of questions', () => {
+    const deck = buildFlopDeck(10);
+    expect(deck).toHaveLength(10);
+  });
+
+  it('covers all six textures when the deck is long enough', () => {
+    const deck = buildFlopDeck(12);
+    const seen = new Set(deck.map(q => q.texture));
+    for (const texture of BOARD_TEXTURES) {
+      expect(seen).toContain(texture);
+    }
+  });
+
+  it('every question matches its classification — so correct answers stay valid', () => {
+    const deck = buildFlopDeck(18);
+    for (const q of deck) {
+      expect(classifyFlop(q.cards)).toBe(q.texture);
+    }
+  });
+});

--- a/src/utils/share.js
+++ b/src/utils/share.js
@@ -22,6 +22,7 @@
 import { TERMS } from '../data/terms.js';
 import { RFI_RANGES, STACK_DEPTHS } from '../data/rfi-ranges.js';
 import { LIMP_RANGES, VS_RAISE_RANGES } from '../data/preflop-ranges.js';
+import { classifyFlop, FLOP_RANKS, FLOP_SUITS } from './flop.js';
 
 const TYPE_ENCODE = { rfi: 'r', limp: 'l', vsRaise: 'v' };
 const TYPE_DECODE = { r: 'rfi', l: 'limp', v: 'vsRaise' };
@@ -117,6 +118,57 @@ export function decodePreflopQuiz(query) {
   }
   if (deck.length === 0) return null;
   return { stackDepth, deck };
+}
+
+// Flop quiz: encodes three cards per question. The correct texture is
+// re-derived via classifyFlop, so only the cards need to travel in the URL.
+//
+//   #/quizzes/flop?fq=<q1>,<q2>,...
+//     qN = <r1><s1><r2><s2><r3><s3>
+//     rN ∈ {2..9,T,J,Q,K,A}  (T for 10 keeps every card two chars)
+//     sN ∈ {s,h,d,c}
+const RANK_ENCODE = { '10': 'T' };
+const RANK_DECODE = { T: '10' };
+
+function encodeRank(r) { return RANK_ENCODE[r] || r; }
+function decodeRank(r) { return RANK_DECODE[r] || r; }
+
+export function encodeFlopQuiz(deck) {
+  if (!Array.isArray(deck) || deck.length === 0) return null;
+  const parts = [];
+  for (const q of deck) {
+    if (!q?.cards || q.cards.length !== 3) return null;
+    let s = '';
+    for (const c of q.cards) {
+      if (!FLOP_RANKS.includes(c.rank) || !FLOP_SUITS.includes(c.suit)) return null;
+      s += encodeRank(c.rank) + SUIT_ENCODE[c.suit];
+    }
+    parts.push(s);
+  }
+  return `fq=${parts.join(',')}`;
+}
+
+export function decodeFlopQuiz(query) {
+  const raw = query?.fq;
+  if (!raw) return null;
+  const deck = [];
+  for (const s of raw.split(',')) {
+    if (s.length !== 6) return null;
+    const cards = [];
+    for (let i = 0; i < 3; i++) {
+      const rawRank = s[i * 2];
+      const rawSuit = s[i * 2 + 1];
+      const rank = decodeRank(rawRank);
+      const suit = SUIT_DECODE[rawSuit];
+      if (!FLOP_RANKS.includes(rank) || !suit) return null;
+      cards.push({ rank, suit });
+    }
+    const texture = classifyFlop(cards);
+    if (!texture) return null;
+    deck.push({ cards, texture });
+  }
+  if (deck.length === 0) return null;
+  return { deck };
 }
 
 // Build an absolute share URL for the given hash path + encoded query.

--- a/src/utils/share.test.js
+++ b/src/utils/share.test.js
@@ -5,6 +5,7 @@ import { LIMP_RANGES, VS_RAISE_RANGES } from '../data/preflop-ranges.js';
 import {
   encodeTermQuiz, decodeTermQuiz,
   encodePreflopQuiz, decodePreflopQuiz,
+  encodeFlopQuiz, decodeFlopQuiz,
   buildShareUrl, buildScoreMessage,
 } from './share.js';
 
@@ -135,6 +136,39 @@ describe('encodePreflopQuiz / decodePreflopQuiz', () => {
     expect(decoded.map(q => `${q.type}.${q.hand}.${q.heroPos}`)).toEqual([
       'rfi.AA.UTG', 'rfi.72o.HJ', 'rfi.KK.CO',
     ]);
+  });
+});
+
+describe('encodeFlopQuiz / decodeFlopQuiz', () => {
+  const deck = [
+    { cards: [{rank:'A',suit:'♠'},{rank:'9',suit:'♠'},{rank:'5',suit:'♦'}], texture: 'Two-tone Flop' },
+    { cards: [{rank:'K',suit:'♣'},{rank:'8',suit:'♠'},{rank:'3',suit:'♦'}], texture: 'Dry / Static Flop' },
+    { cards: [{rank:'10',suit:'♥'},{rank:'9',suit:'♥'},{rank:'8',suit:'♥'}], texture: 'Monotone Flop' },
+  ];
+
+  it('round-trips a deck and re-derives the correct texture', () => {
+    const encoded = encodeFlopQuiz(deck);
+    expect(encoded).toMatch(/^fq=/);
+    const { deck: decoded } = decodeFlopQuiz({ fq: encoded.slice(3) });
+    expect(decoded).toHaveLength(3);
+    expect(decoded[0].cards).toEqual(deck[0].cards);
+    expect(decoded[0].texture).toBe('Two-tone Flop');
+    expect(decoded[1].texture).toBe('Dry / Static Flop');
+    expect(decoded[2].texture).toBe('Monotone Flop');
+  });
+
+  it('encodes 10 as T so every card stays two characters', () => {
+    const encoded = encodeFlopQuiz([deck[2]]);
+    expect(encoded).toBe('fq=Th9h8h');
+  });
+
+  it('returns null for malformed / missing input', () => {
+    expect(encodeFlopQuiz([])).toBeNull();
+    expect(encodeFlopQuiz(null)).toBeNull();
+    expect(decodeFlopQuiz({})).toBeNull();
+    expect(decodeFlopQuiz({ fq: '' })).toBeNull();
+    expect(decodeFlopQuiz({ fq: 'invalid' })).toBeNull();
+    expect(decodeFlopQuiz({ fq: 'Xs8s3d' })).toBeNull();
   });
 });
 

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -46,6 +46,18 @@ export function initVsRaiseQuizStats() {
   return { totalQuizzes:0, totalQuestions:0, totalCorrect:0, byHeroPosition:{}, byVillainPosition:{}, recentScores:[] };
 }
 
+// Flop (Board Texture) Quiz Stats
+export function getFlopQuizStats() {
+  try { const d = localStorage.getItem('flop-quiz-stats'); return d ? JSON.parse(d) : null; }
+  catch(e) { return null; }
+}
+export function saveFlopQuizStats(s) {
+  try { localStorage.setItem('flop-quiz-stats', JSON.stringify(s)); } catch(e) {}
+}
+export function initFlopQuizStats() {
+  return { totalQuizzes:0, totalQuestions:0, totalCorrect:0, bestStreak:0, byTexture:{}, recentScores:[] };
+}
+
 // All-Modes Quiz Stats
 export function getAllModesQuizStats() {
   try { const d = localStorage.getItem('all-modes-quiz-stats'); return d ? JSON.parse(d) : null; }

--- a/src/utils/storage.test.js
+++ b/src/utils/storage.test.js
@@ -4,6 +4,7 @@ import {
   getVsRaiseQuizStats, saveVsRaiseQuizStats, initVsRaiseQuizStats,
   getAllModesQuizStats, saveAllModesQuizStats, initAllModesQuizStats,
   getTermQuizStats, saveTermQuizStats, initTermQuizStats,
+  getFlopQuizStats, saveFlopQuizStats, initFlopQuizStats,
   getSettings, saveSettings, resetSettings, DEFAULT_SETTINGS, CARD_SIZES,
   QUIZ_LENGTH_MIN, QUIZ_LENGTH_MAX,
 } from './storage.js';
@@ -43,6 +44,36 @@ describe('initLimpQuizStats', () => {
     const loaded = getLimpQuizStats();
     expect(loaded.totalQuizzes).toBe(3);
     expect(loaded.totalCorrect).toBe(25);
+  });
+});
+
+describe('initFlopQuizStats', () => {
+  it('returns the expected shape for the Board Texture quiz', () => {
+    const s = initFlopQuizStats();
+    expect(s.totalQuizzes).toBe(0);
+    expect(s.totalQuestions).toBe(0);
+    expect(s.totalCorrect).toBe(0);
+    expect(s.bestStreak).toBe(0);
+    expect(s.byTexture).toEqual({});
+    expect(Array.isArray(s.recentScores)).toBe(true);
+  });
+
+  it('getFlopQuizStats returns null when nothing stored', () => {
+    expect(getFlopQuizStats()).toBeNull();
+  });
+
+  it('save/get round-trips — per-texture buckets survive serialization', () => {
+    const s = initFlopQuizStats();
+    s.totalQuizzes = 2;
+    s.totalQuestions = 12;
+    s.totalCorrect = 9;
+    s.bestStreak = 5;
+    s.byTexture['Paired Flop'] = { total: 3, correct: 2 };
+    saveFlopQuizStats(s);
+    const loaded = getFlopQuizStats();
+    expect(loaded.totalQuizzes).toBe(2);
+    expect(loaded.bestStreak).toBe(5);
+    expect(loaded.byTexture['Paired Flop']).toEqual({ total: 3, correct: 2 });
   });
 });
 


### PR DESCRIPTION
New /quizzes/flop route asks the user to classify a randomly dealt flop
as one of the six Board Texture categories (Paired, Monotone, Wet,
Two-tone, Connected, Dry). Uses the existing term definitions and
illustration engine — answers are drawn from the same texture pool so
the user has to read ranks, suits, and connectedness to pick correctly.

- utils/flop.js: classifyFlop + per-texture generators + buildFlopDeck
- sections/flop/Quiz.jsx: setup → playing → complete flow with
  auto-advance, shareable links, and per-texture stats tracking
- share.js: fq=... encoding (three cards per question, T for 10)
- storage.js: flop-quiz-stats localStorage schema
- Dashboard: new section with accuracy-by-texture bars
- SubNav: Flop tab added across the three quiz modes