### PR TITLE
Auto-select By River when By Turn is selected in Flop Combos phase 1

### DIFF
--- a/src/sections/flop/CombosQuiz.jsx
+++ b/src/sections/flop/CombosQuiz.jsx
@@ -47,6 +47,29 @@ function ruleOfFour(outs) {
   return outs * 4 + '%';
 }
 
+// Toggle one cell of the phase-1 reachability table. When the user turns a
+// category's "By Turn" ON, "By River" auto-selects too — anything reachable
+// in one card is reachable in two. Turning "By Turn" OFF leaves the river
+// selection alone, since the user may still want to flag a backdoor
+// (river-only) draw. River clicks are a plain toggle.
+export function toggleReach(p1Turn, p1River, cat, horizon) {
+  if (horizon === 'turn') {
+    const nextTurn = new Set(p1Turn);
+    if (p1Turn.has(cat)) {
+      nextTurn.delete(cat);
+      return { p1Turn: nextTurn, p1River };
+    }
+    nextTurn.add(cat);
+    if (p1River.has(cat)) return { p1Turn: nextTurn, p1River };
+    const nextRiver = new Set(p1River);
+    nextRiver.add(cat);
+    return { p1Turn: nextTurn, p1River: nextRiver };
+  }
+  const nextRiver = new Set(p1River);
+  if (nextRiver.has(cat)) nextRiver.delete(cat); else nextRiver.add(cat);
+  return { p1Turn, p1River: nextRiver };
+}
+
 // Question grading: returns per-category status + whether the hand is perfect.
 // For each category C:
 //   turnRight:    user's "reachable by turn" ✓/✗ matches truth
@@ -286,12 +309,9 @@ export function CombosQuiz({ query }) {
     // Made categories (and their subsets) are guaranteed correct — locked on
     // for both horizons.
     if (analysis && analysis.madeSet.has(cat)) return;
-    const setter = horizon === 'turn' ? setP1Turn : setP1River;
-    setter(prev => {
-      const next = new Set(prev);
-      if (next.has(cat)) next.delete(cat); else next.add(cat);
-      return next;
-    });
+    const { p1Turn: nextTurn, p1River: nextRiver } = toggleReach(p1Turn, p1River, cat, horizon);
+    if (nextTurn !== p1Turn) setP1Turn(nextTurn);
+    if (nextRiver !== p1River) setP1River(nextRiver);
   }
 
   function goToPhase2() {

--- a/src/sections/flop/CombosQuiz.test.js
+++ b/src/sections/flop/CombosQuiz.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
-import { gradeHand } from './CombosQuiz.jsx';
+import { gradeHand, toggleReach } from './CombosQuiz.jsx';
 import { analyzeQuestion, QUIZ_CATEGORIES } from '../../utils/combos.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -129,6 +129,52 @@ describe('gradeHand', () => {
     expect(g.handCorrect).toBe(false);
     const flushPc = g.perCat['Flush'];
     expect(flushPc.phase2Right).toBe(false);
+  });
+});
+
+describe('toggleReach', () => {
+  it('selecting "By Turn" auto-selects "By River" — reachable in one card implies reachable in two', () => {
+    const { p1Turn, p1River } = toggleReach(new Set(), new Set(), 'Flush', 'turn');
+    expect(p1Turn.has('Flush')).toBe(true);
+    expect(p1River.has('Flush')).toBe(true);
+  });
+
+  it('selecting "By Turn" leaves an already-on river untouched (returns same reference)', () => {
+    const turn = new Set();
+    const river = new Set(['Flush']);
+    const out = toggleReach(turn, river, 'Flush', 'turn');
+    expect(out.p1Turn.has('Flush')).toBe(true);
+    expect(out.p1River).toBe(river);
+  });
+
+  it('deselecting "By Turn" does not auto-deselect "By River" — keeps backdoor (river-only) selection intact', () => {
+    const turn = new Set(['Flush']);
+    const river = new Set(['Flush']);
+    const out = toggleReach(turn, river, 'Flush', 'turn');
+    expect(out.p1Turn.has('Flush')).toBe(false);
+    expect(out.p1River.has('Flush')).toBe(true);
+  });
+
+  it('toggling "By River" alone does not affect "By Turn"', () => {
+    const turn = new Set();
+    const river = new Set();
+    const on = toggleReach(turn, river, 'Flush', 'river');
+    expect(on.p1Turn).toBe(turn);
+    expect(on.p1River.has('Flush')).toBe(true);
+
+    const off = toggleReach(turn, on.p1River, 'Flush', 'river');
+    expect(off.p1Turn).toBe(turn);
+    expect(off.p1River.has('Flush')).toBe(false);
+  });
+
+  it('returns new Set instances for the changed horizon — does not mutate inputs', () => {
+    const turn = new Set();
+    const river = new Set();
+    const out = toggleReach(turn, river, 'Flush', 'turn');
+    expect(out.p1Turn).not.toBe(turn);
+    expect(out.p1River).not.toBe(river);
+    expect(turn.size).toBe(0);
+    expect(river.size).toBe(0);
   });
 });
 


### PR DESCRIPTION
Reachable in one card implies reachable in two, so promoting the river
checkmark removes a redundant click. Toggling By Turn off does not
auto-deselect By River — the user may still want to flag a backdoor
(river-only) draw.

https://claude.ai/code/session_01WLUNKjp1xbjpCeaPz88cji