### PR TITLE
Make suit icons into quick links for Terminology / Preflop / Quizzes / Stats

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -10,6 +10,13 @@ const NAV_ITEMS = [
   { href: '#/settings', label: 'Settings', section: 'settings' },
 ];
 
+const SUIT_LINKS = [
+  { href: '#/terminology/study', suit: '\u2660', className: 's', label: 'Terminology' },
+  { href: '#/preflop/charts', suit: '\u2665', className: 'h', label: 'Preflop Strategy' },
+  { href: '#/quizzes/preflop', suit: '\u2666', className: 'd', label: 'Quizzes' },
+  { href: '#/stats', suit: '\u2663', className: 'c', label: 'Stats' },
+];
+
 export function Header() {
   const [currentPath, setCurrentPath] = useState(window.location.hash.slice(1) || '/welcome');
   const [menuOpen, setMenuOpen] = useState(false);
@@ -71,10 +78,11 @@ export function Header() {
       </nav>
 
       <div class="suits-row">
-        <span class="s">{'\u2660'}</span>
-        <span class="h">{'\u2665'}</span>
-        <span class="d">{'\u2666'}</span>
-        <span class="c">{'\u2663'}</span>
+        {SUIT_LINKS.map(item => (
+          <a key={item.href} href={item.href} class={item.className} aria-label={item.label}>
+            {item.suit}
+          </a>
+        ))}
       </div>
       {isWelcome && (
         <>

--- a/src/components/Header.test.js
+++ b/src/components/Header.test.js
@@ -37,6 +37,13 @@ describe('Header — hamburger menu', () => {
     }
   });
 
+  it('maps the suit icons to quick links for key sections', () => {
+    expect(source).toContain("'#/terminology/study'");
+    expect(source).toContain("'#/preflop/charts'");
+    expect(source).toContain("'#/quizzes/preflop'");
+    expect(source).toContain("'#/stats'");
+  });
+
   it('includes a backdrop that closes the menu when clicked outside', () => {
     expect(source).toMatch(/nav-backdrop/);
     // The backdrop's onClick must also call setMenuOpen(false)

--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -7,6 +7,8 @@ header{
 .suits-row{font-size:2rem;letter-spacing:0.6rem;margin-bottom:0.8rem;
   animation:suitFade 3s ease-in-out infinite alternate}
 @keyframes suitFade{from{opacity:.5}to{opacity:1}}
+.suits-row a{text-decoration:none;display:inline-block;transition:transform .2s ease,filter .2s ease}
+.suits-row a:hover,.suits-row a:focus-visible{transform:translateY(-1px);filter:brightness(1.15)}
 .suits-row .s,.suits-row .c{color:#f0e8d0}
 .suits-row .h,.suits-row .d{color:#c0392b}
 h1{font-family:'Playfair Display',Georgia,serif;font-size:clamp(1.8rem,5vw,3rem);


### PR DESCRIPTION
### Motivation
- Provide quick-navigation shortcuts by turning the top suit icons into links to common sections (Terminology, Preflop Strategy, Quizzes, Stats).
- Preserve the existing compact header behavior and visual treatment while making the suit row interactive across pages.

### Description
- Added a `SUIT_LINKS` array and render the suit icons as anchor tags in `src/components/Header.jsx` so each suit points to the intended route.
- Updated `src/styles/header.css` to keep the visual appearance for the suits and add subtle hover/focus feedback while removing link underlines.
- Extended `src/components/Header.test.js` with an assertion that verifies the new suit quick-link destinations are present in the source.

### Testing
- Ran the header/style tests via `npm test -- --run src/components/Header.test.js src/styles/header-mobile.test.js`, and both test files passed.
- Test run summary: 2 test files, 15 tests total, all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f05a327883309b3fde5fc1cefa22)