### PR TITLE
Add post-turn phase to Flop Combos quiz

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ poker-trainer/
 │   │   ├── explain.js                  # Quiz feedback rationale (hand features + action logic)
 │   │   ├── share.js                    # Encode/decode quiz config into share-link query strings
 │   │   ├── flop.js                     # Flop generation + classifyFlop() for Board Texture quiz
-│   │   └── combos.js                   # evalFive, bestOf, analyzeQuestion — Flop Combos evaluator
+│   │   └── combos.js                   # evalFive, bestOf, analyzeQuestion (flop snapshot), analyzeWithTurn (post-turn snapshot) — Flop Combos evaluator
 │   ├── hooks/
 │   │   ├── useFilters.js               # activeCats state + toggle logic
 │   │   └── useDeck.js                  # deck, idx, flipped, nav, shuffle
@@ -75,7 +75,7 @@ poker-trainer/
 │       │   └── Quiz.jsx                # Raise/fold RFI quiz
 │       ├── flop/
 │       │   ├── Quiz.jsx                # Board-texture classification quiz (3 cards → texture)
-│       │   └── CombosQuiz.jsx          # Flop Combos & Outs quiz (hole + flop → reachable-by-turn / -by-river + outs)
+│       │   └── CombosQuiz.jsx          # Flop Combos & Outs quiz: 4 phases — flop reach (turn+river), turn outs, post-turn river reach, river outs
 │       ├── stats/
 │       │   └── Dashboard.jsx           # Full stats dashboard
 │       └── settings/
@@ -102,7 +102,7 @@ Hash-based routing (`#/path`) for GitHub Pages compatibility.
 | `#/quizzes/terminology` | Terminology Quiz.jsx | Multiple-choice terminology quiz |
 | `#/quizzes/preflop` | Preflop Quiz.jsx | Raise/fold/3-bet preflop quiz (RFI / vs-Limp / vs-Raise / All) |
 | `#/quizzes/flop` | Flop Quiz.jsx | Board-texture classification quiz (3 flop cards → one of 6 textures) |
-| `#/quizzes/flop-combos` | CombosQuiz.jsx | Flop Combos & Outs quiz (hole cards + flop → categories reachable by turn / by river + single-card turn outs) |
+| `#/quizzes/flop-combos` | CombosQuiz.jsx | Flop Combos & Outs quiz (hole cards + flop → categories reachable by turn / by river + single-card turn outs; then a turn card is revealed and the user re-classifies river reachability + counts river outs) |
 | `#/stats` | Dashboard.jsx | Full stats dashboard |
 | `#/settings` | Settings.jsx | User preferences (auto-advance, card image size) |
 
@@ -117,7 +117,7 @@ Quiz routes accept query strings that encode a reproducible quiz:
 | `#/quizzes/terminology` | `?tq=<i,i,i,...>` | Comma-separated indexes into `TERMS`; defines the ordered question deck. |
 | `#/quizzes/preflop` | `?pq=<stackDepth>~<q1>~<q2>...` | Each `qN = <typeCode>.<hand>.<heroPos>.<villainOrDash>.<suitCode>` where typeCode ∈ `{r,l,v}` (rfi, limp, vsRaise) and suitCode ∈ `{s,h,d,c}`. Correct actions are re-derived from the GTO ranges; suits preserve the exact card rendering. The trailing suit field is optional — legacy 4-field links still decode. |
 | `#/quizzes/flop` | `?fq=<q1>,<q2>,...` | Each `qN = <r1><s1><r2><s2><r3><s3>` — three cards with `rN ∈ {2..9,T,J,Q,K,A}` (T for 10) and `sN ∈ {s,h,d,c}`. The correct texture is re-derived by `classifyFlop` at load time, so only the cards need to travel in the URL. |
-| `#/quizzes/flop-combos` | `?cq=<q1>,<q2>,...` | Each `qN = <h1><h2><f1><f2><f3>` — 2 hole cards followed by 3 flop cards, 10 chars per question, same rank/suit alphabet as `fq`. The analysis (reachable-by-turn, reachable-by-river, turn outs, river probabilities) is re-derived by `analyzeQuestion` at load time. |
+| `#/quizzes/flop-combos` | `?cq=<q1>,<q2>,...` | Each `qN = <h1><h2><f1><f2><f3><t>` — 2 hole cards, 3 flop cards, and 1 turn card; 12 chars per question, same rank/suit alphabet as `fq`. The analysis (reachable-by-turn, reachable-by-river, turn outs, river probabilities, post-turn river outs) is re-derived by `analyzeQuestion` + `analyzeWithTurn` at load time. Legacy 10-char questions (no turn) still decode and the recipient gets a freshly-rolled turn for those questions. |
 
 Both quiz types auto-start in the playing phase when loaded from a shared link, bypassing the setup screen so the recipient can't alter the shared deck. "Play Again" replays the same deck; "New Random Quiz" drops out of shared mode and returns the user to the setup screen (topic picker for terminology, mode/stack/positions for preflop). See `src/utils/share.js` and `src/components/ShareButton.jsx`.
 
@@ -179,7 +179,7 @@ Fonts: `'Playfair Display'` for headings, `'Crimson Pro'` for body text.
 | `rfi-quiz-stats` | `{ totalQuizzes, totalQuestions, totalCorrect, byPosition, recentScores }` |
 | `term-quiz-stats` | `{ totalQuizzes, totalQuestions, totalCorrect, bestStreak, byCategory, recentScores }` |
 | `flop-quiz-stats` | `{ totalQuizzes, totalQuestions, totalCorrect, bestStreak, byTexture, recentScores }` |
-| `flop-combos-quiz-stats` | `{ totalQuizzes, totalQuestions, totalCorrect, bestStreak, phase1Correct, phase1Total, phase2Correct, phase2Total, byCategory, recentScores }` |
+| `flop-combos-quiz-stats` | `{ totalQuizzes, totalQuestions, totalCorrect, bestStreak, phase1Correct, phase1Total, phase2Correct, phase2Total, phase3Correct, phase3Total, phase4Correct, phase4Total, byCategory, recentScores }` |
 | `study-progress` | `{ cardsSeen: [], totalFlips, byCategory: {} }` |
 | `settings` | `{ autoAdvance, autoAdvanceSeconds, cardSize, quizLength }` |
 

--- a/src/sections/flop/CombosQuiz.jsx
+++ b/src/sections/flop/CombosQuiz.jsx
@@ -10,7 +10,9 @@ import { ShareButton } from '../../components/ShareButton.jsx';
 import { cardSvg } from '../../utils/illustrations.jsx';
 import {
   analyzeQuestion,
+  analyzeWithTurn,
   buildCombosDeck,
+  randomTurnCard,
   QUIZ_CATEGORIES,
 } from '../../utils/combos.js';
 import {
@@ -72,25 +74,38 @@ export function toggleReach(p1Turn, p1River, cat, horizon) {
 
 // Question grading: returns per-category status + whether the hand is perfect.
 // For each category C:
-//   turnRight:    user's "reachable by turn" ✓/✗ matches truth
-//   riverRight:   user's "reachable by river" ✓/✗ matches truth
-//   phase2Right:  if category was selected as by-turn and is not made, user's
-//                 outs exactly match actual turn-out count; otherwise null
-//                 (not applicable — no outs to count)
-//   categoryRight: turnRight && riverRight && phase2Right !== false
+//   turnRight:    user's flop "reachable by turn" ✓/✗ matches truth
+//   riverRight:   user's flop "reachable by river" ✓/✗ matches truth
+//   phase2Right:  if category was selected as by-turn and is not made on the
+//                 flop, user's turn-out count exactly matches actual; otherwise
+//                 null (not applicable — no turn outs to count)
+//   phase3Right:  user's post-turn "reachable by river" ✓/✗ matches truth
+//                 (null when the turn snapshot has not been graded yet)
+//   phase4Right:  if category was selected as river-reachable post-turn and
+//                 is not made after the turn, user's river-out count exactly
+//                 matches actual; otherwise null
+//   categoryRight: every applicable judgement above is right
 //
 // Phase 1 contributes 2 judgements per category (turn + river). Phase 2 only
 // kicks in for categories the user marked as reachable-by-turn and that aren't
-// already made on the flop — those are the ones with concrete turn outs to
-// count. A category marked as river-only (backdoor) has 0 turn outs by
-// definition; we skip the input rather than force "0".
-export function gradeHand(analysis, p1Turn, p1River, p2Outs) {
+// already made on the flop. Phase 3 contributes 1 post-turn judgement per
+// category. Phase 4 only kicks in for categories the user marked as river-
+// reachable post-turn and that aren't already made after the turn. Categories
+// marked as river-only (backdoor) on the flop have 0 turn outs by definition;
+// we skip the input rather than force "0". Same applies to backdoor → no
+// river outs after a brick turn.
+export function gradeHand(analysis, p1Turn, p1River, p2Outs, turnAnalysis, p3River, p4Outs) {
   const perCat = {};
   let phase1TurnCorrect = 0;
   let phase1RiverCorrect = 0;
   let phase2Correct = 0;
   let phase2Asked = 0;
+  let phase3Correct = 0;
+  let phase4Correct = 0;
+  let phase4Asked = 0;
   const madeSet = analysis.madeSet || new Set([analysis.made]);
+  const turnMadeSet = turnAnalysis ? (turnAnalysis.madeSet || new Set([turnAnalysis.made])) : null;
+  const turnGraded = !!turnAnalysis;
   for (const C of QUIZ_CATEGORIES) {
     const trueByTurn = analysis.reachableByTurn.has(C);
     const trueByRiver = analysis.reachableByRiver.has(C);
@@ -116,17 +131,51 @@ export function gradeHand(analysis, p1Turn, p1River, p2Outs) {
       }
     }
 
-    const categoryRight = turnRight && riverRight && phase2Right !== false;
+    let phase3Right = null;
+    let phase4Right = null;
+    let trueRiverPostTurn = null;
+    let userRiverPostTurn = null;
+    let madePostTurn = null;
+    if (turnGraded) {
+      trueRiverPostTurn = turnAnalysis.reachableByRiver.has(C);
+      userRiverPostTurn = (p3River || new Set()).has(C);
+      phase3Right = trueRiverPostTurn === userRiverPostTurn;
+      if (phase3Right) phase3Correct += 1;
+      madePostTurn = turnMadeSet.has(C);
+
+      const askedInP4 = userRiverPostTurn && !madePostTurn;
+      if (askedInP4) {
+        phase4Asked += 1;
+        const actual = turnAnalysis.riverOuts[C].count;
+        const entered = Number((p4Outs || {})[C]);
+        if (Number.isFinite(entered) && entered === actual) {
+          phase4Right = true;
+          phase4Correct += 1;
+        } else {
+          phase4Right = false;
+        }
+      }
+    }
+
+    const categoryRight = turnRight && riverRight
+      && phase2Right !== false
+      && phase3Right !== false
+      && phase4Right !== false;
     perCat[C] = {
       turnRight,
       riverRight,
       phase2Right,
+      phase3Right,
+      phase4Right,
       categoryRight,
       trueByTurn,
       trueByRiver,
       userByTurn,
       userByRiver,
       made,
+      trueRiverPostTurn,
+      userRiverPostTurn,
+      madePostTurn,
     };
   }
   const allCorrect = Object.values(perCat).every(x => x.categoryRight);
@@ -140,8 +189,23 @@ export function gradeHand(analysis, p1Turn, p1River, p2Outs) {
     phase1RiverTotal: QUIZ_CATEGORIES.length,
     phase2Correct,
     phase2Total: phase2Asked,
+    phase3Correct,
+    phase3Total: turnGraded ? QUIZ_CATEGORIES.length : 0,
+    phase4Correct,
+    phase4Total: phase4Asked,
     handCorrect: allCorrect,
   };
+}
+
+// Hydrate any deck question that lacks a turn card (legacy 10-char shared
+// links or freshly-built mocks) with a deterministic random turn rolled from
+// the cards left in the deck after hole+flop. This keeps phase-3 always
+// renderable without sprinkling null-checks through the playing UI.
+export function ensureDeckHasTurns(deck) {
+  return deck.map(q => {
+    if (q.turn) return q;
+    return { ...q, turn: randomTurnCard([...q.holes, ...q.flop]) };
+  });
 }
 
 export function CombosQuiz({ query }) {
@@ -149,12 +213,14 @@ export function CombosQuiz({ query }) {
   const [settings, setSettings] = useState(() => getSettings());
   const [phase, setPhase] = useState(sharedInit ? 'playing' : 'setup');
   const [subphase, setSubphase] = useState('p1');
-  const [sharedDeck, setSharedDeck] = useState(() => sharedInit?.deck || null);
-  const [deck, setDeck] = useState(() => sharedInit?.deck || []);
+  const [sharedDeck, setSharedDeck] = useState(() => sharedInit ? ensureDeckHasTurns(sharedInit.deck) : null);
+  const [deck, setDeck] = useState(() => sharedInit ? ensureDeckHasTurns(sharedInit.deck) : []);
   const [qIdx, setQIdx] = useState(0);
   const [p1Turn, setP1Turn] = useState(() => new Set());
   const [p1River, setP1River] = useState(() => new Set());
   const [p2Outs, setP2Outs] = useState({});
+  const [p3River, setP3River] = useState(() => new Set());
+  const [p4Outs, setP4Outs] = useState({});
   const [score, setScore] = useState(0);
   const [streak, setStreak] = useState(0);
   const [total, setTotal] = useState(0);
@@ -163,6 +229,10 @@ export function CombosQuiz({ query }) {
 
   const current = deck[qIdx];
   const analysis = useMemo(() => (current ? analyzeQuestion(current.holes, current.flop) : null), [current]);
+  const turnAnalysis = useMemo(
+    () => (current?.turn ? analyzeWithTurn(current.holes, current.flop, current.turn) : null),
+    [current]
+  );
   const isComplete = phase === 'playing' && qIdx >= deck.length && deck.length > 0;
 
   // When a fresh question becomes the active one (start of phase 1), pre-check
@@ -191,6 +261,25 @@ export function CombosQuiz({ query }) {
     setP1River(seed);
   }, [qIdx, phase, subphase, analysis]);
 
+  // Same auto-seed pattern for phase 3: pre-check every category made after
+  // the turn is revealed. This includes any draws from the flop that hit on
+  // the turn, plus the original flop-made categories that survive.
+  useEffect(() => {
+    if (phase !== 'playing' || subphase !== 'p3' || !turnAnalysis) return;
+    const made = new Set(
+      [...turnAnalysis.madeSet].filter(c => QUIZ_CATEGORIES.includes(c))
+    );
+    setP3River((prev) => {
+      if (prev.size > 0) {
+        const allPresent = [...made].every(c => prev.has(c));
+        if (allPresent) return prev;
+      }
+      const next = new Set(prev);
+      for (const c of made) next.add(c);
+      return next;
+    });
+  }, [qIdx, phase, subphase, turnAnalysis]);
+
   // Persist stats exactly once per completed run.
   useEffect(() => {
     if (!isComplete || statsSaved) return;
@@ -200,11 +289,19 @@ export function CombosQuiz({ query }) {
     stats.totalCorrect += score;
     if (streak > stats.bestStreak) stats.bestStreak = streak;
     if (!stats.byCategory) stats.byCategory = {};
+    if (typeof stats.phase3Correct !== 'number') stats.phase3Correct = 0;
+    if (typeof stats.phase3Total !== 'number') stats.phase3Total = 0;
+    if (typeof stats.phase4Correct !== 'number') stats.phase4Correct = 0;
+    if (typeof stats.phase4Total !== 'number') stats.phase4Total = 0;
     for (const r of results) {
       stats.phase1Correct += r.grade.phase1Correct;
       stats.phase1Total   += r.grade.phase1Total;
       stats.phase2Correct += r.grade.phase2Correct;
       stats.phase2Total   += r.grade.phase2Total;
+      stats.phase3Correct += r.grade.phase3Correct;
+      stats.phase3Total   += r.grade.phase3Total;
+      stats.phase4Correct += r.grade.phase4Correct;
+      stats.phase4Total   += r.grade.phase4Total;
       for (const C of QUIZ_CATEGORIES) {
         const b = stats.byCategory[C] || { total: 0, correct: 0 };
         b.total += 1;
@@ -219,26 +316,30 @@ export function CombosQuiz({ query }) {
   }, [isComplete, statsSaved, total, score, streak, results]);
 
   // Shared-link handler: when ?cq= appears or changes, rebuild from the
-  // encoded cards and auto-start the quiz.
+  // encoded cards and auto-start the quiz. Legacy 10-char shares with no turn
+  // are hydrated with a random turn so phase 3 always has a card to reveal.
   useEffect(() => {
     const next = decodeCombosQuiz(query);
     if (!next) return;
+    const hydrated = ensureDeckHasTurns(next.deck);
     const sameDeck = sharedDeck
-      && sharedDeck.length === next.deck.length
+      && sharedDeck.length === hydrated.length
       && sharedDeck.every((q, i) => {
         const a = [...q.holes, ...q.flop];
-        const b = [...next.deck[i].holes, ...next.deck[i].flop];
+        const b = [...hydrated[i].holes, ...hydrated[i].flop];
         return a.every((c, j) => c.rank === b[j].rank && c.suit === b[j].suit);
       });
     if (sameDeck) return;
-    setSharedDeck(next.deck);
-    setDeck(next.deck);
+    setSharedDeck(hydrated);
+    setDeck(hydrated);
     setPhase('playing');
     setSubphase('p1');
     setQIdx(0);
     setP1Turn(new Set());
     setP1River(new Set());
     setP2Outs({});
+    setP3River(new Set());
+    setP4Outs({});
     setScore(0);
     setStreak(0);
     setTotal(0);
@@ -255,6 +356,8 @@ export function CombosQuiz({ query }) {
     setP1Turn(new Set());
     setP1River(new Set());
     setP2Outs({});
+    setP3River(new Set());
+    setP4Outs({});
     setScore(0);
     setStreak(0);
     setTotal(0);
@@ -273,6 +376,8 @@ export function CombosQuiz({ query }) {
     setP1Turn(new Set());
     setP1River(new Set());
     setP2Outs({});
+    setP3River(new Set());
+    setP4Outs({});
     setScore(0);
     setStreak(0);
     setTotal(0);
@@ -288,6 +393,8 @@ export function CombosQuiz({ query }) {
     setP1Turn(new Set());
     setP1River(new Set());
     setP2Outs({});
+    setP3River(new Set());
+    setP4Outs({});
     setScore(0);
     setStreak(0);
     setTotal(0);
@@ -314,12 +421,33 @@ export function CombosQuiz({ query }) {
     if (nextRiver !== p1River) setP1River(nextRiver);
   }
 
+  function toggleP3(cat) {
+    if (subphase !== 'p3') return;
+    // Categories made after the turn are guaranteed correct — locked on.
+    if (turnAnalysis && turnAnalysis.madeSet.has(cat)) return;
+    setP3River(prev => {
+      const next = new Set(prev);
+      if (next.has(cat)) next.delete(cat); else next.add(cat);
+      return next;
+    });
+  }
+
   function goToPhase2() {
     setSubphase('p2');
   }
 
+  // Submit phase 2 → reveal turn → phase 3. The hand is graded only after
+  // phase 4 so all four phases contribute to the per-hand correct/incorrect.
   function submitPhase2() {
-    const grade = gradeHand(analysis, p1Turn, p1River, p2Outs);
+    setSubphase('p3');
+  }
+
+  function goToPhase4() {
+    setSubphase('p4');
+  }
+
+  function submitPhase4() {
+    const grade = gradeHand(analysis, p1Turn, p1River, p2Outs, turnAnalysis, p3River, p4Outs);
     if (grade.handCorrect) {
       setScore(s => s + 1);
       setStreak(s => s + 1);
@@ -329,9 +457,13 @@ export function CombosQuiz({ query }) {
     setTotal(t => t + 1);
     setResults(r => [...r, {
       analysis,
+      turnAnalysis,
+      turnCard: current?.turn,
       p1Turn: new Set(p1Turn),
       p1River: new Set(p1River),
       p2Outs: { ...p2Outs },
+      p3River: new Set(p3River),
+      p4Outs: { ...p4Outs },
       grade,
     }]);
     setSubphase('fb');
@@ -344,6 +476,8 @@ export function CombosQuiz({ query }) {
     setP1Turn(new Set());
     setP1River(new Set());
     setP2Outs({});
+    setP3River(new Set());
+    setP4Outs({});
     setSubphase('p1');
   }
 
@@ -358,7 +492,7 @@ export function CombosQuiz({ query }) {
         <div class="rq-panel">
           <h2 class="rq-title">Flop Combos &amp; Outs</h2>
           <p class="rq-sub">
-            Each hand shows 2 hole cards and a 3-card flop. First, classify every hand category twice: is it reachable <strong>by the turn</strong> (one more card) and is it reachable <strong>by the river</strong> (two more cards)? Then, for each category you marked as reachable by the turn, enter the number of <strong>single-card outs</strong> &mdash; cards that make the category if they arrive on the turn.
+            Each hand shows 2 hole cards and a 3-card flop. First, classify every hand category twice: is it reachable <strong>by the turn</strong> (one more card) and is it reachable <strong>by the river</strong> (two more cards)? Then, for each category you marked as reachable by the turn, enter the number of <strong>single-card outs</strong> &mdash; cards that make the category if they arrive on the turn. Once you submit, a random <strong>turn card</strong> is revealed and you'll repeat the exercise for the river: mark every category still reachable in one card, then enter the river outs.
           </p>
           <div class="rq-setup-label">Categories you'll judge</div>
           <ul class="rq-texture-list combos-cat-list">
@@ -394,7 +528,7 @@ export function CombosQuiz({ query }) {
             <div class="score-big">{score} / {total} &mdash; {pct}%</div>
             <p>{msg}</p>
             <p class="combos-summary-sub">
-              A hand counts as correct only when every category judgement (phase 1 and phase 2) is exact.
+              A hand counts as correct only when every category judgement is exact across all four phases (flop reachability + outs and river reachability + outs after the turn).
             </p>
             <button class="rq-restart" onClick={restart}>Play Again</button>
             {sharedDeck ? (
@@ -449,6 +583,12 @@ export function CombosQuiz({ query }) {
                 <div class="combos-board-lbl">Flop</div>
                 <div class="hand" dangerouslySetInnerHTML={{ __html: renderCards(current.flop) }} />
               </div>
+              {(subphase === 'p3' || subphase === 'p4' || subphase === 'fb') && current.turn && (
+                <div class="combos-board-row combos-board-turn">
+                  <div class="combos-board-lbl">Turn</div>
+                  <div class="hand" dangerouslySetInnerHTML={{ __html: renderCards([current.turn]) }} />
+                </div>
+              )}
             </div>
 
             {subphase === 'p1' && (
@@ -468,6 +608,25 @@ export function CombosQuiz({ query }) {
                 p2Outs={p2Outs}
                 setP2Outs={setP2Outs}
                 onSubmit={submitPhase2}
+              />
+            )}
+
+            {subphase === 'p3' && turnAnalysis && (
+              <Phase3
+                madeSet={turnAnalysis.madeSet}
+                p3River={p3River}
+                onToggle={toggleP3}
+                onNext={goToPhase4}
+              />
+            )}
+
+            {subphase === 'p4' && turnAnalysis && (
+              <Phase4
+                turnAnalysis={turnAnalysis}
+                p3River={p3River}
+                p4Outs={p4Outs}
+                setP4Outs={setP4Outs}
+                onSubmit={submitPhase4}
               />
             )}
 
@@ -610,8 +769,114 @@ function Phase2({ analysis, p1Turn, p2Outs, setP2Outs, onSubmit }) {
   );
 }
 
+function Phase3({ madeSet, p3River, onToggle, onNext }) {
+  return (
+    <>
+      <div class="combos-phase-header">
+        <span class="combos-phase-tag">Phase 3</span>
+        <span class="combos-phase-q">Turn revealed. For each category, mark whether it's still reachable by the river (one more card).</span>
+      </div>
+      <div class="combos-reach-table" role="table">
+        <div class="combos-reach-head combos-reach-head-single" role="row">
+          <div class="combos-reach-cat" role="columnheader">Category</div>
+          <div class="combos-reach-col-h" role="columnheader" title="Reachable after the river">By&nbsp;River</div>
+        </div>
+        {QUIZ_CATEGORIES.map(C => {
+          const riverOn = p3River.has(C);
+          const locked = madeSet && madeSet.has(C);
+          const lockTitle = locked ? 'Already made after the turn' : undefined;
+          return (
+            <div class={'combos-reach-row combos-reach-row-single' + (locked ? ' locked' : '')} role="row" key={C}>
+              <div class="combos-reach-cat" role="cell">
+                <span class="combos-reach-cat-lbl">{C}</span>
+                {locked && <span class="combos-check-made">made</span>}
+              </div>
+              <div class="combos-reach-cell" role="cell">
+                <button
+                  type="button"
+                  class={'combos-reach-btn' + (riverOn ? ' on' : '') + (locked ? ' locked' : '')}
+                  aria-pressed={riverOn}
+                  aria-label={`${C} reachable by river after turn`}
+                  aria-disabled={locked || undefined}
+                  title={lockTitle}
+                  onClick={() => onToggle(C)}
+                >
+                  <span class="combos-check-box">{riverOn ? '✓' : ''}</span>
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <div class="rq-next-row">
+        <button class="rq-next" style="display:inline-block" onClick={onNext}>
+          Next →
+        </button>
+      </div>
+    </>
+  );
+}
+
+function Phase4({ turnAnalysis, p3River, p4Outs, setP4Outs, onSubmit }) {
+  // Phase 4 only asks for outs on categories the user marked as reachable
+  // by the river after the turn — those are the ones with concrete river outs
+  // to count. Categories already made after the turn skip the input.
+  const toAnswer = QUIZ_CATEGORIES.filter(C => p3River.has(C));
+  if (toAnswer.length === 0) {
+    return (
+      <>
+        <div class="combos-phase-header">
+          <span class="combos-phase-tag">Phase 4</span>
+          <span class="combos-phase-q">No river-reachable categories selected — submit to see the answer.</span>
+        </div>
+        <div class="rq-next-row">
+          <button class="rq-next" style="display:inline-block" onClick={onSubmit}>
+            Submit →
+          </button>
+        </div>
+      </>
+    );
+  }
+  return (
+    <>
+      <div class="combos-phase-header">
+        <span class="combos-phase-tag">Phase 4</span>
+        <span class="combos-phase-q">How many single-card (river) outs for each?</span>
+      </div>
+      <div class="combos-outs-grid">
+        {toAnswer.map(C => {
+          const made = turnAnalysis.madeSet.has(C);
+          return (
+            <div key={C} class="combos-outs-row">
+              <div class="combos-outs-lbl">{C}</div>
+              {made ? (
+                <div class="combos-outs-made">Already made</div>
+              ) : (
+                <input
+                  type="number"
+                  min="0"
+                  max="46"
+                  class="combos-outs-input"
+                  value={p4Outs[C] ?? ''}
+                  onInput={(e) => setP4Outs(prev => ({ ...prev, [C]: e.currentTarget.value }))}
+                  placeholder="#"
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+      <div class="rq-next-row">
+        <button class="rq-next" style="display:inline-block" onClick={onSubmit}>
+          Submit →
+        </button>
+      </div>
+    </>
+  );
+}
+
 function Feedback({ result, onNext, isLast }) {
-  const { analysis, grade, p2Outs } = result;
+  const { analysis, turnAnalysis, grade, p2Outs, p4Outs } = result;
   return (
     <>
       <div class="combos-phase-header">
@@ -627,7 +892,9 @@ function Feedback({ result, onNext, isLast }) {
           const prob = analysis.riverProb[C];
           const entered = p2Outs[C];
           const askedOuts = pc.userByTurn && !pc.made;
-          const anyTouched = pc.trueByTurn || pc.trueByRiver || pc.userByTurn || pc.userByRiver;
+          const anyTouched = pc.trueByTurn || pc.trueByRiver
+            || pc.userByTurn || pc.userByRiver
+            || pc.trueRiverPostTurn || pc.userRiverPostTurn;
           const rowCls = 'combos-fb-row '
             + (pc.categoryRight ? 'ok' : (anyTouched ? 'bad' : 'dim'));
           let badgeLabel, badgeCls;
@@ -635,12 +902,25 @@ function Feedback({ result, onNext, isLast }) {
           else if (pc.trueByTurn) { badgeLabel = 'Reachable by turn'; badgeCls = 'reachable'; }
           else if (pc.trueByRiver) { badgeLabel = 'Backdoor (river only)'; badgeCls = 'reachable'; }
           else { badgeLabel = 'Not reachable'; badgeCls = 'unreach'; }
+
+          const turnRiverActual = turnAnalysis ? turnAnalysis.riverOuts[C] : null;
+          const askedRiverOuts = pc.userRiverPostTurn && !pc.madePostTurn;
+          const enteredRiverOuts = (p4Outs || {})[C];
+
+          let postBadgeLabel = null, postBadgeCls = '';
+          if (turnAnalysis) {
+            if (pc.madePostTurn) { postBadgeLabel = 'Made after turn'; postBadgeCls = 'made'; }
+            else if (pc.trueRiverPostTurn) { postBadgeLabel = 'Reachable by river'; postBadgeCls = 'reachable'; }
+            else { postBadgeLabel = 'Not reachable'; postBadgeCls = 'unreach'; }
+          }
+
           return (
             <div key={C} class={rowCls}>
               <div class="combos-fb-head">
                 <span class="combos-fb-cat">{C}</span>
                 <span class={'combos-fb-badge ' + badgeCls}>{badgeLabel}</span>
               </div>
+              <div class="combos-fb-section-lbl">On the flop</div>
               <div class="combos-fb-line">
                 <span class="combos-fb-k">By turn:</span>
                 <span class={'combos-fb-v ' + (pc.turnRight ? 'ok' : 'bad')}>
@@ -684,6 +964,43 @@ function Feedback({ result, onNext, isLast }) {
                   <div class="hand combos-fb-outs-cards"
                        dangerouslySetInnerHTML={{ __html: renderCards(actualOuts.cards, 34, 48) }} />
                 </div>
+              )}
+
+              {turnAnalysis && (
+                <>
+                  <div class="combos-fb-section-lbl">After the turn</div>
+                  {postBadgeLabel && (
+                    <div class="combos-fb-line">
+                      <span class="combos-fb-k">Status:</span>
+                      <span class={'combos-fb-badge ' + postBadgeCls}>{postBadgeLabel}</span>
+                    </div>
+                  )}
+                  <div class="combos-fb-line">
+                    <span class="combos-fb-k">By river:</span>
+                    <span class={'combos-fb-v ' + (pc.phase3Right ? 'ok' : 'bad')}>
+                      you said <strong>{pc.userRiverPostTurn ? 'yes' : 'no'}</strong>
+                      {' '}&middot; actual <strong>{pc.trueRiverPostTurn ? 'yes' : 'no'}</strong>
+                      {' '}{pc.phase3Right ? '✓' : '✗'}
+                    </span>
+                  </div>
+                  {askedRiverOuts && turnRiverActual && (
+                    <div class="combos-fb-line">
+                      <span class="combos-fb-k">Your river outs:</span>
+                      <span class={'combos-fb-v ' + (pc.phase4Right ? 'ok' : 'bad')}>
+                        {enteredRiverOuts === '' || enteredRiverOuts == null ? '—' : enteredRiverOuts}
+                        {' '}vs. actual <strong>{turnRiverActual.count}</strong>
+                        {' '}{pc.phase4Right ? '✓' : '✗'}
+                      </span>
+                    </div>
+                  )}
+                  {!pc.madePostTurn && turnRiverActual && turnRiverActual.count > 0 && (
+                    <div class="combos-fb-outs">
+                      <div class="combos-fb-k">River outs ({turnRiverActual.count}):</div>
+                      <div class="hand combos-fb-outs-cards"
+                           dangerouslySetInnerHTML={{ __html: renderCards(turnRiverActual.cards, 34, 48) }} />
+                    </div>
+                  )}
+                </>
               )}
             </div>
           );

--- a/src/sections/flop/CombosQuiz.test.js
+++ b/src/sections/flop/CombosQuiz.test.js
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
-import { gradeHand, toggleReach } from './CombosQuiz.jsx';
-import { analyzeQuestion, QUIZ_CATEGORIES } from '../../utils/combos.js';
+import { gradeHand, toggleReach, ensureDeckHasTurns } from './CombosQuiz.jsx';
+import { analyzeQuestion, analyzeWithTurn, QUIZ_CATEGORIES } from '../../utils/combos.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const combosSource = readFileSync(resolve(__dirname, 'CombosQuiz.jsx'), 'utf8');
@@ -175,6 +175,120 @@ describe('toggleReach', () => {
     expect(out.p1River).not.toBe(river);
     expect(turn.size).toBe(0);
     expect(river.size).toBe(0);
+  });
+});
+
+describe('gradeHand with turn phases', () => {
+  // AsKs on 2s 7s Jd, brick turn 4d — still drawing to flush. Phase 3 should
+  // flag Flush as river-reachable; phase 4 should expect 9 river outs.
+  const holes = [c('A', '♠'), c('K', '♠')];
+  const flop = [c('2', '♠'), c('7', '♠'), c('J', '♦')];
+  const turn = c('4', '♦');
+  const analysis = analyzeQuestion(holes, flop);
+  const turnAnalysis = analyzeWithTurn(holes, flop, turn);
+
+  function flopInputs() {
+    const p1Turn = new Set(QUIZ_CATEGORIES.filter(C => analysis.reachableByTurn.has(C)));
+    const p1River = new Set(QUIZ_CATEGORIES.filter(C => analysis.reachableByRiver.has(C)));
+    const p2 = {};
+    for (const C of p1Turn) {
+      if (!analysis.madeSet.has(C)) p2[C] = String(analysis.turnOuts[C].count);
+    }
+    return { p1Turn, p1River, p2 };
+  }
+
+  function turnInputs() {
+    const p3River = new Set(QUIZ_CATEGORIES.filter(C => turnAnalysis.reachableByRiver.has(C)));
+    const p4 = {};
+    for (const C of p3River) {
+      if (!turnAnalysis.madeSet.has(C)) p4[C] = String(turnAnalysis.riverOuts[C].count);
+    }
+    return { p3River, p4 };
+  }
+
+  it('scores a perfect hand only when both flop and turn judgements match truth', () => {
+    const { p1Turn, p1River, p2 } = flopInputs();
+    const { p3River, p4 } = turnInputs();
+    const g = gradeHand(analysis, p1Turn, p1River, p2, turnAnalysis, p3River, p4);
+    expect(g.handCorrect).toBe(true);
+    expect(g.phase3Correct).toBe(QUIZ_CATEGORIES.length);
+    expect(g.phase3Total).toBe(QUIZ_CATEGORIES.length);
+    expect(g.phase4Correct).toBe(g.phase4Total);
+  });
+
+  it('docks phase 3 when user misses a post-turn river-reachable category', () => {
+    const { p1Turn, p1River, p2 } = flopInputs();
+    const { p3River, p4 } = turnInputs();
+    p3River.delete('Flush');
+    delete p4['Flush'];
+    const g = gradeHand(analysis, p1Turn, p1River, p2, turnAnalysis, p3River, p4);
+    expect(g.handCorrect).toBe(false);
+    expect(g.perCat['Flush'].phase3Right).toBe(false);
+    expect(g.perCat['Flush'].categoryRight).toBe(false);
+  });
+
+  it('docks phase 4 when river outs are off by one', () => {
+    const { p1Turn, p1River, p2 } = flopInputs();
+    const { p3River, p4 } = turnInputs();
+    p4['Flush'] = String(turnAnalysis.riverOuts['Flush'].count + 1);
+    const g = gradeHand(analysis, p1Turn, p1River, p2, turnAnalysis, p3River, p4);
+    expect(g.handCorrect).toBe(false);
+    expect(g.perCat['Flush'].phase4Right).toBe(false);
+  });
+
+  it('does not ask phase 4 for categories already made after the turn', () => {
+    // Made-after-turn case: 7s7h on Kc 7d 2s, turn 7c → Quads on the turn.
+    const madeHoles = [c('7', '♠'), c('7', '♥')];
+    const madeFlop = [c('K', '♣'), c('7', '♦'), c('2', '♠')];
+    const madeTurn = c('7', '♣');
+    const a = analyzeQuestion(madeHoles, madeFlop);
+    const ta = analyzeWithTurn(madeHoles, madeFlop, madeTurn);
+    expect(ta.made).toBe('Four of a Kind');
+    const p1Turn = new Set(QUIZ_CATEGORIES.filter(C => a.reachableByTurn.has(C)));
+    const p1River = new Set(QUIZ_CATEGORIES.filter(C => a.reachableByRiver.has(C)));
+    const p2 = {};
+    for (const C of p1Turn) if (!a.madeSet.has(C)) p2[C] = String(a.turnOuts[C].count);
+    const p3River = new Set(QUIZ_CATEGORIES.filter(C => ta.reachableByRiver.has(C)));
+    const p4 = {};
+    for (const C of p3River) if (!ta.madeSet.has(C)) p4[C] = String(ta.riverOuts[C].count);
+    const g = gradeHand(a, p1Turn, p1River, p2, ta, p3River, p4);
+    expect(g.perCat['Four of a Kind'].phase4Right).toBeNull();
+    expect(g.handCorrect).toBe(true);
+  });
+
+  it('keeps the legacy 4-arg call working (no turn analysis) — phase3/phase4 totals stay at 0', () => {
+    const { p1Turn, p1River, p2 } = flopInputs();
+    const g = gradeHand(analysis, p1Turn, p1River, p2);
+    expect(g.handCorrect).toBe(true);
+    expect(g.phase3Correct).toBe(0);
+    expect(g.phase3Total).toBe(0);
+    expect(g.phase4Correct).toBe(0);
+    expect(g.phase4Total).toBe(0);
+  });
+});
+
+describe('ensureDeckHasTurns', () => {
+  it('hydrates legacy turn-less questions with a deterministic random turn', () => {
+    const deck = [
+      { holes: [c('A', '♠'), c('K', '♥')], flop: [c('2', '♠'), c('7', '♠'), c('J', '♦')] },
+    ];
+    const hydrated = ensureDeckHasTurns(deck);
+    expect(hydrated[0].turn).toBeTruthy();
+    // Turn must not collide with any known card.
+    const used = new Set([...deck[0].holes, ...deck[0].flop].map(x => x.rank + x.suit));
+    expect(used.has(hydrated[0].turn.rank + hydrated[0].turn.suit)).toBe(false);
+  });
+
+  it('preserves an existing turn card unchanged', () => {
+    const deck = [
+      {
+        holes: [c('A', '♠'), c('K', '♥')],
+        flop: [c('2', '♠'), c('7', '♠'), c('J', '♦')],
+        turn: c('9', '♣'),
+      },
+    ];
+    const hydrated = ensureDeckHasTurns(deck);
+    expect(hydrated[0].turn).toEqual(deck[0].turn);
   });
 });
 

--- a/src/sections/stats/Dashboard.jsx
+++ b/src/sections/stats/Dashboard.jsx
@@ -81,6 +81,12 @@ export function Dashboard({ path }) {
     ? Math.round(combosQuiz.phase1Correct / combosQuiz.phase1Total * 100) : 0;
   const combosPhase2Acc = combosQuiz.phase2Total > 0
     ? Math.round(combosQuiz.phase2Correct / combosQuiz.phase2Total * 100) : 0;
+  const combosPhase3Total = combosQuiz.phase3Total || 0;
+  const combosPhase3Acc = combosPhase3Total > 0
+    ? Math.round((combosQuiz.phase3Correct || 0) / combosPhase3Total * 100) : 0;
+  const combosPhase4Total = combosQuiz.phase4Total || 0;
+  const combosPhase4Acc = combosPhase4Total > 0
+    ? Math.round((combosQuiz.phase4Correct || 0) / combosPhase4Total * 100) : 0;
 
   return (
     <div class="stats-dashboard">
@@ -336,6 +342,14 @@ export function Dashboard({ path }) {
               <div class="stats-card">
                 <div class="stats-val">{combosPhase2Acc}%</div>
                 <div class="stats-lbl">Phase 2 Acc.</div>
+              </div>
+              <div class="stats-card">
+                <div class="stats-val">{combosPhase3Acc}%</div>
+                <div class="stats-lbl">Phase 3 Acc.</div>
+              </div>
+              <div class="stats-card">
+                <div class="stats-val">{combosPhase4Acc}%</div>
+                <div class="stats-lbl">Phase 4 Acc.</div>
               </div>
               <div class="stats-card">
                 <div class="stats-val">{combosQuiz.bestStreak}</div>

--- a/src/styles/combos-quiz.css
+++ b/src/styles/combos-quiz.css
@@ -10,6 +10,9 @@
   border:1px solid var(--gold-dark);border-radius:14px}
 .combos-board-row{display:flex;flex-direction:column;align-items:center;gap:.35rem}
 .combos-board-lbl{font-size:.7rem;color:var(--gold);letter-spacing:.12em;text-transform:uppercase}
+.combos-board-turn{padding-top:.7rem;border-top:1px dashed rgba(201,168,76,.35);
+  width:100%;align-items:center}
+.combos-board-turn .combos-board-lbl{color:var(--gold-bright)}
 
 .combos-phase-header{display:flex;align-items:center;gap:.6rem;margin-bottom:.7rem;
   flex-wrap:wrap;justify-content:center}
@@ -33,6 +36,8 @@
   border:1px solid rgba(201,168,76,.2)}
 .combos-reach-row.locked{border-style:dashed;border-color:rgba(52,152,219,.4);
   background:rgba(52,152,219,.06)}
+.combos-reach-head.combos-reach-head-single,
+.combos-reach-row-single{grid-template-columns:minmax(0,1fr) 92px}
 .combos-reach-col-h{text-align:center}
 .combos-reach-cat{display:flex;align-items:center;gap:.5rem;
   font-family:'Crimson Pro',serif;font-size:.95rem;color:var(--text);min-width:0}
@@ -104,6 +109,11 @@
 .combos-fb-v.bad{color:#f0b8b0}
 .combos-fb-outs{margin-top:.45rem}
 .combos-fb-outs-cards{flex-wrap:wrap;gap:4px !important;justify-content:flex-start}
+.combos-fb-section-lbl{font-size:.7rem;color:var(--gold);letter-spacing:.1em;
+  text-transform:uppercase;margin:.55rem 0 .15rem;
+  padding-top:.45rem;border-top:1px dashed rgba(201,168,76,.25)}
+.combos-fb-row > .combos-fb-section-lbl:first-of-type{border-top:none;
+  padding-top:.2rem;margin-top:.3rem}
 
 .combos-summary-sub{font-size:.85rem;color:var(--muted);max-width:500px;
   margin:.5rem auto 1rem}

--- a/src/utils/combos.js
+++ b/src/utils/combos.js
@@ -1,7 +1,11 @@
 // Flop Combos & Outs quiz — hand evaluator, per-question analyzer, deck builder.
 //
-// A "question" is: 2 hole cards + 3 flop cards (all distinct).
-// We report, for every hand category:
+// A "question" is: 2 hole cards + 3 flop cards + 1 turn card (the turn is
+// pre-rolled at deck-build time so shared decks reproduce identically and so a
+// later phase can reveal it without re-randomizing).
+//
+// `analyzeQuestion(holes, flop)` reports the flop snapshot — what the user
+// answers in phases 1 & 2 (before seeing the turn). For every category:
 //   made:             the current best category from hole+flop
 //   turnOuts:         cards that, drawn on the turn, make the best 5-card hand
 //                     contain that category (subset-closed: a card making a
@@ -16,6 +20,14 @@
 //   reachable:        alias of reachableByRiver (kept for backward compatibility)
 //   riverProb:        exact probability that the final best 5-card category equals
 //                     C, over all C(47,2)=1081 runouts
+//
+// `analyzeWithTurn(holes, flop, turn)` reports the turn snapshot — what the
+// user answers in phases 3 & 4 (after the turn is revealed). It mirrors the
+// flop analyzer but for the single card still to come:
+//   made:             best category from hole+flop+turn (6 cards)
+//   riverOuts:        cards that, drawn on the river, make the best 5-card
+//                     hand contain that category (subset-closed)
+//   reachableByRiver: categories with ≥1 river out (subset-closed) ∪ madeSet
 
 import { FLOP_RANKS, FLOP_SUITS } from './flop.js';
 
@@ -214,6 +226,48 @@ export function analyzeQuestion(holes, flop) {
   };
 }
 
+// `analyzeWithTurn` — turn-snapshot analyzer for phases 3 & 4. Mirrors
+// `analyzeQuestion` but with one card already known (the turn) and only one
+// more to come (the river). Returns madeSet, riverOuts (subset-closed), and
+// reachableByRiver (subset-closed ∪ madeSet).
+export function analyzeWithTurn(holes, flop, turn) {
+  const known = [...holes, ...flop, turn];
+  const remaining = deckMinus(known);
+  const made = bestOf(known).category;
+  const madeSet = categoriesIncluded(made);
+
+  const riverOuts = {};
+  for (const c of CATEGORIES) riverOuts[c] = { count: 0, cards: [] };
+
+  const withOne = known.slice();
+  withOne.push(null);
+  for (const r of remaining) {
+    withOne[withOne.length - 1] = r;
+    const strictCat = bestOf(withOne).category;
+    for (const cat of categoriesIncluded(strictCat)) {
+      riverOuts[cat].cards.push(r);
+      riverOuts[cat].count += 1;
+    }
+  }
+  for (const c of CATEGORIES) riverOuts[c].cards.sort(cmpCard);
+
+  const reachableByRiver = new Set();
+  for (const c of CATEGORIES) {
+    if (riverOuts[c].count > 0) {
+      reachableByRiver.add(c);
+      for (const s of SUBSETS[c]) reachableByRiver.add(s);
+    }
+  }
+  for (const c of madeSet) reachableByRiver.add(c);
+
+  return {
+    made,
+    madeSet,
+    riverOuts,
+    reachableByRiver,
+  };
+}
+
 function randInt(n) { return Math.floor(Math.random() * n); }
 
 function shufflePick(arr, n) {
@@ -225,18 +279,30 @@ function shufflePick(arr, n) {
   return copy.slice(0, n);
 }
 
-function randomFiveCards() {
+function randomSixCards() {
   const all = [];
   for (const r of FLOP_RANKS) for (const s of FLOP_SUITS) all.push({ rank: r, suit: s });
-  return shufflePick(all, 5);
+  return shufflePick(all, 6);
+}
+
+// Pick a fresh turn card that is not already in `used`. Used when a shared
+// deck arrives without a turn (legacy 10-char encoding) and we need to
+// hydrate one before phase 3.
+export function randomTurnCard(used) {
+  const remaining = deckMinus(used);
+  return remaining[randInt(remaining.length)];
 }
 
 export function buildCombosDeck(length) {
   const deck = [];
   const n = Math.max(1, length | 0);
   for (let i = 0; i < n; i++) {
-    const five = randomFiveCards();
-    deck.push({ holes: [five[0], five[1]], flop: [five[2], five[3], five[4]] });
+    const six = randomSixCards();
+    deck.push({
+      holes: [six[0], six[1]],
+      flop: [six[2], six[3], six[4]],
+      turn: six[5],
+    });
   }
   return deck;
 }

--- a/src/utils/combos.test.js
+++ b/src/utils/combos.test.js
@@ -3,6 +3,7 @@ import {
   evalFive,
   bestOf,
   analyzeQuestion,
+  analyzeWithTurn,
   buildCombosDeck,
   CATEGORIES,
   QUIZ_CATEGORIES,
@@ -337,17 +338,95 @@ describe('buildCombosDeck', () => {
     expect(deck).toHaveLength(7);
   });
 
-  it('each question has 2 hole cards and 3 flop cards, all distinct', () => {
+  it('each question has 2 hole cards, 3 flop cards, and 1 turn card, all distinct', () => {
     const deck = buildCombosDeck(15);
     for (const q of deck) {
       expect(q.holes).toHaveLength(2);
       expect(q.flop).toHaveLength(3);
-      const keys = new Set([...q.holes, ...q.flop].map(x => x.rank + x.suit));
-      expect(keys.size).toBe(5);
+      expect(q.turn).toBeTruthy();
+      const keys = new Set([...q.holes, ...q.flop, q.turn].map(x => x.rank + x.suit));
+      expect(keys.size).toBe(6);
     }
   });
 
   it('never returns a zero-length deck even when asked for 0 (minimum 1 question)', () => {
     expect(buildCombosDeck(0).length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('analyzeWithTurn', () => {
+  it('AsKs on 2s 7s Jd, turn 9s → Flush already made (4 spades), reachable includes Flush', () => {
+    const holes = [c('A', '♠'), c('K', '♠')];
+    const flop = [c('2', '♠'), c('7', '♠'), c('J', '♦')];
+    const turn = c('9', '♠');
+    const a = analyzeWithTurn(holes, flop, turn);
+    expect(a.made).toBe('Flush');
+    expect(a.madeSet.has('Flush')).toBe(true);
+    expect(a.reachableByRiver.has('Flush')).toBe(true);
+  });
+
+  it('AsKs on 2s 7s Jd, turn 4d (brick) → still drawing to Flush, 9 river outs (spades left)', () => {
+    const holes = [c('A', '♠'), c('K', '♠')];
+    const flop = [c('2', '♠'), c('7', '♠'), c('J', '♦')];
+    const turn = c('4', '♦');
+    const a = analyzeWithTurn(holes, flop, turn);
+    expect(a.made).toBe('High Card');
+    // 13 spades total - 3 already known (As, Ks, 2s, 7s = 4) = 9 spades left in deck.
+    expect(a.riverOuts['Flush'].count).toBe(9);
+    expect(a.reachableByRiver.has('Flush')).toBe(true);
+  });
+
+  it('77 on Kc 7d 2s, turn 7c → Quads made; reachable includes Quads + subsets', () => {
+    const holes = [c('7', '♠'), c('7', '♥')];
+    const flop = [c('K', '♣'), c('7', '♦'), c('2', '♠')];
+    const turn = c('7', '♣');
+    const a = analyzeWithTurn(holes, flop, turn);
+    expect(a.made).toBe('Four of a Kind');
+    expect(a.madeSet.has('Four of a Kind')).toBe(true);
+    expect(a.madeSet.has('Three of a Kind')).toBe(true);
+    expect(a.madeSet.has('Pair')).toBe(true);
+    expect(a.reachableByRiver.has('Four of a Kind')).toBe(true);
+  });
+
+  it('riverOuts is subset-closed: a river card making a Full House also counts as Three of a Kind / Pair / Two Pair', () => {
+    // KQ on KQ7 + Q turn → Two Pair made on flop, then Trips of Q after turn.
+    // Wait, need a clearer setup: KQ on KQ7 rainbow + 7 turn → Two Pair (KK QQ via flop already?? Let me redo.
+    // Just use KQ on K72 + Q turn → Two Pair on the turn (Kings + Queens).
+    const holes = [c('K', '♠'), c('Q', '♦')];
+    const flop = [c('K', '♥'), c('7', '♣'), c('2', '♠')];
+    const turn = c('Q', '♣');
+    const a = analyzeWithTurn(holes, flop, turn);
+    expect(a.made).toBe('Two Pair');
+    // Any K, Q, 7, or 2 on the river → Full House. Pair stays implied for all
+    // those river cards via subset closure of FH.
+    expect(a.riverOuts['Full House'].count).toBeGreaterThan(0);
+    // Pair count should be at least the FH count (subset closure).
+    expect(a.riverOuts['Pair'].count).toBeGreaterThanOrEqual(a.riverOuts['Full House'].count);
+  });
+
+  it('reachableByRiver after turn = madeSet ∪ {C: riverOuts[C].count > 0, with subset closure}', () => {
+    const holes = [c('A', '♠'), c('K', '♠')];
+    const flop = [c('2', '♠'), c('7', '♠'), c('J', '♦')];
+    const turn = c('4', '♦');
+    const a = analyzeWithTurn(holes, flop, turn);
+    for (const C of CATEGORIES) {
+      if (a.riverOuts[C].count > 0) {
+        expect(a.reachableByRiver.has(C)).toBe(true);
+      }
+    }
+    for (const M of a.madeSet) expect(a.reachableByRiver.has(M)).toBe(true);
+  });
+
+  it('uses 46 remaining cards (52 minus hole+flop+turn) — total iterated outs across distinct categories ≤ 46', () => {
+    const holes = [c('A', '♠'), c('K', '♠')];
+    const flop = [c('2', '♠'), c('7', '♠'), c('J', '♦')];
+    const turn = c('9', '♣');
+    const a = analyzeWithTurn(holes, flop, turn);
+    // The strict-best category counts (without subset closure) must sum to 46.
+    // Using High Card + Pair we get sum-by-strict-best ≠ subset-closed sum, so
+    // instead just sanity-check that no category exceeds 46.
+    for (const C of CATEGORIES) {
+      expect(a.riverOuts[C].count).toBeLessThanOrEqual(46);
+    }
   });
 });

--- a/src/utils/share.js
+++ b/src/utils/share.js
@@ -171,20 +171,27 @@ export function decodeFlopQuiz(query) {
   return { deck };
 }
 
-// Flop Combos & Outs quiz: encodes 2 hole cards + 3 flop cards per question.
+// Flop Combos & Outs quiz: encodes 2 hole + 3 flop + 1 turn card per question.
 // Correct answers (made / reachable / outs / probability) are re-derived via
-// analyzeQuestion on decode, so only the cards need to travel in the URL.
+// analyzeQuestion / analyzeWithTurn on decode, so only the cards need to
+// travel in the URL.
 //
 //   #/quizzes/flop-combos?cq=<q1>,<q2>,...
-//     qN = <h1><h2><f1><f2><f3>  (5 cards × 2 chars = 10 chars per question)
+//     qN = <h1><h2><f1><f2><f3><t>  (6 cards × 2 chars = 12 chars per question)
 //     rank uses T for 10; suit codes are s/h/d/c.
+//
+// Backward compatibility: legacy 10-char questions (no turn) still decode —
+// a fresh turn is rolled at deck-build / phase-3 entry time so old links keep
+// working, the recipient just gets a randomized turn for those questions.
 export function encodeCombosQuiz(deck) {
   if (!Array.isArray(deck) || deck.length === 0) return null;
   const parts = [];
   for (const q of deck) {
     if (!q?.holes || q.holes.length !== 2 || !q.flop || q.flop.length !== 3) return null;
+    const cards = [...q.holes, ...q.flop];
+    if (q.turn) cards.push(q.turn);
     let s = '';
-    for (const c of [...q.holes, ...q.flop]) {
+    for (const c of cards) {
       if (!FLOP_RANKS.includes(c.rank) || !FLOP_SUITS.includes(c.suit)) return null;
       s += encodeRank(c.rank) + SUIT_ENCODE[c.suit];
     }
@@ -198,9 +205,10 @@ export function decodeCombosQuiz(query) {
   if (!raw) return null;
   const deck = [];
   for (const s of raw.split(',')) {
-    if (s.length !== 10) return null;
+    if (s.length !== 10 && s.length !== 12) return null;
+    const nCards = s.length / 2;
     const cards = [];
-    for (let i = 0; i < 5; i++) {
+    for (let i = 0; i < nCards; i++) {
       const rawRank = s[i * 2];
       const rawSuit = s[i * 2 + 1];
       const rank = decodeRank(rawRank);
@@ -208,7 +216,9 @@ export function decodeCombosQuiz(query) {
       if (!FLOP_RANKS.includes(rank) || !suit) return null;
       cards.push({ rank, suit });
     }
-    deck.push({ holes: [cards[0], cards[1]], flop: [cards[2], cards[3], cards[4]] });
+    const question = { holes: [cards[0], cards[1]], flop: [cards[2], cards[3], cards[4]] };
+    if (cards.length === 6) question.turn = cards[5];
+    deck.push(question);
   }
   if (deck.length === 0) return null;
   return { deck };

--- a/src/utils/share.test.js
+++ b/src/utils/share.test.js
@@ -204,6 +204,32 @@ describe('encodeCombosQuiz / decodeCombosQuiz', () => {
     expect(decodeCombosQuiz({ cq: 'short' })).toBeNull();
     expect(decodeCombosQuiz({ cq: 'Xs8s3d2c9h' })).toBeNull();
   });
+
+  it('round-trips a deck that includes a turn card (12-char question)', () => {
+    const deckWithTurn = [
+      {
+        holes: [{rank:'A',suit:'♠'},{rank:'K',suit:'♥'}],
+        flop:  [{rank:'2',suit:'♠'},{rank:'7',suit:'♠'},{rank:'J',suit:'♦'}],
+        turn:  {rank:'9',suit:'♣'},
+      },
+    ];
+    const encoded = encodeCombosQuiz(deckWithTurn);
+    expect(encoded).toBe('cq=AsKh2s7sJd9c');
+    const decoded = decodeCombosQuiz({ cq: encoded.slice(3) });
+    expect(decoded.deck).toHaveLength(1);
+    expect(decoded.deck[0].turn).toEqual(deckWithTurn[0].turn);
+  });
+
+  it('decodes legacy 10-char questions (no turn) without setting a turn — recipient hydrates a fresh one', () => {
+    const decoded = decodeCombosQuiz({ cq: 'AsKh2s7sJd' });
+    expect(decoded.deck).toHaveLength(1);
+    expect(decoded.deck[0].turn).toBeUndefined();
+    expect(decoded.deck[0].holes).toEqual([{rank:'A',suit:'♠'},{rank:'K',suit:'♥'}]);
+  });
+
+  it('rejects a question with an odd partial card (e.g. 11 chars)', () => {
+    expect(decodeCombosQuiz({ cq: 'AsKh2s7sJd9' })).toBeNull();
+  });
 });
 
 describe('buildScoreMessage', () => {

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -60,8 +60,10 @@ export function initFlopQuizStats() {
 
 // Flop Combos & Outs Quiz Stats
 // totalQuestions here = number of hands played; totalCorrect = number of hands
-// answered perfectly (every category judgement in both phases right).
-// phase1/phase2 track finer-grained per-category judgements for diagnostic bars.
+// answered perfectly (every category judgement across all four phases right).
+// phase1..phase4 track finer-grained per-category judgements for diagnostic
+// bars: phase 1+2 cover the flop snapshot; phase 3+4 cover the post-turn
+// snapshot once the turn card is revealed.
 export function getFlopCombosQuizStats() {
   try { const d = localStorage.getItem('flop-combos-quiz-stats'); return d ? JSON.parse(d) : null; }
   catch(e) { return null; }
@@ -79,6 +81,10 @@ export function initFlopCombosQuizStats() {
     phase1Total: 0,
     phase2Correct: 0,
     phase2Total: 0,
+    phase3Correct: 0,
+    phase3Total: 0,
+    phase4Correct: 0,
+    phase4Total: 0,
     byCategory: {},
     recentScores: [],
   };


### PR DESCRIPTION
After the user submits the flop reachability + turn-outs answers (phases
1 and 2), the quiz now reveals a pre-rolled turn card and asks the same
exercise again for the river. Phase 3 collects river-reachability
judgements; phase 4 collects single-card river outs for each category
the user marked as river-reachable. The hand only counts as correct
when every judgement across all four phases is exact.

- combos.js: new analyzeWithTurn() for the post-turn snapshot; deck
  builder now pre-rolls a turn so shared decks reproduce identically.
- share.js: combos cq= encoding extends from 10 to 12 chars per question
  to round-trip the turn card; legacy 10-char links still decode and
  the recipient hydrates a fresh turn for those questions.
- CombosQuiz.jsx: subphase machine extended with p3 + p4; new Phase3
  and Phase4 components mirror their flop-snapshot counterparts;
  feedback panel splits per-category review into "On the flop" and
  "After the turn" sections.
- storage / Dashboard: track phase3 and phase4 accuracy alongside the
  existing phase1 / phase2 counters.