### PR TITLE
Show exact post-turn river probability in Flop Combos review

### DIFF
--- a/src/sections/flop/CombosQuiz.jsx
+++ b/src/sections/flop/CombosQuiz.jsx
@@ -49,6 +49,11 @@ function ruleOfFour(outs) {
   return outs * 4 + '%';
 }
 
+function exactOneCardPct(outs, unseen = 46) {
+  if (!Number.isFinite(outs) || outs <= 0) return '0.0%';
+  return ((outs / unseen) * 100).toFixed(1) + '%';
+}
+
 // Toggle one cell of the phase-1 reachability table. When the user turns a
 // category's "By Turn" ON, "By River" auto-selects too — anything reachable
 // in one card is reachable in two. Turning "By Turn" OFF leaves the river
@@ -1000,6 +1005,17 @@ function Feedback({ result, onNext, isLast }) {
                         {enteredRiverOuts === '' || enteredRiverOuts == null ? '—' : enteredRiverOuts}
                         {' '}vs. actual <strong>{turnRiverActual.count}</strong>
                         {' '}{pc.phase4Right ? '✓' : '✗'}
+                      </span>
+                    </div>
+                  )}
+                  {turnRiverActual && (pc.trueRiverPostTurn || pc.madePostTurn) && (
+                    <div class="combos-fb-line">
+                      <span class="combos-fb-k">River probability:</span>
+                      <span class="combos-fb-v">
+                        <strong>{pc.madePostTurn ? '100.0%' : exactOneCardPct(turnRiverActual.count)}</strong>
+                        {!pc.madePostTurn && turnRiverActual.count > 0 && (
+                          <> &middot; 1-card exact ({turnRiverActual.count}/46)</>
+                        )}
                       </span>
                     </div>
                   )}

--- a/src/sections/flop/CombosQuiz.test.js
+++ b/src/sections/flop/CombosQuiz.test.js
@@ -308,6 +308,14 @@ describe('Feedback rendering', () => {
     expect(ruleOfFourGate, 'rule-of-4 / runner-runner suffix should be gated on !pc.made').not.toBeNull();
   });
 
+
+  it('shows post-turn river probability using exact one-card outs math', () => {
+    const postTurnProb = combosSource.match(
+      /\{turnRiverActual && \(pc\.trueRiverPostTurn \|\| pc\.madePostTurn\) && \(\s*<div class="combos-fb-line">[\s\S]*?River probability:[\s\S]*?exactOneCardPct\(turnRiverActual\.count\)/
+    );
+    expect(postTurnProb, 'after-turn feedback should show river probability from river outs').not.toBeNull();
+  });
+
   it('renders an example runout only when the user missed a river-reachable category', () => {
     // The example block is the teaching moment for backdoor draws the user
     // wrote off as unreachable. Gate: pc.trueByRiver && !pc.userByRiver.


### PR DESCRIPTION
### Motivation
- Provide precise probability feedback for the post-turn (phase‑3) review so users see the exact chance to hit on the river from the revealed turn instead of only the flop-side approximations.

### Description
- Add `exactOneCardPct(outs, unseen = 46)` helper to compute exact one-card river probability from turn outs in `src/sections/flop/CombosQuiz.jsx`.
- Update the "After the turn" feedback UI to display a `River probability` line per category that shows `100.0%` when the category is already made on the turn or `exactOneCardPct(turnRiverActual.count)` otherwise, and include a `1-card exact (x/46)` note for non-made categories with outs.
- Keep existing flop-side probability (`ruleOfFour`) unchanged and only extend the post-turn feedback.
- Add a regression test in `src/sections/flop/CombosQuiz.test.js` that asserts the after-turn feedback markup includes the new probability rendering path.

### Testing
- Ran `npm test -- src/sections/flop/CombosQuiz.test.js`, and the test file passed: 23 tests, 0 failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18f072cd083309aafe3f7745e552e)