### PR TITLE
Add Flop Combos & Outs quiz

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ poker-trainer/
 │   │   ├── welcome.css                 # Welcome page hand rankings, section cards
 │   │   ├── study.css                   # Flashcard scene, 3D flip, card nav
 │   │   ├── quiz.css                    # Term quiz + RFI quiz styles
+│   │   ├── combos-quiz.css             # Flop Combos & Outs quiz styles
 │   │   ├── reference.css              # Search input, ref grid, modal
 │   │   ├── charts.css                  # Position tabs, RFI grid, legend
 │   │   └── stats.css                   # Stats dashboard styles
@@ -49,7 +50,9 @@ poker-trainer/
 │   │   ├── shuffle.js                  # Immutable Fisher-Yates shuffle
 │   │   ├── storage.js                  # localStorage helpers for all 3 stat stores
 │   │   ├── explain.js                  # Quiz feedback rationale (hand features + action logic)
-│   │   └── share.js                    # Encode/decode quiz config into share-link query strings
+│   │   ├── share.js                    # Encode/decode quiz config into share-link query strings
+│   │   ├── flop.js                     # Flop generation + classifyFlop() for Board Texture quiz
+│   │   └── combos.js                   # evalFive, bestOf, analyzeQuestion — Flop Combos evaluator
 │   ├── hooks/
 │   │   ├── useFilters.js               # activeCats state + toggle logic
 │   │   └── useDeck.js                  # deck, idx, flipped, nav, shuffle
@@ -71,7 +74,8 @@ poker-trainer/
 │       │   ├── Charts.jsx              # RFI hand range grid with position tabs
 │       │   └── Quiz.jsx                # Raise/fold RFI quiz
 │       ├── flop/
-│       │   └── Quiz.jsx                # Board-texture classification quiz (3 cards → texture)
+│       │   ├── Quiz.jsx                # Board-texture classification quiz (3 cards → texture)
+│       │   └── CombosQuiz.jsx          # Flop Combos & Outs quiz (hole + flop → reachable categories + outs)
 │       ├── stats/
 │       │   └── Dashboard.jsx           # Full stats dashboard
 │       └── settings/
@@ -98,6 +102,7 @@ Hash-based routing (`#/path`) for GitHub Pages compatibility.
 | `#/quizzes/terminology` | Terminology Quiz.jsx | Multiple-choice terminology quiz |
 | `#/quizzes/preflop` | Preflop Quiz.jsx | Raise/fold/3-bet preflop quiz (RFI / vs-Limp / vs-Raise / All) |
 | `#/quizzes/flop` | Flop Quiz.jsx | Board-texture classification quiz (3 flop cards → one of 6 textures) |
+| `#/quizzes/flop-combos` | CombosQuiz.jsx | Flop Combos & Outs quiz (hole cards + flop → reachable categories + single-card outs) |
 | `#/stats` | Dashboard.jsx | Full stats dashboard |
 | `#/settings` | Settings.jsx | User preferences (auto-advance, card image size) |
 
@@ -112,6 +117,7 @@ Quiz routes accept query strings that encode a reproducible quiz:
 | `#/quizzes/terminology` | `?tq=<i,i,i,...>` | Comma-separated indexes into `TERMS`; defines the ordered question deck. |
 | `#/quizzes/preflop` | `?pq=<stackDepth>~<q1>~<q2>...` | Each `qN = <typeCode>.<hand>.<heroPos>.<villainOrDash>.<suitCode>` where typeCode ∈ `{r,l,v}` (rfi, limp, vsRaise) and suitCode ∈ `{s,h,d,c}`. Correct actions are re-derived from the GTO ranges; suits preserve the exact card rendering. The trailing suit field is optional — legacy 4-field links still decode. |
 | `#/quizzes/flop` | `?fq=<q1>,<q2>,...` | Each `qN = <r1><s1><r2><s2><r3><s3>` — three cards with `rN ∈ {2..9,T,J,Q,K,A}` (T for 10) and `sN ∈ {s,h,d,c}`. The correct texture is re-derived by `classifyFlop` at load time, so only the cards need to travel in the URL. |
+| `#/quizzes/flop-combos` | `?cq=<q1>,<q2>,...` | Each `qN = <h1><h2><f1><f2><f3>` — 2 hole cards followed by 3 flop cards, 10 chars per question, same rank/suit alphabet as `fq`. The analysis (reachable categories, turn outs, river probabilities) is re-derived by `analyzeQuestion` at load time. |
 
 Both quiz types auto-start in the playing phase when loaded from a shared link, bypassing the setup screen so the recipient can't alter the shared deck. "Play Again" replays the same deck; "New Random Quiz" drops out of shared mode and returns the user to the setup screen (topic picker for terminology, mode/stack/positions for preflop). See `src/utils/share.js` and `src/components/ShareButton.jsx`.
 
@@ -173,6 +179,7 @@ Fonts: `'Playfair Display'` for headings, `'Crimson Pro'` for body text.
 | `rfi-quiz-stats` | `{ totalQuizzes, totalQuestions, totalCorrect, byPosition, recentScores }` |
 | `term-quiz-stats` | `{ totalQuizzes, totalQuestions, totalCorrect, bestStreak, byCategory, recentScores }` |
 | `flop-quiz-stats` | `{ totalQuizzes, totalQuestions, totalCorrect, bestStreak, byTexture, recentScores }` |
+| `flop-combos-quiz-stats` | `{ totalQuizzes, totalQuestions, totalCorrect, bestStreak, phase1Correct, phase1Total, phase2Correct, phase2Total, byCategory, recentScores }` |
 | `study-progress` | `{ cardsSeen: [], totalFlips, byCategory: {} }` |
 | `settings` | `{ autoAdvance, autoAdvanceSeconds, cardSize, quizLength }` |
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - **Preflop Quiz** — The RFI / vs-Limp / vs-Raise preflop quizzes (above).
 - **Terminology Quiz** — Multiple-choice questions on poker terms across all 9 categories.
 - **Flop Texture Quiz** — Classify a randomly dealt three-card flop as one of the six Board Texture categories (Paired, Monotone, Wet / Dynamic, Two-tone, Connected, Dry / Static). Four multiple-choice options are drawn from the same pool so the user has to read the flop's ranks, suits, and connectedness to pick the right one.
+- **Flop Combos & Outs Quiz** — Given 2 hole cards and a 3-card flop, (phase 1) select every hand category still reachable by the river (Pair through Royal Flush, backdoor draws included) and (phase 2) enter the number of single-card turn outs for each selected category. Feedback reveals the exact river probability, the rule-of-4 approximation, and renders the specific out cards so you can see exactly which cards complete each draw.
 
 ### Stats
 - **Dashboard** — Full statistics view showing study progress, terminology quiz accuracy, and RFI quiz performance by position. Surfaces a "Recommended Next Quiz" card that points you at your weakest area (or an untaken quiz for a baseline) with a one-click button to start it.
@@ -89,6 +90,7 @@ All routes use hash-based URLs for GitHub Pages compatibility:
 | `#/preflop/charts` | RFI hand range grids |
 | `#/preflop/quiz` | Raise/fold RFI quiz |
 | `#/quizzes/flop` | Flop Texture (Board Texture) quiz |
+| `#/quizzes/flop-combos` | Flop Combos & Outs quiz |
 | `#/stats` | Stats dashboard |
 
 ## Deployment

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -8,6 +8,7 @@ import { LimpCharts } from './sections/preflop/LimpCharts.jsx';
 import { RaiseCharts } from './sections/preflop/RaiseCharts.jsx';
 import { PreflopQuiz } from './sections/preflop/Quiz.jsx';
 import { FlopQuiz } from './sections/flop/Quiz.jsx';
+import { CombosQuiz } from './sections/flop/CombosQuiz.jsx';
 import { Dashboard } from './sections/stats/Dashboard.jsx';
 import { Welcome } from './sections/welcome/Welcome.jsx';
 import { Settings } from './sections/settings/Settings.jsx';
@@ -49,6 +50,7 @@ const ROUTES = {
   '/quizzes/terminology': TermQuiz,
   '/quizzes/preflop': PreflopQuiz,
   '/quizzes/flop': FlopQuiz,
+  '/quizzes/flop-combos': CombosQuiz,
   '/stats': Dashboard,
   '/settings': Settings,
 };

--- a/src/routing.js
+++ b/src/routing.js
@@ -9,6 +9,7 @@ export const ROUTES_LIST = [
   '/quizzes/terminology',
   '/quizzes/preflop',
   '/quizzes/flop',
+  '/quizzes/flop-combos',
   '/stats',
   '/settings',
 ];

--- a/src/routing.test.js
+++ b/src/routing.test.js
@@ -66,6 +66,11 @@ describe('routing', () => {
     expect(resolveRoute('/quizzes/flop')).toBe('/quizzes/flop');
   });
 
+  it('/quizzes/flop-combos exists in routes list — combos & outs quiz is reachable', () => {
+    expect(ROUTES_LIST).toContain('/quizzes/flop-combos');
+    expect(resolveRoute('/quizzes/flop-combos')).toBe('/quizzes/flop-combos');
+  });
+
   it('resolves /quizzes shorthand to preflop quiz — preflop is default quiz mode', () => {
     expect(resolveRoute('/quizzes')).toBe('/quizzes/preflop');
   });

--- a/src/sections/flop/CombosQuiz.jsx
+++ b/src/sections/flop/CombosQuiz.jsx
@@ -1,0 +1,562 @@
+// Flop Combos & Outs quiz.
+//
+// Auto-advance is intentionally not wired into this quiz: the feedback panel is
+// dense (per-category outs + probability + out-card lists), and auto-dismissing
+// it would defeat the teaching intent.
+
+import { useState, useMemo, useEffect } from 'preact/hooks';
+import { SubNav } from '../../components/SubNav.jsx';
+import { ShareButton } from '../../components/ShareButton.jsx';
+import { cardSvg } from '../../utils/illustrations.jsx';
+import {
+  analyzeQuestion,
+  buildCombosDeck,
+  QUIZ_CATEGORIES,
+} from '../../utils/combos.js';
+import {
+  getFlopCombosQuizStats,
+  saveFlopCombosQuizStats,
+  initFlopCombosQuizStats,
+  getSettings,
+} from '../../utils/storage.js';
+import {
+  encodeCombosQuiz,
+  decodeCombosQuiz,
+  buildShareUrl,
+  buildScoreMessage,
+} from '../../utils/share.js';
+import '../../styles/quiz.css';
+import '../../styles/combos-quiz.css';
+
+const TABS = [
+  { path: '/quizzes/preflop', label: 'Preflop' },
+  { path: '/quizzes/flop', label: 'Flop Texture' },
+  { path: '/quizzes/flop-combos', label: 'Flop Combos' },
+  { path: '/quizzes/terminology', label: 'Terminology' },
+];
+
+function renderCards(cards, w = 60, h = 84) {
+  return cards.map(c => cardSvg(c.rank, c.suit, w, h)).join('');
+}
+
+function fmtPct(p) {
+  return (p * 100).toFixed(1) + '%';
+}
+
+function ruleOfFour(outs) {
+  return outs * 4 + '%';
+}
+
+// Question grading: returns per-category status + whether the hand is perfect.
+// For each category C:
+//   phase1Right: user's "reachable" ✓/✗ matches truth
+//   phase2Right: if category was selected and not made, user's outs exactly match
+//                 actual turn-out count; otherwise null (not applicable)
+//   categoryRight: phase1Right && phase2Right !== false  (all judgements for this category)
+export function gradeHand(analysis, p1Selected, p2Outs) {
+  const perCat = {};
+  let phase1Correct = 0;
+  let phase2Correct = 0;
+  let phase2Asked = 0;
+  for (const C of QUIZ_CATEGORIES) {
+    const trueReachable = analysis.reachable.has(C);
+    const userSelected = p1Selected.has(C);
+    const phase1Right = trueReachable === userSelected;
+    if (phase1Right) phase1Correct += 1;
+
+    const made = analysis.made === C;
+    const askedInP2 = userSelected && !made;
+    let phase2Right = null;
+    if (askedInP2) {
+      phase2Asked += 1;
+      const actual = analysis.turnOuts[C].count;
+      const entered = Number(p2Outs[C]);
+      if (Number.isFinite(entered) && entered === actual) {
+        phase2Right = true;
+        phase2Correct += 1;
+      } else {
+        phase2Right = false;
+      }
+    }
+
+    const categoryRight = phase1Right && phase2Right !== false;
+    perCat[C] = { phase1Right, phase2Right, categoryRight, trueReachable, userSelected, made };
+  }
+  const allCorrect = Object.values(perCat).every(x => x.categoryRight);
+  return {
+    perCat,
+    phase1Correct,
+    phase1Total: QUIZ_CATEGORIES.length,
+    phase2Correct,
+    phase2Total: phase2Asked,
+    handCorrect: allCorrect,
+  };
+}
+
+export function CombosQuiz({ query }) {
+  const sharedInit = decodeCombosQuiz(query);
+  const [settings, setSettings] = useState(() => getSettings());
+  const [phase, setPhase] = useState(sharedInit ? 'playing' : 'setup');
+  const [subphase, setSubphase] = useState('p1');
+  const [sharedDeck, setSharedDeck] = useState(() => sharedInit?.deck || null);
+  const [deck, setDeck] = useState(() => sharedInit?.deck || []);
+  const [qIdx, setQIdx] = useState(0);
+  const [p1Selected, setP1Selected] = useState(() => new Set());
+  const [p2Outs, setP2Outs] = useState({});
+  const [score, setScore] = useState(0);
+  const [streak, setStreak] = useState(0);
+  const [total, setTotal] = useState(0);
+  const [results, setResults] = useState([]);
+  const [statsSaved, setStatsSaved] = useState(false);
+
+  const current = deck[qIdx];
+  const analysis = useMemo(() => (current ? analyzeQuestion(current.holes, current.flop) : null), [current]);
+  const isComplete = phase === 'playing' && qIdx >= deck.length && deck.length > 0;
+
+  // Persist stats exactly once per completed run.
+  useEffect(() => {
+    if (!isComplete || statsSaved) return;
+    const stats = getFlopCombosQuizStats() || initFlopCombosQuizStats();
+    stats.totalQuizzes++;
+    stats.totalQuestions += total;
+    stats.totalCorrect += score;
+    if (streak > stats.bestStreak) stats.bestStreak = streak;
+    if (!stats.byCategory) stats.byCategory = {};
+    for (const r of results) {
+      stats.phase1Correct += r.grade.phase1Correct;
+      stats.phase1Total   += r.grade.phase1Total;
+      stats.phase2Correct += r.grade.phase2Correct;
+      stats.phase2Total   += r.grade.phase2Total;
+      for (const C of QUIZ_CATEGORIES) {
+        const b = stats.byCategory[C] || { total: 0, correct: 0 };
+        b.total += 1;
+        if (r.grade.perCat[C].categoryRight) b.correct += 1;
+        stats.byCategory[C] = b;
+      }
+    }
+    stats.recentScores.push({ date: new Date().toLocaleDateString(), score, total });
+    if (stats.recentScores.length > 20) stats.recentScores = stats.recentScores.slice(-20);
+    saveFlopCombosQuizStats(stats);
+    setStatsSaved(true);
+  }, [isComplete, statsSaved, total, score, streak, results]);
+
+  // Shared-link handler: when ?cq= appears or changes, rebuild from the
+  // encoded cards and auto-start the quiz.
+  useEffect(() => {
+    const next = decodeCombosQuiz(query);
+    if (!next) return;
+    const sameDeck = sharedDeck
+      && sharedDeck.length === next.deck.length
+      && sharedDeck.every((q, i) => {
+        const a = [...q.holes, ...q.flop];
+        const b = [...next.deck[i].holes, ...next.deck[i].flop];
+        return a.every((c, j) => c.rank === b[j].rank && c.suit === b[j].suit);
+      });
+    if (sameDeck) return;
+    setSharedDeck(next.deck);
+    setDeck(next.deck);
+    setPhase('playing');
+    setSubphase('p1');
+    setQIdx(0);
+    setP1Selected(new Set());
+    setP2Outs({});
+    setScore(0);
+    setStreak(0);
+    setTotal(0);
+    setResults([]);
+    setStatsSaved(false);
+  }, [query?.cq]);
+
+  function startQuiz() {
+    const fresh = getSettings();
+    setSettings(fresh);
+    const newDeck = buildCombosDeck(fresh.quizLength);
+    setDeck(newDeck);
+    setQIdx(0);
+    setP1Selected(new Set());
+    setP2Outs({});
+    setScore(0);
+    setStreak(0);
+    setTotal(0);
+    setResults([]);
+    setStatsSaved(false);
+    setSubphase('p1');
+    setPhase('playing');
+  }
+
+  function restart() {
+    const fresh = getSettings();
+    setSettings(fresh);
+    const newDeck = sharedDeck ? sharedDeck : buildCombosDeck(fresh.quizLength);
+    setDeck(newDeck);
+    setQIdx(0);
+    setP1Selected(new Set());
+    setP2Outs({});
+    setScore(0);
+    setStreak(0);
+    setTotal(0);
+    setResults([]);
+    setStatsSaved(false);
+    setSubphase('p1');
+  }
+
+  function exitQuiz() {
+    setPhase('setup');
+    setSubphase('p1');
+    setQIdx(0);
+    setP1Selected(new Set());
+    setP2Outs({});
+    setScore(0);
+    setStreak(0);
+    setTotal(0);
+    setResults([]);
+    setStatsSaved(false);
+  }
+
+  function startFreshQuiz() {
+    setSharedDeck(null);
+    setDeck([]);
+    exitQuiz();
+    if (window.location.hash.includes('?cq=')) {
+      window.location.hash = '#/quizzes/flop-combos';
+    }
+  }
+
+  function toggleP1(cat) {
+    if (subphase !== 'p1') return;
+    setP1Selected(prev => {
+      const next = new Set(prev);
+      if (next.has(cat)) next.delete(cat); else next.add(cat);
+      return next;
+    });
+  }
+
+  function goToPhase2() {
+    setSubphase('p2');
+  }
+
+  function submitPhase2() {
+    const grade = gradeHand(analysis, p1Selected, p2Outs);
+    if (grade.handCorrect) {
+      setScore(s => s + 1);
+      setStreak(s => s + 1);
+    } else {
+      setStreak(0);
+    }
+    setTotal(t => t + 1);
+    setResults(r => [...r, { analysis, p1Selected: new Set(p1Selected), p2Outs: { ...p2Outs }, grade }]);
+    setSubphase('fb');
+  }
+
+  function nextQuestion(e) {
+    if (e?.currentTarget?.blur) e.currentTarget.blur();
+    const next = qIdx + 1;
+    setQIdx(next);
+    setP1Selected(new Set());
+    setP2Outs({});
+    setSubphase('p1');
+  }
+
+  const shareQuery = encodeCombosQuiz(deck);
+  const shareUrl = shareQuery ? buildShareUrl('/quizzes/flop-combos', shareQuery) : null;
+
+  // ── Setup screen ──────────────────────────────────────────────────────────
+  if (phase === 'setup') {
+    return (
+      <div>
+        <SubNav tabs={TABS} currentPath="/quizzes/flop-combos" />
+        <div class="rq-panel">
+          <h2 class="rq-title">Flop Combos &amp; Outs</h2>
+          <p class="rq-sub">
+            Each hand shows 2 hole cards and a 3-card flop. First, pick every hand category you could still make by the river. Then, for each category you picked, enter the number of <strong>single-card outs</strong> &mdash; cards that make the category if they arrive on the turn.
+          </p>
+          <div class="rq-setup-label">Categories you'll judge</div>
+          <ul class="rq-texture-list combos-cat-list">
+            {QUIZ_CATEGORIES.map(C => (
+              <li key={C}><strong>{C}</strong></li>
+            ))}
+          </ul>
+          <p class="rq-sub combos-setup-note">
+            Runner-runner (backdoor) draws count as achievable, but their single-card outs are 0 &mdash; only the river probability reflects them.
+          </p>
+          <div class="rq-start-row">
+            <button class="rq-start-btn" onClick={startQuiz}>Start Quiz</button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Complete screen ───────────────────────────────────────────────────────
+  if (isComplete) {
+    const pct = total > 0 ? Math.round(score / total * 100) : 0;
+    const msg = pct >= 90 ? 'Phenomenal — you read boards like a pro!' :
+                pct >= 70 ? 'Well played — solid combinatorial chops.' :
+                pct >= 40 ? 'Good start — review the categories and try again.' :
+                            'Revisit hand rankings and come back sharper!';
+
+    return (
+      <div>
+        <SubNav tabs={TABS} currentPath="/quizzes/flop-combos" />
+        <div class="rq-panel">
+          <div class="rq-complete">
+            <h2>{pct >= 70 ? '🏆' : '🃏'} Quiz Complete</h2>
+            <div class="score-big">{score} / {total} &mdash; {pct}%</div>
+            <p>{msg}</p>
+            <p class="combos-summary-sub">
+              A hand counts as correct only when every category judgement (phase 1 and phase 2) is exact.
+            </p>
+            <button class="rq-restart" onClick={restart}>Play Again</button>
+            {sharedDeck ? (
+              <button class="rq-restart" style="background:transparent;border:1px solid var(--gold-dark)" onClick={startFreshQuiz}>New Random Quiz</button>
+            ) : (
+              <button class="rq-restart" style="background:transparent;border:1px solid var(--gold-dark)" onClick={exitQuiz}>Back to Setup</button>
+            )}
+            <a class="rq-restart" href="#/stats" style="background:transparent;border:1px solid var(--gold-dark);text-decoration:none;display:inline-block;text-align:center">Stats</a>
+            <div class="share-row">
+              <ShareButton url={shareUrl} label="Share Link" copiedLabel="Link Copied!" />
+              <ShareButton
+                content={shareUrl ? buildScoreMessage(score, total, shareUrl) : null}
+                label="Share Score"
+                copiedLabel="Message Copied!"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Playing screen ────────────────────────────────────────────────────────
+  const pctDisplay = total > 0 ? Math.round(score / total * 100) + '%' : '—';
+  const progress = Math.max(0, Math.min(1, qIdx / Math.max(1, deck.length)));
+  const currentResult = results[qIdx]; // only defined in fb subphase
+
+  return (
+    <div class="rq-playing-wrapper">
+      <div class="rq-panel">
+        <div class="rq-playing-header">
+          <div class="rq-mode-badge">Flop Combos{sharedDeck ? ' · Shared' : ''}</div>
+          <button class="rq-exit-btn" onClick={sharedDeck ? startFreshQuiz : exitQuiz}>Exit</button>
+        </div>
+
+        <div class="rq-progress"><div class="rq-progress-fill" style={{ width: (progress * 100) + '%' }}></div></div>
+        <div class="rq-status">
+          <div class="rq-stat"><div class="val">{score}</div><div class="lbl">Correct</div></div>
+          <div class="rq-stat"><div class="val">{qIdx + 1} / {deck.length}</div><div class="lbl">Question</div></div>
+          <div class="rq-stat"><div class="val">{streak}</div><div class="lbl">Streak</div></div>
+          <div class="rq-stat"><div class="val">{pctDisplay}</div><div class="lbl">Accuracy</div></div>
+        </div>
+
+        {current && analysis && (
+          <>
+            <div class="combos-board">
+              <div class="combos-board-row">
+                <div class="combos-board-lbl">Your hand</div>
+                <div class="hand" dangerouslySetInnerHTML={{ __html: renderCards(current.holes) }} />
+              </div>
+              <div class="combos-board-row">
+                <div class="combos-board-lbl">Flop</div>
+                <div class="hand" dangerouslySetInnerHTML={{ __html: renderCards(current.flop) }} />
+              </div>
+            </div>
+
+            {subphase === 'p1' && (
+              <Phase1
+                p1Selected={p1Selected}
+                onToggle={toggleP1}
+                onNext={goToPhase2}
+              />
+            )}
+
+            {subphase === 'p2' && (
+              <Phase2
+                analysis={analysis}
+                p1Selected={p1Selected}
+                p2Outs={p2Outs}
+                setP2Outs={setP2Outs}
+                onSubmit={submitPhase2}
+              />
+            )}
+
+            {subphase === 'fb' && currentResult && (
+              <Feedback
+                result={currentResult}
+                onNext={nextQuestion}
+                isLast={qIdx + 1 >= deck.length}
+              />
+            )}
+
+            <div class="share-row">
+              <ShareButton url={shareUrl} label="Share Link" copiedLabel="Link Copied!" />
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Phase1({ p1Selected, onToggle, onNext }) {
+  return (
+    <>
+      <div class="combos-phase-header">
+        <span class="combos-phase-tag">Phase 1</span>
+        <span class="combos-phase-q">Which categories are reachable by the river?</span>
+      </div>
+      <div class="combos-check-grid">
+        {QUIZ_CATEGORIES.map(C => {
+          const on = p1Selected.has(C);
+          return (
+            <button
+              key={C}
+              type="button"
+              class={'combos-check' + (on ? ' on' : '')}
+              aria-pressed={on}
+              onClick={() => onToggle(C)}
+            >
+              <span class="combos-check-box">{on ? '✓' : ''}</span>
+              <span class="combos-check-lbl">{C}</span>
+            </button>
+          );
+        })}
+      </div>
+      <div class="rq-next-row">
+        <button class="rq-next" style="display:inline-block" onClick={onNext}>
+          Check Answers →
+        </button>
+      </div>
+    </>
+  );
+}
+
+function Phase2({ analysis, p1Selected, p2Outs, setP2Outs, onSubmit }) {
+  const toAnswer = QUIZ_CATEGORIES.filter(C => p1Selected.has(C));
+  if (toAnswer.length === 0) {
+    // Nothing selected → no outs to enter. Let the user confirm their phase-1 answer.
+    return (
+      <>
+        <div class="combos-phase-header">
+          <span class="combos-phase-tag">Phase 2</span>
+          <span class="combos-phase-q">No categories selected — submit to see the answer.</span>
+        </div>
+        <div class="rq-next-row">
+          <button class="rq-next" style="display:inline-block" onClick={onSubmit}>
+            Submit →
+          </button>
+        </div>
+      </>
+    );
+  }
+  return (
+    <>
+      <div class="combos-phase-header">
+        <span class="combos-phase-tag">Phase 2</span>
+        <span class="combos-phase-q">How many single-card (turn) outs for each?</span>
+      </div>
+      <div class="combos-outs-grid">
+        {toAnswer.map(C => {
+          const made = analysis.made === C;
+          return (
+            <div key={C} class="combos-outs-row">
+              <div class="combos-outs-lbl">{C}</div>
+              {made ? (
+                <div class="combos-outs-made">Already made</div>
+              ) : (
+                <input
+                  type="number"
+                  min="0"
+                  max="47"
+                  class="combos-outs-input"
+                  value={p2Outs[C] ?? ''}
+                  onInput={(e) => setP2Outs(prev => ({ ...prev, [C]: e.currentTarget.value }))}
+                  placeholder="#"
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+      <div class="rq-next-row">
+        <button class="rq-next" style="display:inline-block" onClick={onSubmit}>
+          Submit →
+        </button>
+      </div>
+    </>
+  );
+}
+
+function Feedback({ result, onNext, isLast }) {
+  const { analysis, grade, p2Outs } = result;
+  return (
+    <>
+      <div class="combos-phase-header">
+        <span class={'combos-phase-tag' + (grade.handCorrect ? ' ok' : ' bad')}>
+          {grade.handCorrect ? 'All correct' : 'Some mistakes'}
+        </span>
+        <span class="combos-phase-q">Review</span>
+      </div>
+      <div class="combos-fb-list">
+        {QUIZ_CATEGORIES.map(C => {
+          const pc = grade.perCat[C];
+          const actualOuts = analysis.turnOuts[C];
+          const prob = analysis.riverProb[C];
+          const entered = p2Outs[C];
+          const askedOuts = pc.userSelected && !pc.made;
+          const rowCls = 'combos-fb-row '
+            + (pc.categoryRight ? 'ok' : (pc.trueReachable || pc.userSelected ? 'bad' : 'dim'));
+          return (
+            <div key={C} class={rowCls}>
+              <div class="combos-fb-head">
+                <span class="combos-fb-cat">{C}</span>
+                {pc.made && <span class="combos-fb-badge made">Made on flop</span>}
+                {pc.trueReachable && !pc.made && <span class="combos-fb-badge reachable">Reachable</span>}
+                {!pc.trueReachable && <span class="combos-fb-badge unreach">Not reachable</span>}
+              </div>
+              <div class="combos-fb-line">
+                <span class="combos-fb-k">Your pick:</span>
+                <span class={'combos-fb-v ' + (pc.phase1Right ? 'ok' : 'bad')}>
+                  {pc.userSelected ? 'Reachable' : 'Not reachable'}
+                  {' '}{pc.phase1Right ? '✓' : '✗'}
+                </span>
+              </div>
+              {askedOuts && (
+                <div class="combos-fb-line">
+                  <span class="combos-fb-k">Your outs:</span>
+                  <span class={'combos-fb-v ' + (pc.phase2Right ? 'ok' : 'bad')}>
+                    {entered === '' || entered == null ? '—' : entered}
+                    {' '}vs. actual <strong>{actualOuts.count}</strong>
+                    {' '}{pc.phase2Right ? '✓' : '✗'}
+                  </span>
+                </div>
+              )}
+              {pc.trueReachable && (
+                <div class="combos-fb-line">
+                  <span class="combos-fb-k">River probability:</span>
+                  <span class="combos-fb-v">
+                    <strong>{fmtPct(prob)}</strong>
+                    {actualOuts.count > 0
+                      ? <> &middot; rule of 4: ≈{ruleOfFour(actualOuts.count)}</>
+                      : <> &middot; runner-runner (no turn outs)</>}
+                  </span>
+                </div>
+              )}
+              {actualOuts.count > 0 && (
+                <div class="combos-fb-outs">
+                  <div class="combos-fb-k">Turn outs ({actualOuts.count}):</div>
+                  <div class="hand combos-fb-outs-cards"
+                       dangerouslySetInnerHTML={{ __html: renderCards(actualOuts.cards, 34, 48) }} />
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+      <div class="rq-next-row">
+        <button class="rq-next" style="display:inline-block" onClick={onNext}>
+          {isLast ? 'Finish' : 'Next Question'} →
+        </button>
+      </div>
+    </>
+  );
+}

--- a/src/sections/flop/CombosQuiz.test.js
+++ b/src/sections/flop/CombosQuiz.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { gradeHand } from './CombosQuiz.jsx';
+import { analyzeQuestion, QUIZ_CATEGORIES } from '../../utils/combos.js';
+
+const c = (rank, suit) => ({ rank, suit });
+
+describe('gradeHand', () => {
+  // AsKs on 2s 7s Jd — flush draw. Categories reachable: Pair, Two Pair, Trips,
+  // Straight (no — no connected cards to the Broadway), Flush, Full House?, etc.
+  // We use analyzeQuestion so the test stays honest to the real reachability set.
+  const holes = [c('A', '♠'), c('K', '♠')];
+  const flop = [c('2', '♠'), c('7', '♠'), c('J', '♦')];
+  const analysis = analyzeQuestion(holes, flop);
+
+  it('scores a perfect hand when every category judgement matches truth', () => {
+    const p1 = new Set(QUIZ_CATEGORIES.filter(C => analysis.reachable.has(C)));
+    const p2 = {};
+    for (const C of QUIZ_CATEGORIES) {
+      if (p1.has(C) && analysis.made !== C) {
+        p2[C] = String(analysis.turnOuts[C].count);
+      }
+    }
+    const g = gradeHand(analysis, p1, p2);
+    expect(g.handCorrect).toBe(true);
+    expect(g.phase1Correct).toBe(QUIZ_CATEGORIES.length);
+    expect(g.phase2Correct).toBe(g.phase2Total);
+  });
+
+  it('docks phase 1 when user misses a reachable category', () => {
+    const p1 = new Set(QUIZ_CATEGORIES.filter(C => analysis.reachable.has(C) && C !== 'Flush'));
+    const p2 = {};
+    for (const C of p1) {
+      if (analysis.made !== C) p2[C] = String(analysis.turnOuts[C].count);
+    }
+    const g = gradeHand(analysis, p1, p2);
+    expect(g.handCorrect).toBe(false);
+    expect(g.perCat['Flush'].phase1Right).toBe(false);
+    expect(g.perCat['Flush'].categoryRight).toBe(false);
+  });
+
+  it('docks phase 2 when outs are off by one', () => {
+    const p1 = new Set(QUIZ_CATEGORIES.filter(C => analysis.reachable.has(C)));
+    const p2 = {};
+    for (const C of QUIZ_CATEGORIES) {
+      if (p1.has(C) && analysis.made !== C) {
+        const trueCount = analysis.turnOuts[C].count;
+        // Flip one category's answer to be wrong by 1.
+        p2[C] = String(C === 'Flush' ? trueCount + 1 : trueCount);
+      }
+    }
+    const g = gradeHand(analysis, p1, p2);
+    expect(g.handCorrect).toBe(false);
+    expect(g.perCat['Flush'].phase2Right).toBe(false);
+  });
+
+  it('does not ask phase 2 for made categories even if user selected them', () => {
+    const madeHoles = [c('7', '♠'), c('7', '♥')];
+    const madeFlop = [c('K', '♣'), c('7', '♦'), c('2', '♠')];
+    const a = analyzeQuestion(madeHoles, madeFlop);
+    expect(a.made).toBe('Three of a Kind');
+    const p1 = new Set(QUIZ_CATEGORIES.filter(C => a.reachable.has(C)));
+    // Leave "Three of a Kind" out of p2 — user isn't asked for outs on made hands.
+    const p2 = {};
+    for (const C of p1) {
+      if (a.made !== C) p2[C] = String(a.turnOuts[C].count);
+    }
+    const g = gradeHand(a, p1, p2);
+    expect(g.perCat['Three of a Kind'].phase2Right).toBeNull();
+    expect(g.handCorrect).toBe(true);
+  });
+
+  it('treats empty/blank phase 2 entries as wrong', () => {
+    const p1 = new Set(QUIZ_CATEGORIES.filter(C => analysis.reachable.has(C)));
+    const p2 = {}; // no inputs
+    const g = gradeHand(analysis, p1, p2);
+    expect(g.handCorrect).toBe(false);
+    // Any reachable-not-made category is now wrong in phase 2.
+    const flushPc = g.perCat['Flush'];
+    expect(flushPc.phase2Right).toBe(false);
+  });
+});

--- a/src/sections/flop/Quiz.jsx
+++ b/src/sections/flop/Quiz.jsx
@@ -21,7 +21,8 @@ import '../../styles/quiz.css';
 
 const TABS = [
   { path: '/quizzes/preflop', label: 'Preflop' },
-  { path: '/quizzes/flop', label: 'Flop' },
+  { path: '/quizzes/flop', label: 'Flop Texture' },
+  { path: '/quizzes/flop-combos', label: 'Flop Combos' },
   { path: '/quizzes/terminology', label: 'Terminology' },
 ];
 

--- a/src/sections/preflop/Quiz.jsx
+++ b/src/sections/preflop/Quiz.jsx
@@ -48,7 +48,8 @@ import '../../styles/quiz.css';
 
 const TABS = [
   { path: '/quizzes/preflop', label: 'Preflop' },
-  { path: '/quizzes/flop', label: 'Flop' },
+  { path: '/quizzes/flop', label: 'Flop Texture' },
+  { path: '/quizzes/flop-combos', label: 'Flop Combos' },
   { path: '/quizzes/terminology', label: 'Terminology' },
 ];
 

--- a/src/sections/stats/Dashboard.jsx
+++ b/src/sections/stats/Dashboard.jsx
@@ -1,8 +1,9 @@
 import { useState } from 'preact/hooks';
 import { TERMS, CATS } from '../../data/terms.js';
 import { RFI_QUIZ_POSITIONS } from '../../data/rfi-ranges.js';
-import { getStudyProgress, initStudyProgress, getTermQuizStats, initTermQuizStats, getRfiQuizStats, initRfiQuizStats, getLimpQuizStats, initLimpQuizStats, getVsRaiseQuizStats, initVsRaiseQuizStats, getAllModesQuizStats, initAllModesQuizStats, getFlopQuizStats, initFlopQuizStats } from '../../utils/storage.js';
+import { getStudyProgress, initStudyProgress, getTermQuizStats, initTermQuizStats, getRfiQuizStats, initRfiQuizStats, getLimpQuizStats, initLimpQuizStats, getVsRaiseQuizStats, initVsRaiseQuizStats, getAllModesQuizStats, initAllModesQuizStats, getFlopQuizStats, initFlopQuizStats, getFlopCombosQuizStats, initFlopCombosQuizStats } from '../../utils/storage.js';
 import { BOARD_TEXTURES } from '../../utils/flop.js';
+import { QUIZ_CATEGORIES } from '../../utils/combos.js';
 import { LIMP_HERO_POSITIONS, RAISE_HERO_POSITIONS } from '../../data/preflop-ranges.js';
 import { Recommendation } from '../../components/Recommendation.jsx';
 import '../../styles/stats.css';
@@ -18,6 +19,7 @@ export function Dashboard({ path }) {
   const vsRaiseQuiz = getVsRaiseQuizStats() || initVsRaiseQuizStats();
   const allModes   = getAllModesQuizStats() || initAllModesQuizStats();
   const flopQuiz   = getFlopQuizStats()    || initFlopQuizStats();
+  const combosQuiz = getFlopCombosQuizStats() || initFlopCombosQuizStats();
 
   const totalTerms = TERMS.length;
   const cardsSeen = study.cardsSeen.length;
@@ -64,9 +66,21 @@ export function Dashboard({ path }) {
     localStorage.removeItem('flop-quiz-stats');
     refresh();
   }
+  function resetCombosQuiz() {
+    if (!confirm('Reset all Flop Combos & Outs quiz stats? This cannot be undone.')) return;
+    localStorage.removeItem('flop-combos-quiz-stats');
+    refresh();
+  }
 
   const flopAccuracy = flopQuiz.totalQuestions > 0
     ? Math.round(flopQuiz.totalCorrect / flopQuiz.totalQuestions * 100) : 0;
+
+  const combosAccuracy = combosQuiz.totalQuestions > 0
+    ? Math.round(combosQuiz.totalCorrect / combosQuiz.totalQuestions * 100) : 0;
+  const combosPhase1Acc = combosQuiz.phase1Total > 0
+    ? Math.round(combosQuiz.phase1Correct / combosQuiz.phase1Total * 100) : 0;
+  const combosPhase2Acc = combosQuiz.phase2Total > 0
+    ? Math.round(combosQuiz.phase2Correct / combosQuiz.phase2Total * 100) : 0;
 
   return (
     <div class="stats-dashboard">
@@ -281,6 +295,78 @@ export function Dashboard({ path }) {
                 <div class="stats-history-title">Recent Scores</div>
                 {flopQuiz.recentScores.slice(-5).reverse().map((r, i) => {
                   const p = Math.round(r.score / r.total * 100);
+                  return (
+                    <div class="stats-history-row" key={i}>
+                      <span>{r.date}</span>
+                      <span style={{ color: p >= 70 ? '#27ae60' : p >= 50 ? '#c9a84c' : '#c0392b' }}>
+                        {r.score}/{r.total} ({p}%)
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Flop Combos & Outs Quiz */}
+      <div class="stats-section">
+        <div class="stats-section-header">
+          <h3>Flop Combos &amp; Outs Quiz</h3>
+          <button class="stats-reset" onClick={resetCombosQuiz}>Reset</button>
+        </div>
+        {combosQuiz.totalQuizzes === 0 ? (
+          <p class="stats-empty">No quizzes taken yet. <a href="#/quizzes/flop-combos">Take a quiz</a></p>
+        ) : (
+          <>
+            <div class="stats-grid">
+              <div class="stats-card">
+                <div class="stats-val">{combosQuiz.totalQuizzes}</div>
+                <div class="stats-lbl">Quizzes</div>
+              </div>
+              <div class="stats-card">
+                <div class="stats-val">{combosAccuracy}%</div>
+                <div class="stats-lbl">Perfect Hands</div>
+              </div>
+              <div class="stats-card">
+                <div class="stats-val">{combosPhase1Acc}%</div>
+                <div class="stats-lbl">Phase 1 Acc.</div>
+              </div>
+              <div class="stats-card">
+                <div class="stats-val">{combosPhase2Acc}%</div>
+                <div class="stats-lbl">Phase 2 Acc.</div>
+              </div>
+              <div class="stats-card">
+                <div class="stats-val">{combosQuiz.bestStreak}</div>
+                <div class="stats-lbl">Best Streak</div>
+              </div>
+            </div>
+            {combosQuiz.byCategory && Object.keys(combosQuiz.byCategory).length > 0 && (
+              <div class="stats-bars">
+                <div class="stats-bars-title">Accuracy by Category</div>
+                {QUIZ_CATEGORIES.map(cat => {
+                  const ps = combosQuiz.byCategory[cat];
+                  if (!ps || ps.total === 0) return null;
+                  const pct = Math.round(ps.correct / ps.total * 100);
+                  const clr = pct >= 80 ? '#27ae60' : pct >= 60 ? '#c9a84c' : '#c0392b';
+                  return (
+                    <div class="stats-cat-row" key={cat}>
+                      <div class="stats-cat-label">{cat}</div>
+                      <div class="stats-cat-bar">
+                        <div class="stats-cat-bar-fill" style={{ width: pct + '%', background: clr }}></div>
+                        <div class="stats-cat-bar-text">{pct}% ({ps.correct}/{ps.total})</div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+            {combosQuiz.recentScores.length > 0 && (
+              <div class="stats-history">
+                <div class="stats-history-title">Recent Scores</div>
+                {combosQuiz.recentScores.slice(-5).reverse().map((r, i) => {
+                  const p = r.total > 0 ? Math.round(r.score / r.total * 100) : 0;
                   return (
                     <div class="stats-history-row" key={i}>
                       <span>{r.date}</span>

--- a/src/sections/terminology/Quiz.jsx
+++ b/src/sections/terminology/Quiz.jsx
@@ -13,7 +13,8 @@ import '../../styles/quiz.css';
 
 const TABS = [
   { path: '/quizzes/preflop', label: 'Preflop' },
-  { path: '/quizzes/flop', label: 'Flop' },
+  { path: '/quizzes/flop', label: 'Flop Texture' },
+  { path: '/quizzes/flop-combos', label: 'Flop Combos' },
   { path: '/quizzes/terminology', label: 'Terminology' },
 ];
 

--- a/src/styles/combos-quiz.css
+++ b/src/styles/combos-quiz.css
@@ -1,0 +1,81 @@
+/* Flop Combos & Outs quiz */
+
+.combos-cat-list{grid-template-columns:repeat(auto-fit,minmax(150px,1fr))}
+.combos-cat-list li{text-align:center}
+.combos-setup-note{font-size:.85rem;max-width:600px;margin:.6rem auto 0;color:var(--muted)}
+
+/* Board display: hole cards + flop, stacked */
+.combos-board{display:flex;flex-direction:column;gap:.9rem;align-items:center;
+  margin-bottom:1.2rem;padding:1.1rem;background:linear-gradient(135deg,#1e3d28,#0c2010);
+  border:1px solid var(--gold-dark);border-radius:14px}
+.combos-board-row{display:flex;flex-direction:column;align-items:center;gap:.35rem}
+.combos-board-lbl{font-size:.7rem;color:var(--gold);letter-spacing:.12em;text-transform:uppercase}
+
+.combos-phase-header{display:flex;align-items:center;gap:.6rem;margin-bottom:.7rem;
+  flex-wrap:wrap;justify-content:center}
+.combos-phase-tag{display:inline-block;padding:.2rem .7rem;border-radius:12px;
+  background:var(--gold-dark);color:var(--gold-bright);font-size:.75rem;
+  letter-spacing:.08em;text-transform:uppercase;font-weight:600}
+.combos-phase-tag.ok{background:rgba(46,204,113,.25);color:#a8f0c6}
+.combos-phase-tag.bad{background:rgba(192,57,43,.25);color:#f0b8b0}
+.combos-phase-q{font-family:'Playfair Display',serif;font-size:1.1rem;color:var(--text);
+  text-align:center}
+
+/* Phase 1: checkbox grid */
+.combos-check-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));
+  gap:8px;margin-bottom:1rem}
+.combos-check{display:flex;align-items:center;gap:.6rem;padding:.6rem .8rem;
+  border-radius:10px;border:1px solid rgba(201,168,76,.3);
+  background:rgba(255,255,255,.04);color:var(--text);font-family:'Crimson Pro',serif;
+  font-size:.95rem;cursor:pointer;transition:all .15s;text-align:left}
+.combos-check:focus{outline:none}
+.combos-check:focus-visible{outline:2px solid var(--gold);outline-offset:2px}
+@media (hover:hover) {
+  .combos-check:hover:not(.on){background:rgba(201,168,76,.1);border-color:var(--gold)}
+}
+.combos-check.on{background:rgba(46,204,113,.18);border-color:#27ae60;color:#d8f5e0}
+.combos-check-box{display:inline-flex;align-items:center;justify-content:center;
+  width:22px;height:22px;border-radius:5px;border:1.5px solid var(--gold-dark);
+  background:rgba(0,0,0,.3);color:var(--gold-bright);font-weight:700;flex-shrink:0}
+.combos-check.on .combos-check-box{background:#27ae60;border-color:#27ae60;color:#0c2416}
+.combos-check-lbl{flex:1}
+
+/* Phase 2: outs inputs */
+.combos-outs-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));
+  gap:8px;margin-bottom:1rem}
+.combos-outs-row{display:flex;align-items:center;justify-content:space-between;
+  padding:.55rem .8rem;border-radius:10px;border:1px solid rgba(201,168,76,.25);
+  background:rgba(255,255,255,.04)}
+.combos-outs-lbl{font-family:'Crimson Pro',serif;color:var(--gold-bright);font-weight:600}
+.combos-outs-input{width:70px;padding:.35rem .5rem;border-radius:6px;
+  border:1px solid var(--gold-dark);background:rgba(0,0,0,.3);color:var(--text);
+  font-family:'Crimson Pro',serif;font-size:1rem;text-align:center}
+.combos-outs-input:focus{outline:none;border-color:var(--gold)}
+.combos-outs-made{font-size:.8rem;padding:.2rem .55rem;border-radius:10px;
+  background:rgba(52,152,219,.18);color:#a8d8f0;border:1px solid rgba(52,152,219,.4)}
+
+/* Feedback list */
+.combos-fb-list{display:flex;flex-direction:column;gap:.6rem;margin-bottom:1rem}
+.combos-fb-row{padding:.7rem .85rem;border-radius:10px;
+  border:1px solid rgba(201,168,76,.2);background:rgba(255,255,255,.035)}
+.combos-fb-row.ok{border-color:rgba(46,204,113,.45);background:rgba(46,204,113,.08)}
+.combos-fb-row.bad{border-color:rgba(192,57,43,.5);background:rgba(192,57,43,.08)}
+.combos-fb-row.dim{opacity:.65}
+.combos-fb-head{display:flex;align-items:center;gap:.5rem;margin-bottom:.3rem;
+  flex-wrap:wrap}
+.combos-fb-cat{font-family:'Playfair Display',serif;font-size:1rem;color:var(--gold-bright)}
+.combos-fb-badge{font-size:.7rem;padding:.1rem .5rem;border-radius:10px;
+  text-transform:uppercase;letter-spacing:.06em;font-weight:600;white-space:nowrap}
+.combos-fb-badge.made{background:rgba(52,152,219,.2);color:#a8d8f0}
+.combos-fb-badge.reachable{background:rgba(201,168,76,.2);color:var(--gold-bright)}
+.combos-fb-badge.unreach{background:rgba(255,255,255,.05);color:var(--muted)}
+.combos-fb-line{display:flex;flex-wrap:wrap;gap:.4rem;font-size:.9rem;line-height:1.35;
+  color:var(--text);margin-top:.15rem}
+.combos-fb-k{color:var(--muted);font-size:.8rem;letter-spacing:.05em;min-width:115px}
+.combos-fb-v.ok{color:#a8f0c6}
+.combos-fb-v.bad{color:#f0b8b0}
+.combos-fb-outs{margin-top:.45rem}
+.combos-fb-outs-cards{flex-wrap:wrap;gap:4px !important;justify-content:flex-start}
+
+.combos-summary-sub{font-size:.85rem;color:var(--muted);max-width:500px;
+  margin:.5rem auto 1rem}

--- a/src/utils/combos.js
+++ b/src/utils/combos.js
@@ -1,0 +1,173 @@
+// Flop Combos & Outs quiz — hand evaluator, per-question analyzer, deck builder.
+//
+// A "question" is: 2 hole cards + 3 flop cards (all distinct).
+// We report, for every hand category:
+//   made:       the current best category from hole+flop
+//   turnOuts:   cards that, drawn on the turn, make the best 5-card hand exactly
+//               that category (the poker definition of "outs")
+//   reachable:  categories achievable as the final showdown category given any
+//               (turn, river) runout — includes runner-runner draws
+//   riverProb:  exact probability that the final best 5-card category equals C,
+//               over all C(47,2)=1081 runouts
+
+import { FLOP_RANKS, FLOP_SUITS } from './flop.js';
+
+export const CATEGORIES = [
+  'High Card',
+  'Pair',
+  'Two Pair',
+  'Three of a Kind',
+  'Straight',
+  'Flush',
+  'Full House',
+  'Four of a Kind',
+  'Straight Flush',
+  'Royal Flush',
+];
+
+// Categories offered as quiz options (High Card excluded — always trivially
+// reachable on any flop, adds no teaching value).
+export const QUIZ_CATEGORIES = CATEGORIES.slice(1);
+
+function rankIdx(r) { return FLOP_RANKS.indexOf(r); }
+
+function isStraight(sortedIdx) {
+  if (sortedIdx.length !== 5) return false;
+  let consecutive = true;
+  for (let i = 1; i < 5; i++) {
+    if (sortedIdx[i] - sortedIdx[i - 1] !== 1) { consecutive = false; break; }
+  }
+  if (consecutive) return true;
+  // A-2-3-4-5 wheel: ranks index out as [0,1,2,3,12].
+  return sortedIdx[0] === 0 && sortedIdx[1] === 1
+      && sortedIdx[2] === 2 && sortedIdx[3] === 3
+      && sortedIdx[4] === 12;
+}
+
+export function evalFive(cards) {
+  const ranks = cards.map(c => c.rank);
+  const suits = cards.map(c => c.suit);
+  const idxs = [...new Set(ranks.map(rankIdx))].sort((a, b) => a - b);
+  const counts = {};
+  for (const r of ranks) counts[r] = (counts[r] || 0) + 1;
+  const countValues = Object.values(counts).sort((a, b) => b - a);
+
+  const flush = new Set(suits).size === 1;
+  const straight = idxs.length === 5 && isStraight(idxs);
+
+  if (straight && flush) {
+    const top = idxs[4];
+    if (top === 12 && idxs[0] === 8) return { rank: 9, category: 'Royal Flush' };
+    return { rank: 8, category: 'Straight Flush' };
+  }
+  if (countValues[0] === 4) return { rank: 7, category: 'Four of a Kind' };
+  if (countValues[0] === 3 && countValues[1] === 2) return { rank: 6, category: 'Full House' };
+  if (flush) return { rank: 5, category: 'Flush' };
+  if (straight) return { rank: 4, category: 'Straight' };
+  if (countValues[0] === 3) return { rank: 3, category: 'Three of a Kind' };
+  if (countValues[0] === 2 && countValues[1] === 2) return { rank: 2, category: 'Two Pair' };
+  if (countValues[0] === 2) return { rank: 1, category: 'Pair' };
+  return { rank: 0, category: 'High Card' };
+}
+
+export function bestOf(cards) {
+  if (cards.length === 5) return evalFive(cards);
+  let best = { rank: -1, category: null };
+  const n = cards.length;
+  for (let i = 0; i < n - 4; i++)
+    for (let j = i + 1; j < n - 3; j++)
+      for (let k = j + 1; k < n - 2; k++)
+        for (let l = k + 1; l < n - 1; l++)
+          for (let m = l + 1; m < n; m++) {
+            const e = evalFive([cards[i], cards[j], cards[k], cards[l], cards[m]]);
+            if (e.rank > best.rank) best = e;
+          }
+  return best;
+}
+
+function deckMinus(used) {
+  const usedKeys = new Set(used.map(c => c.rank + c.suit));
+  const out = [];
+  for (const r of FLOP_RANKS) {
+    for (const s of FLOP_SUITS) {
+      const k = r + s;
+      if (!usedKeys.has(k)) out.push({ rank: r, suit: s });
+    }
+  }
+  return out;
+}
+
+// Sort out-card lists high-rank first, then by suit, for a stable readable order.
+const SUIT_ORDER = { '♠': 0, '♥': 1, '♦': 2, '♣': 3 };
+function cmpCard(a, b) {
+  const dr = rankIdx(b.rank) - rankIdx(a.rank);
+  if (dr !== 0) return dr;
+  return SUIT_ORDER[a.suit] - SUIT_ORDER[b.suit];
+}
+
+export function analyzeQuestion(holes, flop) {
+  const known = [...holes, ...flop];
+  const remaining = deckMinus(known);
+  const made = bestOf(known).category;
+
+  const turnOuts = {};
+  for (const c of CATEGORIES) turnOuts[c] = { count: 0, cards: [] };
+
+  const withOne = known.slice();
+  withOne.push(null);
+  for (const t of remaining) {
+    withOne[withOne.length - 1] = t;
+    const cat = bestOf(withOne).category;
+    turnOuts[cat].cards.push(t);
+    turnOuts[cat].count += 1;
+  }
+  for (const c of CATEGORIES) turnOuts[c].cards.sort(cmpCard);
+
+  const riverCounts = {};
+  for (const c of CATEGORIES) riverCounts[c] = 0;
+
+  const withTwo = known.slice();
+  withTwo.push(null, null);
+  for (let i = 0; i < remaining.length; i++) {
+    withTwo[withTwo.length - 2] = remaining[i];
+    for (let j = i + 1; j < remaining.length; j++) {
+      withTwo[withTwo.length - 1] = remaining[j];
+      riverCounts[bestOf(withTwo).category] += 1;
+    }
+  }
+  const total = remaining.length * (remaining.length - 1) / 2;
+  const riverProb = {};
+  for (const c of CATEGORIES) riverProb[c] = riverCounts[c] / total;
+
+  const reachable = new Set();
+  for (const c of CATEGORIES) if (riverCounts[c] > 0) reachable.add(c);
+
+  return { made, reachable, turnOuts, riverProb };
+}
+
+function randInt(n) { return Math.floor(Math.random() * n); }
+
+function shufflePick(arr, n) {
+  const copy = [...arr];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = randInt(i + 1);
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy.slice(0, n);
+}
+
+function randomFiveCards() {
+  const all = [];
+  for (const r of FLOP_RANKS) for (const s of FLOP_SUITS) all.push({ rank: r, suit: s });
+  return shufflePick(all, 5);
+}
+
+export function buildCombosDeck(length) {
+  const deck = [];
+  const n = Math.max(1, length | 0);
+  for (let i = 0; i < n; i++) {
+    const five = randomFiveCards();
+    deck.push({ holes: [five[0], five[1]], flop: [five[2], five[3], five[4]] });
+  }
+  return deck;
+}

--- a/src/utils/combos.test.js
+++ b/src/utils/combos.test.js
@@ -1,0 +1,206 @@
+import { describe, it, expect } from 'vitest';
+import {
+  evalFive,
+  bestOf,
+  analyzeQuestion,
+  buildCombosDeck,
+  CATEGORIES,
+  QUIZ_CATEGORIES,
+} from './combos.js';
+
+const c = (rank, suit) => ({ rank, suit });
+
+describe('CATEGORIES', () => {
+  it('are ordered weakest → strongest, Royal Flush last', () => {
+    expect(CATEGORIES[0]).toBe('High Card');
+    expect(CATEGORIES[CATEGORIES.length - 1]).toBe('Royal Flush');
+    expect(CATEGORIES).toHaveLength(10);
+  });
+
+  it('QUIZ_CATEGORIES drops only High Card', () => {
+    expect(QUIZ_CATEGORIES).toHaveLength(9);
+    expect(QUIZ_CATEGORIES).not.toContain('High Card');
+    expect(QUIZ_CATEGORIES).toContain('Royal Flush');
+  });
+});
+
+describe('evalFive', () => {
+  it('identifies High Card', () => {
+    expect(evalFive([c('A', '♠'), c('J', '♣'), c('9', '♦'), c('6', '♥'), c('2', '♣')]).category)
+      .toBe('High Card');
+  });
+
+  it('identifies One Pair', () => {
+    expect(evalFive([c('A', '♠'), c('A', '♣'), c('K', '♦'), c('J', '♥'), c('7', '♠')]).category)
+      .toBe('Pair');
+  });
+
+  it('identifies Two Pair', () => {
+    expect(evalFive([c('K', '♠'), c('K', '♥'), c('Q', '♦'), c('Q', '♣'), c('J', '♠')]).category)
+      .toBe('Two Pair');
+  });
+
+  it('identifies Three of a Kind', () => {
+    expect(evalFive([c('9', '♠'), c('9', '♥'), c('9', '♦'), c('A', '♣'), c('4', '♥')]).category)
+      .toBe('Three of a Kind');
+  });
+
+  it('identifies a normal Straight', () => {
+    expect(evalFive([c('8', '♠'), c('9', '♦'), c('10', '♥'), c('J', '♠'), c('Q', '♣')]).category)
+      .toBe('Straight');
+  });
+
+  it('identifies an Ace-low wheel Straight (A-2-3-4-5)', () => {
+    expect(evalFive([c('A', '♠'), c('2', '♦'), c('3', '♥'), c('4', '♣'), c('5', '♠')]).category)
+      .toBe('Straight');
+  });
+
+  it('does NOT call Q-K-A-2-3 a straight (no wrap-around)', () => {
+    expect(evalFive([c('Q', '♠'), c('K', '♦'), c('A', '♥'), c('2', '♣'), c('3', '♠')]).category)
+      .toBe('High Card');
+  });
+
+  it('identifies a Flush', () => {
+    expect(evalFive([c('A', '♦'), c('J', '♦'), c('9', '♦'), c('6', '♦'), c('2', '♦')]).category)
+      .toBe('Flush');
+  });
+
+  it('identifies a Full House', () => {
+    expect(evalFive([c('K', '♠'), c('K', '♥'), c('K', '♦'), c('7', '♥'), c('7', '♦')]).category)
+      .toBe('Full House');
+  });
+
+  it('identifies Four of a Kind', () => {
+    expect(evalFive([c('A', '♠'), c('A', '♥'), c('A', '♦'), c('A', '♣'), c('K', '♠')]).category)
+      .toBe('Four of a Kind');
+  });
+
+  it('identifies a Straight Flush (non-royal)', () => {
+    expect(evalFive([c('7', '♥'), c('8', '♥'), c('9', '♥'), c('10', '♥'), c('J', '♥')]).category)
+      .toBe('Straight Flush');
+  });
+
+  it('identifies the Steel Wheel (A-2-3-4-5 suited) as a Straight Flush, not Royal', () => {
+    expect(evalFive([c('A', '♠'), c('2', '♠'), c('3', '♠'), c('4', '♠'), c('5', '♠')]).category)
+      .toBe('Straight Flush');
+  });
+
+  it('identifies a Royal Flush', () => {
+    expect(evalFive([c('A', '♠'), c('K', '♠'), c('Q', '♠'), c('J', '♠'), c('10', '♠')]).category)
+      .toBe('Royal Flush');
+  });
+});
+
+describe('bestOf', () => {
+  it('picks the best 5-card category from 7 cards', () => {
+    // AA in hand + AKQJT of spades on board → Royal Flush beats the pair of aces.
+    const seven = [
+      c('A', '♥'), c('A', '♦'),
+      c('A', '♠'), c('K', '♠'), c('Q', '♠'), c('J', '♠'), c('10', '♠'),
+    ];
+    expect(bestOf(seven).category).toBe('Royal Flush');
+  });
+
+  it('finds Full House among 7 cards when two pairs + a triple fit', () => {
+    // 77 hole, flop K72 rainbow, turn 7, river K → Full House (sevens full of kings).
+    const seven = [
+      c('7', '♠'), c('7', '♥'),
+      c('K', '♣'), c('7', '♦'), c('2', '♠'),
+      c('7', '♣'), // wait — four 7s would be quads; adjust.
+      c('K', '♦'),
+    ];
+    // Dedupe: we actually wrote three 7s + the hole 7s = four. Fix input:
+    const fixed = [
+      c('7', '♠'), c('7', '♥'),
+      c('K', '♣'), c('7', '♦'), c('2', '♠'),
+      c('K', '♦'), c('3', '♠'),
+    ];
+    expect(bestOf(fixed).category).toBe('Full House');
+  });
+});
+
+describe('analyzeQuestion', () => {
+  it('AsKs on 2s 7s Jd → made pair of aces? no, no pair. Flush draw: 9 turn outs to Flush', () => {
+    const holes = [c('A', '♠'), c('K', '♠')];
+    const flop = [c('2', '♠'), c('7', '♠'), c('J', '♦')];
+    const a = analyzeQuestion(holes, flop);
+    expect(a.made).toBe('High Card');
+    expect(a.reachable.has('Flush')).toBe(true);
+    expect(a.turnOuts['Flush'].count).toBe(9);
+    // Rule-of-4 approximation for 9 outs is ~36%; exact is ~35%.
+    expect(a.riverProb['Flush']).toBeGreaterThan(0.33);
+    expect(a.riverProb['Flush']).toBeLessThan(0.38);
+  });
+
+  it('77 on Kc 7d 2s → Three of a Kind already made; outs-to-Quads = 1 seven left', () => {
+    const holes = [c('7', '♠'), c('7', '♥')];
+    const flop = [c('K', '♣'), c('7', '♦'), c('2', '♠')];
+    const a = analyzeQuestion(holes, flop);
+    expect(a.made).toBe('Three of a Kind');
+    expect(a.turnOuts['Four of a Kind'].count).toBe(1);
+    expect(a.turnOuts['Four of a Kind'].cards[0]).toEqual(c('7', '♣'));
+    // Any K or 2 on the turn pairs the board → Full House. 3 kings + 3 twos = 6 turn outs.
+    expect(a.turnOuts['Full House'].count).toBe(6);
+  });
+
+  it('98 on K 6 5 rainbow (gutshot to 9-high straight) → 4 turn outs, exactly the four sevens', () => {
+    const holes = [c('9', '♠'), c('8', '♥')];
+    const flop = [c('K', '♦'), c('6', '♣'), c('5', '♠')];
+    const a = analyzeQuestion(holes, flop);
+    expect(a.reachable.has('Straight')).toBe(true);
+    expect(a.turnOuts['Straight'].count).toBe(4);
+    for (const card of a.turnOuts['Straight'].cards) expect(card.rank).toBe('7');
+  });
+
+  it('AsKh on 2s 7s Jd (backdoor flush via spade runner-runner) → 0 turn outs to Flush but positive river prob', () => {
+    const holes = [c('A', '♠'), c('K', '♥')];
+    const flop = [c('2', '♠'), c('7', '♠'), c('J', '♦')];
+    const a = analyzeQuestion(holes, flop);
+    // 3 spades known, 10 spades left in the deck. One spade on the turn gives us
+    // 4 spades in 6 cards — still not a flush. Two spades on turn+river makes it.
+    expect(a.turnOuts['Flush'].count).toBe(0);
+    expect(a.reachable.has('Flush')).toBe(true);
+    expect(a.riverProb['Flush']).toBeGreaterThan(0);
+    // C(10,2) / C(47,2) = 45/1081 ≈ 4.2%.
+    expect(a.riverProb['Flush']).toBeLessThan(0.08);
+    expect(a.riverProb['Flush']).toBeGreaterThan(0.03);
+  });
+
+  it('riverProb values across all categories sum to 1', () => {
+    const holes = [c('Q', '♣'), c('Q', '♦')];
+    const flop = [c('7', '♠'), c('4', '♥'), c('2', '♦')];
+    const a = analyzeQuestion(holes, flop);
+    let sum = 0;
+    for (const k of Object.keys(a.riverProb)) sum += a.riverProb[k];
+    expect(sum).toBeCloseTo(1, 6);
+  });
+
+  it('made flush (suited hole + 3 of suit on flop) → reachable includes Flush even with no upgrade on some runouts', () => {
+    const holes = [c('A', '♠'), c('K', '♠')];
+    const flop = [c('2', '♠'), c('7', '♠'), c('J', '♠')];
+    const a = analyzeQuestion(holes, flop);
+    expect(a.made).toBe('Flush');
+    expect(a.reachable.has('Flush')).toBe(true);
+  });
+});
+
+describe('buildCombosDeck', () => {
+  it('produces the requested number of questions', () => {
+    const deck = buildCombosDeck(7);
+    expect(deck).toHaveLength(7);
+  });
+
+  it('each question has 2 hole cards and 3 flop cards, all distinct', () => {
+    const deck = buildCombosDeck(15);
+    for (const q of deck) {
+      expect(q.holes).toHaveLength(2);
+      expect(q.flop).toHaveLength(3);
+      const keys = new Set([...q.holes, ...q.flop].map(x => x.rank + x.suit));
+      expect(keys.size).toBe(5);
+    }
+  });
+
+  it('never returns a zero-length deck even when asked for 0 (minimum 1 question)', () => {
+    expect(buildCombosDeck(0).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/utils/share.js
+++ b/src/utils/share.js
@@ -171,6 +171,49 @@ export function decodeFlopQuiz(query) {
   return { deck };
 }
 
+// Flop Combos & Outs quiz: encodes 2 hole cards + 3 flop cards per question.
+// Correct answers (made / reachable / outs / probability) are re-derived via
+// analyzeQuestion on decode, so only the cards need to travel in the URL.
+//
+//   #/quizzes/flop-combos?cq=<q1>,<q2>,...
+//     qN = <h1><h2><f1><f2><f3>  (5 cards × 2 chars = 10 chars per question)
+//     rank uses T for 10; suit codes are s/h/d/c.
+export function encodeCombosQuiz(deck) {
+  if (!Array.isArray(deck) || deck.length === 0) return null;
+  const parts = [];
+  for (const q of deck) {
+    if (!q?.holes || q.holes.length !== 2 || !q.flop || q.flop.length !== 3) return null;
+    let s = '';
+    for (const c of [...q.holes, ...q.flop]) {
+      if (!FLOP_RANKS.includes(c.rank) || !FLOP_SUITS.includes(c.suit)) return null;
+      s += encodeRank(c.rank) + SUIT_ENCODE[c.suit];
+    }
+    parts.push(s);
+  }
+  return `cq=${parts.join(',')}`;
+}
+
+export function decodeCombosQuiz(query) {
+  const raw = query?.cq;
+  if (!raw) return null;
+  const deck = [];
+  for (const s of raw.split(',')) {
+    if (s.length !== 10) return null;
+    const cards = [];
+    for (let i = 0; i < 5; i++) {
+      const rawRank = s[i * 2];
+      const rawSuit = s[i * 2 + 1];
+      const rank = decodeRank(rawRank);
+      const suit = SUIT_DECODE[rawSuit];
+      if (!FLOP_RANKS.includes(rank) || !suit) return null;
+      cards.push({ rank, suit });
+    }
+    deck.push({ holes: [cards[0], cards[1]], flop: [cards[2], cards[3], cards[4]] });
+  }
+  if (deck.length === 0) return null;
+  return { deck };
+}
+
 // Build an absolute share URL for the given hash path + encoded query.
 export function buildShareUrl(path, encodedQuery) {
   const { origin, pathname } = window.location;

--- a/src/utils/share.test.js
+++ b/src/utils/share.test.js
@@ -6,6 +6,7 @@ import {
   encodeTermQuiz, decodeTermQuiz,
   encodePreflopQuiz, decodePreflopQuiz,
   encodeFlopQuiz, decodeFlopQuiz,
+  encodeCombosQuiz, decodeCombosQuiz,
   buildShareUrl, buildScoreMessage,
 } from './share.js';
 
@@ -169,6 +170,39 @@ describe('encodeFlopQuiz / decodeFlopQuiz', () => {
     expect(decodeFlopQuiz({ fq: '' })).toBeNull();
     expect(decodeFlopQuiz({ fq: 'invalid' })).toBeNull();
     expect(decodeFlopQuiz({ fq: 'Xs8s3d' })).toBeNull();
+  });
+});
+
+describe('encodeCombosQuiz / decodeCombosQuiz', () => {
+  const deck = [
+    { holes: [{rank:'A',suit:'♠'},{rank:'K',suit:'♥'}],
+      flop:  [{rank:'2',suit:'♠'},{rank:'7',suit:'♠'},{rank:'J',suit:'♦'}] },
+    { holes: [{rank:'10',suit:'♦'},{rank:'10',suit:'♣'}],
+      flop:  [{rank:'10',suit:'♠'},{rank:'5',suit:'♥'},{rank:'2',suit:'♣'}] },
+  ];
+
+  it('round-trips a deck, preserving exact cards', () => {
+    const encoded = encodeCombosQuiz(deck);
+    expect(encoded).toMatch(/^cq=/);
+    const decoded = decodeCombosQuiz({ cq: encoded.slice(3) });
+    expect(decoded.deck).toHaveLength(2);
+    expect(decoded.deck[0].holes).toEqual(deck[0].holes);
+    expect(decoded.deck[0].flop).toEqual(deck[0].flop);
+    expect(decoded.deck[1].holes).toEqual(deck[1].holes);
+  });
+
+  it('encodes 10 as T so every card is exactly two characters', () => {
+    const encoded = encodeCombosQuiz([deck[1]]);
+    expect(encoded).toBe('cq=TdTcTs5h2c');
+  });
+
+  it('returns null for malformed / missing input', () => {
+    expect(encodeCombosQuiz([])).toBeNull();
+    expect(encodeCombosQuiz(null)).toBeNull();
+    expect(decodeCombosQuiz({})).toBeNull();
+    expect(decodeCombosQuiz({ cq: '' })).toBeNull();
+    expect(decodeCombosQuiz({ cq: 'short' })).toBeNull();
+    expect(decodeCombosQuiz({ cq: 'Xs8s3d2c9h' })).toBeNull();
   });
 });
 

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -58,6 +58,32 @@ export function initFlopQuizStats() {
   return { totalQuizzes:0, totalQuestions:0, totalCorrect:0, bestStreak:0, byTexture:{}, recentScores:[] };
 }
 
+// Flop Combos & Outs Quiz Stats
+// totalQuestions here = number of hands played; totalCorrect = number of hands
+// answered perfectly (every category judgement in both phases right).
+// phase1/phase2 track finer-grained per-category judgements for diagnostic bars.
+export function getFlopCombosQuizStats() {
+  try { const d = localStorage.getItem('flop-combos-quiz-stats'); return d ? JSON.parse(d) : null; }
+  catch(e) { return null; }
+}
+export function saveFlopCombosQuizStats(s) {
+  try { localStorage.setItem('flop-combos-quiz-stats', JSON.stringify(s)); } catch(e) {}
+}
+export function initFlopCombosQuizStats() {
+  return {
+    totalQuizzes: 0,
+    totalQuestions: 0,
+    totalCorrect: 0,
+    bestStreak: 0,
+    phase1Correct: 0,
+    phase1Total: 0,
+    phase2Correct: 0,
+    phase2Total: 0,
+    byCategory: {},
+    recentScores: [],
+  };
+}
+
 // All-Modes Quiz Stats
 export function getAllModesQuizStats() {
   try { const d = localStorage.getItem('all-modes-quiz-stats'); return d ? JSON.parse(d) : null; }

--- a/src/utils/storage.test.js
+++ b/src/utils/storage.test.js
@@ -5,6 +5,7 @@ import {
   getAllModesQuizStats, saveAllModesQuizStats, initAllModesQuizStats,
   getTermQuizStats, saveTermQuizStats, initTermQuizStats,
   getFlopQuizStats, saveFlopQuizStats, initFlopQuizStats,
+  getFlopCombosQuizStats, saveFlopCombosQuizStats, initFlopCombosQuizStats,
   getSettings, saveSettings, resetSettings, DEFAULT_SETTINGS, CARD_SIZES,
   QUIZ_LENGTH_MIN, QUIZ_LENGTH_MAX,
 } from './storage.js';
@@ -74,6 +75,44 @@ describe('initFlopQuizStats', () => {
     expect(loaded.totalQuizzes).toBe(2);
     expect(loaded.bestStreak).toBe(5);
     expect(loaded.byTexture['Paired Flop']).toEqual({ total: 3, correct: 2 });
+  });
+});
+
+describe('initFlopCombosQuizStats', () => {
+  it('returns the expected shape for the Flop Combos & Outs quiz', () => {
+    const s = initFlopCombosQuizStats();
+    expect(s.totalQuizzes).toBe(0);
+    expect(s.totalQuestions).toBe(0);
+    expect(s.totalCorrect).toBe(0);
+    expect(s.bestStreak).toBe(0);
+    expect(s.phase1Total).toBe(0);
+    expect(s.phase1Correct).toBe(0);
+    expect(s.phase2Total).toBe(0);
+    expect(s.phase2Correct).toBe(0);
+    expect(s.byCategory).toEqual({});
+    expect(Array.isArray(s.recentScores)).toBe(true);
+  });
+
+  it('getFlopCombosQuizStats returns null when nothing stored', () => {
+    expect(getFlopCombosQuizStats()).toBeNull();
+  });
+
+  it('save/get round-trips — per-category buckets survive serialization', () => {
+    const s = initFlopCombosQuizStats();
+    s.totalQuizzes = 2;
+    s.totalQuestions = 10;
+    s.totalCorrect = 6;
+    s.phase1Correct = 78;
+    s.phase1Total = 90;
+    s.phase2Correct = 14;
+    s.phase2Total = 22;
+    s.byCategory['Flush'] = { total: 9, correct: 7 };
+    saveFlopCombosQuizStats(s);
+    const loaded = getFlopCombosQuizStats();
+    expect(loaded.totalQuizzes).toBe(2);
+    expect(loaded.phase1Correct).toBe(78);
+    expect(loaded.phase2Total).toBe(22);
+    expect(loaded.byCategory['Flush']).toEqual({ total: 9, correct: 7 });
   });
 });
 


### PR DESCRIPTION
A new two-phase quiz at #/quizzes/flop-combos: each hand shows hole cards
plus a flop, the player picks every category reachable by the river
(phase 1), then enters single-card turn outs for each selected category
(phase 2). Feedback renders the exact river probability, the rule-of-4
approximation, and the specific out cards.

The hand evaluator and per-question analyzer live in src/utils/combos.js
(pure JS, no new dependencies) and enumerate every C(47,2) runout to
derive truth so the quiz is mathematically faithful even for runner-runner
draws. Stats, share links (?cq=...), sub-nav tabs across all quizzes, and
the dashboard breakdown are wired up to match the existing flop quiz.