### PR TITLE
Fix turn-stage river outs calculation for flop combos quiz

### DIFF
--- a/src/utils/combos.js
+++ b/src/utils/combos.js
@@ -135,6 +135,21 @@ export function bestOf(cards) {
   return best;
 }
 
+
+function categoriesPresent(cards) {
+  if (cards.length === 5) return categoriesIncluded(evalFive(cards).category);
+  const present = new Set();
+  const n = cards.length;
+  for (let i = 0; i < n - 4; i++)
+    for (let j = i + 1; j < n - 3; j++)
+      for (let k = j + 1; k < n - 2; k++)
+        for (let l = k + 1; l < n - 1; l++)
+          for (let m = l + 1; m < n; m++) {
+            const cat = evalFive([cards[i], cards[j], cards[k], cards[l], cards[m]]).category;
+            for (const c of categoriesIncluded(cat)) present.add(c);
+          }
+  return present;
+}
 function deckMinus(used) {
   const usedKeys = new Set(used.map(c => c.rank + c.suit));
   const out = [];
@@ -260,8 +275,8 @@ export function analyzeWithTurn(holes, flop, turn) {
   withOne.push(null);
   for (const r of remaining) {
     withOne[withOne.length - 1] = r;
-    const strictCat = bestOf(withOne).category;
-    for (const cat of categoriesIncluded(strictCat)) {
+    const present = categoriesPresent(withOne);
+    for (const cat of present) {
       riverOuts[cat].cards.push(r);
       riverOuts[cat].count += 1;
     }

--- a/src/utils/combos.test.js
+++ b/src/utils/combos.test.js
@@ -487,6 +487,16 @@ describe('analyzeWithTurn', () => {
     for (const M of a.madeSet) expect(a.reachableByRiver.has(M)).toBe(true);
   });
 
+
+  it('when six known cards are all different ranks, Pair has 18 river outs (3 per known rank) even if some rivers also make a stronger hand', () => {
+    const holes = [c('K', '♥'), c('2', '♠')];
+    const flop = [c('10', '♥'), c('6', '♥'), c('J', '♥')];
+    const turn = c('Q', '♣');
+    const a = analyzeWithTurn(holes, flop, turn);
+    expect(a.made).toBe('High Card');
+    expect(a.riverOuts['Pair'].count).toBe(18);
+    expect(a.reachableByRiver.has('Pair')).toBe(true);
+  });
   it('uses 46 remaining cards (52 minus hole+flop+turn) — total iterated outs across distinct categories ≤ 46', () => {
     const holes = [c('A', '♠'), c('K', '♠')];
     const flop = [c('2', '♠'), c('7', '♠'), c('J', '♦')];


### PR DESCRIPTION
### Motivation
- The post-turn outs computation sometimes undercounted river outs for categories like Pair when the six known cards are all different ranks because only the strict best-hand category of each runout was considered.  
- This caused incorrect feedback in the review UI (river outs and reachability) for after-turn snapshots.

### Description
- Added a new helper `categoriesPresent(cards)` that aggregates all categories present across every 5-card subset (with subset-closure) of a 6/7-card hand.  
- Updated `analyzeWithTurn` to use `categoriesPresent` when building `riverOuts` so each candidate river card contributes to every applicable category, not just the strict best category.  
- Added a regression test in `src/utils/combos.test.js` that asserts Pair has 18 river outs in a six-distinct-rank turn scenario to cover the reported case.

### Testing
- Ran `npm test -- src/utils/combos.test.js src/sections/flop/CombosQuiz.test.js` and both test files passed.  
- Test run summary: 2 test files, 77 tests — all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f192425c8883309746c9143386f6b5)